### PR TITLE
[EVAST-00027][SUB-30] Visual support components 

### DIFF
--- a/src/components/conversor/AssetBadgeLink.tsx
+++ b/src/components/conversor/AssetBadgeLink.tsx
@@ -1,0 +1,42 @@
+import type { ElementType } from "react";
+
+interface AssetBadgeLinkProps {
+  icon: ElementType;
+  symbol: string;
+  href?: string;
+  ariaLabel?: string;
+}
+export function AssetBadgeLink({
+  icon: Icon,
+  symbol,
+  href,
+  ariaLabel,
+}: AssetBadgeLinkProps) {
+  const content = (
+    <>
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100">
+        <Icon className="h-4 w-4 text-black" />
+      </div>
+      <span className="text-sm font-medium text-black">{symbol}</span>
+    </>
+  );
+
+  const className =
+    "flex h-10 shrink-0 items-center gap-2 rounded-full border border-gray-200 bg-white py-1.5 pr-3 pl-2 shadow-sm";
+
+  if (!href) {
+    return <div className={className}>{content}</div>;
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={ariaLabel ?? `Open ${symbol} on CoinGecko`}
+      className={className}
+    >
+      {content}
+    </a>
+  );
+}

--- a/src/components/conversor/ConversorFieldConnector.tsx
+++ b/src/components/conversor/ConversorFieldConnector.tsx
@@ -1,0 +1,8 @@
+import { ArrowDownUp } from "lucide-react";
+export function ConversorFieldConnector() {
+  return (
+    <div className="absolute -bottom-3.5 left-1/2 z-10 flex h-7 w-7 -translate-x-1/2 items-center justify-center rounded-full border bg-white shadow-sm">
+      <ArrowDownUp className="h-3.5 w-3.5 text-gray-400" />
+    </div>
+  );
+}

--- a/src/components/conversor/ConversorTitle.tsx
+++ b/src/components/conversor/ConversorTitle.tsx
@@ -1,0 +1,12 @@
+export function ConversorTitle() {
+  return (
+    <div className="space-y-4 text-center">
+      <h1 className="text-5xl leading-tight font-semibold tracking-tight text-black md:text-6xl">
+        Conversor
+      </h1>
+      <p className="mx-auto max-w-lg text-lg text-gray-500 md:text-xl">
+        Confira preços recentes do EVA, Bitcoin, Dólar e Real.
+      </p>
+    </div>
+  );
+}

--- a/src/components/conversor/CurrencyBadge.tsx
+++ b/src/components/conversor/CurrencyBadge.tsx
@@ -1,0 +1,29 @@
+import type { LucideIcon } from "lucide-react";
+
+interface CurrencyBadgeProps {
+  val: number;
+  icon: LucideIcon;
+  color: string;
+  prefix: string;
+  dec: number;
+}
+export function CurrencyBadge({
+  val,
+  icon: Icon,
+  color,
+  prefix,
+  dec,
+}: CurrencyBadgeProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-1.5 shadow-sm">
+      <Icon className="h-4 w-4" color={color} />
+      <span className="font-medium text-black">
+        1 {prefix} = $
+        {val.toLocaleString("en-US", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: dec,
+        })}
+      </span>
+    </div>
+  );
+}

--- a/src/components/conversor/PriceReferences.tsx
+++ b/src/components/conversor/PriceReferences.tsx
@@ -1,0 +1,27 @@
+import { Bitcoin, Hexagon } from "lucide-react";
+
+import { useConversorContext } from "./ConversorContext";
+import { CurrencyBadge } from "./CurrencyBadge";
+
+export function PriceReferences() {
+  const { rates } = useConversorContext();
+
+  return (
+    <div className="flex justify-center gap-3 text-sm font-medium">
+      <CurrencyBadge
+        val={rates.EVA_USD}
+        icon={Hexagon}
+        color="#FC9201"
+        prefix="EVA"
+        dec={6}
+      />
+      <CurrencyBadge
+        val={rates.BTC_USD}
+        icon={Bitcoin}
+        color="#F7931A"
+        prefix="BTC"
+        dec={2}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TMPLT-<ISSUE_ID>] - Same title as issue**_

closes #30 

## Description

This pull request introduces several new UI components for the conversor feature, focusing on modularity and improved code organization. The changes add reusable components for displaying asset and currency badges, a connector icon, a title section, and price references, each with clear props and styling.

**New UI components:**

* [`AssetBadgeLink`](diffhunk://#diff-e8f934e74d02ae323d82cf037bfd7a399eb03c5f49d7bb1f699c6d8a992c2f70R1-R42): Adds a flexible badge component that displays an icon and symbol, optionally as a link, for assets such as cryptocurrencies.
* [`CurrencyBadge`](diffhunk://#diff-70d7886f22a06ad1b71ac8fac02c79ab992558737ca54c86dd8ef9e9db767758R1-R29): Introduces a badge component for displaying currency values with customizable icon, color, prefix, and decimal precision.
* [`ConversorFieldConnector`](diffhunk://#diff-c742c04e0a6a88ae0a7f940cdfc363d6874c91e128e67f076ba0ba723c0ab175R1-R8): Adds a connector component with an arrow icon to visually link fields in the conversor UI.
* [`ConversorTitle`](diffhunk://#diff-be5f262b7657bad46beb2f26e23b6636356b8d88dd52000e03df5c6940685ba6R1-R12): Implements a title section with a heading and descriptive subtitle for the conversor page.
* [`PriceReferences`](diffhunk://#diff-a786bc14cc4d6c075de67cedfca29cdaccefe6f1d27c2fc2f1588c791cbc5c88R1-R27): Displays current EVA and Bitcoin prices using the new `CurrencyBadge` component and data from context.

## Evidences

**ConversorTitle**
<img width="472" height="152" alt="Captura de Tela 2026-04-04 às 18 32 40" src="https://github.com/user-attachments/assets/f55a0019-f060-4bfd-af30-49f548257f68" />

**ConversorFieldConnector**
<img width="74" height="59" alt="Captura de Tela 2026-04-04 às 18 32 07" src="https://github.com/user-attachments/assets/39e4223e-2f88-4390-ae6d-09efee6ef898" />

**CurrencyBadge & PriceReferences**
<img width="383" height="62" alt="Captura de Tela 2026-04-04 às 18 31 14" src="https://github.com/user-attachments/assets/c54f0787-3fd6-4791-9bf1-650a361b5030" />

**AssetBadgeLink**
<img width="118" height="439" alt="Captura de Tela 2026-04-04 às 18 27 51" src="https://github.com/user-attachments/assets/36d151ae-eb09-4aea-872e-24365150e836" />


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
