### PR TITLE
[EVAST-00027][SUB-31] Conversor card core

### DIFF
--- a/src/components/conversor/ConversorActions.tsx
+++ b/src/components/conversor/ConversorActions.tsx
@@ -1,0 +1,33 @@
+import { Image, RefreshCcw, X } from "lucide-react";
+
+import { useConversorContext } from "@/components/conversor/ConversorContext";
+import { Button } from "@/components/ui/button";
+
+export function ConversorActions() {
+  const { onClear, onShare, isGeneratingImage } = useConversorContext();
+
+  return (
+    <div className="mt-3 flex gap-3">
+      <Button
+        variant="ghost"
+        onClick={onClear}
+        className="h-14 w-42 shrink-0 rounded-[24px] border border-gray-100 bg-[#FAFAFA] font-medium text-gray-600 hover:bg-red-50 hover:text-red-500 hover:border-red-200 hover:cursor-pointer"
+      >
+        <X className="mr-2 h-5 w-5" />
+        Limpar
+      </Button>
+      <Button
+        onClick={onShare}
+        disabled={isGeneratingImage}
+        className="h-14 flex-1 rounded-[24px] bg-[#ff9b12] font-medium text-white shadow-sm hover:bg-[#ff9300]   hover:cursor-pointer disabled:cursor-not-allowed"
+      >
+        {isGeneratingImage ? (
+          <RefreshCcw className="mr-2 h-5 w-5 animate-spin" />
+        ) : (
+          <Image className="mr-2 h-5 w-5" />
+        )}
+        Capturar cotação
+      </Button>
+    </div>
+  );
+}

--- a/src/components/conversor/ConversorCard.tsx
+++ b/src/components/conversor/ConversorCard.tsx
@@ -1,0 +1,24 @@
+import { FIELDS } from "@/lib/conversor";
+
+import { ConversorActions } from "./ConversorActions";
+import { ConversorField } from "./ConversorField";
+import { ConversorStatusBar } from "./ConversorStatusBar";
+
+export function ConversorCard() {
+  return (
+    <div className="rounded-[32px] border border-gray-100 bg-white p-3 shadow-xl">
+      <div className="relative space-y-1">
+        {FIELDS.map((field, index) => (
+          <ConversorField
+            key={field.id}
+            field={field}
+            isLast={index === FIELDS.length - 1}
+          />
+        ))}
+      </div>
+
+      <ConversorActions />
+      <ConversorStatusBar />
+    </div>
+  );
+}

--- a/src/components/conversor/ConversorField.tsx
+++ b/src/components/conversor/ConversorField.tsx
@@ -1,0 +1,71 @@
+import { AssetBadgeLink } from "@/components/conversor/AssetBadgeLink";
+import { useConversorContext } from "@/components/conversor/ConversorContext";
+import { ConversorFieldConnector } from "@/components/conversor/ConversorFieldConnector";
+import { Input } from "@/components/ui/input";
+import { sanitizeDecimalInput } from "@/lib/conversor";
+import { cn } from "@/lib/utils";
+import type { FieldDefinition } from "@/types/conversor";
+
+interface ConversorFieldProps {
+  field: FieldDefinition;
+  isLast: boolean;
+}
+export function ConversorField({ field, isLast }: ConversorFieldProps) {
+  const {
+    values,
+    usdValue,
+    activeInput,
+    onFieldFocus,
+    onFieldBlur,
+    onFieldChange,
+  } = useConversorContext();
+
+  const value = values[field.id];
+  const isActive = activeInput === field.id;
+
+  return (
+    <div className="group relative">
+      <div
+        className={cn(
+          "rounded-[24px] border bg-[#FAFAFA] p-5 transition-all",
+          isActive
+            ? "relative z-20 border-gray-200 bg-white ring-1 ring-gray-200 shadow-sm"
+            : "border-transparent hover:border-gray-200",
+        )}
+      >
+        <div className="flex justify-between gap-4">
+          <div className="flex-1">
+            <Input
+              type="text"
+              inputMode="decimal"
+              placeholder="0.0"
+              value={value}
+              onFocus={() => onFieldFocus(field.id)}
+              onBlur={onFieldBlur}
+              onChange={(e) => {
+                const raw = sanitizeDecimalInput(e.target.value);
+                if (raw !== null) onFieldChange(field.id, raw);
+              }}
+              className="h-auto border-0 bg-transparent p-0 text-4xl font-semibold text-black shadow-none focus-visible:ring-0"
+            />
+            <div className="mt-1 text-sm text-gray-500">
+              ≈ $
+              {usdValue.toLocaleString("en-US", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </div>
+          </div>
+
+          <AssetBadgeLink
+            icon={field.icon}
+            symbol={field.symbol}
+            href={field.href}
+            ariaLabel={`Open ${field.label} on CoinGecko`}
+          />
+        </div>
+      </div>
+      {!isLast && <ConversorFieldConnector />}
+    </div>
+  );
+}

--- a/src/components/conversor/ConversorStatusBar.tsx
+++ b/src/components/conversor/ConversorStatusBar.tsx
@@ -1,0 +1,29 @@
+import { AlertCircle, RefreshCcw } from "lucide-react";
+
+import { useConversorContext } from "@/components/conversor/ConversorContext";
+
+export function ConversorStatusBar() {
+  const { isLoading, lastUpdated, error } = useConversorContext();
+
+  return (
+    <div className="mt-3 flex items-center justify-between rounded-[24px] border border-gray-100 bg-[#FAFAFA] px-4 py-3 text-xs font-medium text-gray-500">
+      <div className="flex items-center gap-2">
+        {isLoading ? (
+          <>
+            <RefreshCcw className="h-3.5 w-3.5 animate-spin" /> Atualizando
+          </>
+        ) : (
+          <>
+            <div className="h-2 w-2 rounded-full bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.6)]" />
+            Atualizado {lastUpdated?.toTimeString().split(" ")[0]}
+          </>
+        )}
+      </div>
+      {error && (
+        <div className="flex items-center gap-1.5 text-red-500">
+          <AlertCircle className="h-3.5 w-3.5" /> {error}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TMPLT-<ISSUE_ID>] - Same title as issue**_

closes #31 

## Description

This pull request introduces several new UI components for the conversor feature, organizing the user interface into modular, reusable pieces. The main changes include the creation of `ConversorCard` as a container, individual field components, action buttons, and a status bar, each handling a specific part of the conversor's functionality.

**Core container**
- Added the `ConversorCard` component, which serves as the main container for the conversor UI, rendering all fields, action buttons, and the status bar.

**Field input**
  * Introduced the `ConversorField` component to handle individual input fields, including value display, focus management, and asset badge links.

**Actions**
  * Added the `ConversorActions` component, providing "Clear" and "Capture" (share) buttons, with dynamic icons and disabled state handling during image generation.

**Status and feedback**
  * Implemented the `ConversorStatusBar` component to display loading status, last update time, and error messages to the user.

## Evidences

Attach some prints, gifs or videos of the new change

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
