### PR TITLE
[EVAST-00002][SUB-41] Create `.env` template + Animation Grid refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
+NEXT_PUBLIC_ARBISCAN_API_KEY=your_arbiscan_key
+COINGECKO_API_KEY=your_coingecko_key
+SUPABASE_URL=your_supabase_url
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,6 +139,7 @@
     --cell-animation: eva-grid-flicker-a;
     width: 50px;
     height: 50px;
+    border-radius: 4px;
     background-color: var(--cell-color);
     opacity: 0;
     animation: var(--cell-animation) var(--cell-duration) ease-in-out infinite;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,6 +49,7 @@
 }
 
 :root {
+  --grid-cell-size: 32px;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --grid-line-color: rgba(0, 0, 0, 0.03);
@@ -128,8 +129,8 @@
     display: grid;
     width: 100vw;
     height: 100vh;
-    grid-template-columns: repeat(auto-fill, 50px);
-    grid-auto-rows: 50px;
+    grid-template-columns: repeat(auto-fill, var(--grid-cell-size));
+    grid-auto-rows: var(--grid-cell-size);
     justify-content: start;
     align-content: start;
     overflow: hidden;
@@ -137,8 +138,8 @@
 
   .eva-grid-cell {
     --cell-animation: eva-grid-flicker-a;
-    width: 50px;
-    height: 50px;
+    width: var(--grid-cell-size);
+    height: var(--grid-cell-size);
     border-radius: 4px;
     background-color: var(--cell-color);
     opacity: 0;
@@ -193,7 +194,7 @@
   }
 
   .bg-grid {
-    background-size: 50px 50px;
+    background-size: var(--grid-cell-size) var(--grid-cell-size);
     background-image:
       linear-gradient(to right, var(--grid-line-color) 1px, transparent 1px),
       linear-gradient(to bottom, var(--grid-line-color) 1px, transparent 1px);
@@ -234,7 +235,7 @@
   body {
     @apply bg-background text-foreground;
     min-height: 100vh;
-    background-size: 50px 50px;
+    background-size: var(--grid-cell-size) var(--grid-cell-size);
     background-image:
       linear-gradient(to right, var(--grid-line-color) 1px, transparent 1px),
       linear-gradient(to bottom, var(--grid-line-color) 1px, transparent 1px);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,16 +136,17 @@
   }
 
   .eva-grid-cell {
+    --cell-animation: eva-grid-flicker-a;
     width: 50px;
     height: 50px;
     background-color: var(--cell-color);
     opacity: 0;
-    animation: eva-grid-flicker var(--cell-duration) ease-in-out infinite;
+    animation: var(--cell-animation) var(--cell-duration) ease-in-out infinite;
     animation-delay: var(--cell-delay);
     will-change: opacity;
   }
 
-  @keyframes eva-grid-flicker {
+  @keyframes eva-grid-flicker-a {
     0%,
     100% {
       opacity: 0;
@@ -155,6 +156,38 @@
     }
     65% {
       opacity: 0.06;
+    }
+  }
+
+  @keyframes eva-grid-flicker-b {
+    0%,
+    100% {
+      opacity: 0;
+    }
+    22% {
+      opacity: 0.08;
+    }
+    48% {
+      opacity: var(--cell-opacity);
+    }
+    72% {
+      opacity: 0.04;
+    }
+  }
+
+  @keyframes eva-grid-flicker-c {
+    0%,
+    100% {
+      opacity: 0;
+    }
+    28% {
+      opacity: var(--cell-opacity);
+    }
+    54% {
+      opacity: 0.02;
+    }
+    78% {
+      opacity: 0.09;
     }
   }
 

--- a/src/components/common/AnimatedGridBackground.tsx
+++ b/src/components/common/AnimatedGridBackground.tsx
@@ -1,42 +1,14 @@
 "use client";
 
 import { useEffect, useState, type CSSProperties } from "react";
-
-const CELL_SIZE = 50;
-const CELL_PADDING = 2;
-const INITIAL_CELL_COUNT = 1200;
-
-const ORANGE_TONES = ["rgba(255, 231, 213, 0.95)", "rgba(255, 209, 176, 0.9)"];
-const GRAY_TONES = [
-  "rgba(247, 247, 247, 0.9)",
-  "rgba(242, 242, 242, 0.68)",
-  "rgba(237, 237, 237, 0.75)",
-  "rgba(232, 232, 232, 0.63)",
-  "rgba(228, 228, 228, 0.7)",
-];
-const WHITE_TONES = ["rgba(255, 255, 255, 0.9)"];
-const PALETTE = [...GRAY_TONES, ...GRAY_TONES, ...ORANGE_TONES, ...WHITE_TONES];
-
-function pseudoRandom(seed: number) {
-  const x = Math.sin(seed * 9999.91) * 10000;
-  return x - Math.floor(x);
-}
-
-function getCellCount() {
-  if (typeof window === "undefined") {
-    return INITIAL_CELL_COUNT;
-  }
-
-  const columns = Math.ceil(window.innerWidth / CELL_SIZE) + CELL_PADDING;
-  const rows = Math.ceil(window.innerHeight / CELL_SIZE) + CELL_PADDING;
-
-  return columns * rows;
-}
+import { INITIAL_CELL_COUNT } from "./animatedGrid.constants";
+import { getCellCount, getCellVisualProfile } from "./animatedGrid.utils";
 
 export function AnimatedGridBackground() {
   const [cellCount, setCellCount] = useState(INITIAL_CELL_COUNT);
 
   useEffect(() => {
+    // Keeps coverage accurate after viewport size changes.
     const updateCellCount = () => {
       setCellCount(getCellCount());
     };
@@ -50,13 +22,11 @@ export function AnimatedGridBackground() {
   }, []);
 
   return (
+    // Decorative-only layer: hidden from accessibility tree.
     <div className="eva-grid-bg" aria-hidden="true">
       {Array.from({ length: cellCount }, (_, index) => {
-        const color =
-          PALETTE[Math.floor(pseudoRandom(index + 1) * PALETTE.length)];
-        const opacity = 0.3 + pseudoRandom(index + 7) * 0.22;
-        const duration = 5 + pseudoRandom(index + 13) * 8;
-        const delay = -pseudoRandom(index + 31) * 12;
+        const { color, opacity, duration, delay, animationVariant } =
+          getCellVisualProfile(index);
 
         return (
           <span
@@ -68,6 +38,7 @@ export function AnimatedGridBackground() {
                 "--cell-opacity": opacity.toFixed(3),
                 "--cell-duration": `${duration.toFixed(3)}s`,
                 "--cell-delay": `${delay.toFixed(3)}s`,
+                "--cell-animation": animationVariant,
               } as CSSProperties
             }
           />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -21,13 +21,15 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full bg-white/80 backdrop-blur-md border-b border-gray-100">
+    <header className="sticky top-0 z-50 w-full bg-white/80 backdrop-blur-md border-b border-gray-100 shadow-lg shadow-black/5">
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         <Link href="/" className="flex items-center gap-3 group">
           <div className="w-8 h-8 rounded-xl flex items-center justify-center bg-[#ffba58]">
             <Hexagon className="w-5 h-5 text-black" fill="currentColor" />
           </div>
-          <span className="font-medium text-lg tracking-tight text-black">EVA Station</span>
+          <span className="font-medium text-lg tracking-tight text-black">
+            EVA Station
+          </span>
         </Link>
 
         <nav className="hidden md:flex items-center gap-8">
@@ -44,13 +46,6 @@ export function Header() {
             </Link>
           ))}
         </nav>
-
-        <Button
-          onClick={handleConnect}
-          className="rounded-full bg-black hover:bg-black/80 text-white px-6 font-medium"
-        >
-          Connect
-        </Button>
       </div>
     </header>
   );

--- a/src/components/common/animatedGrid.constants.ts
+++ b/src/components/common/animatedGrid.constants.ts
@@ -1,0 +1,62 @@
+export type ToneTiming = "fast" | "slow";
+
+export type PaletteTone = {
+  color: string;
+  timing: ToneTiming;
+};
+
+// Grid density and viewport padding.
+export const CELL_SIZE = 50;
+export const CELL_PADDING = 2;
+export const INITIAL_CELL_COUNT = 1200;
+
+// Fast cadence for market accent cells (green/red).
+export const FAST_MIN_ANIMATION_DURATION = 1.2;
+export const FAST_ANIMATION_DURATION_VARIANCE = 2.6;
+export const FAST_NEGATIVE_DELAY_WINDOW = 6;
+
+// Slow cadence for neutral base cells (gray/orange/white).
+export const SLOW_MIN_ANIMATION_DURATION = 3.8;
+export const SLOW_ANIMATION_DURATION_VARIANCE = 5.4;
+export const SLOW_NEGATIVE_DELAY_WINDOW = 10;
+
+// Accent tones inspired by price movement flashes.
+export const ORANGE_TONES = [
+  "rgba(255, 223, 197, 0.96)",
+  "rgba(255, 192, 148, 0.94)",
+];
+export const GREEN_TONES = ["rgba(190, 245, 199, 0.88)"];
+export const RED_TONES = ["rgba(255, 198, 198, 0.88)"];
+
+// Base neutral tones to keep the background subtle.
+export const GRAY_TONES = [
+  "rgba(247, 247, 247, 0.9)",
+  "rgba(242, 242, 242, 0.68)",
+  "rgba(237, 237, 237, 0.75)",
+  "rgba(232, 232, 232, 0.63)",
+  "rgba(228, 228, 228, 0.7)",
+];
+export const WHITE_TONES = ["rgba(255, 255, 255, 0.9)"];
+
+// Animation variants are defined in src/app/globals.css.
+export const ANIMATION_VARIANTS = [
+  "eva-grid-flicker-a",
+  "eva-grid-flicker-b",
+  "eva-grid-flicker-c",
+];
+
+export const FAST_ACCENT_REDUCTION_PROBABILITY = 0.875;
+
+function withTiming(colors: string[], timing: ToneTiming): PaletteTone[] {
+  return colors.map((color) => ({ color, timing }));
+}
+
+// Palette distribution controls visual frequency by repeating neutral groups.
+export const PALETTE: PaletteTone[] = [
+  ...withTiming(GRAY_TONES, "slow"),
+  ...withTiming(GRAY_TONES, "slow"),
+  ...withTiming(ORANGE_TONES, "slow"),
+  ...withTiming(GREEN_TONES, "fast"),
+  ...withTiming(RED_TONES, "fast"),
+  ...withTiming(WHITE_TONES, "slow"),
+];

--- a/src/components/common/animatedGrid.constants.ts
+++ b/src/components/common/animatedGrid.constants.ts
@@ -6,7 +6,7 @@ export type PaletteTone = {
 };
 
 // Grid density and viewport padding.
-export const CELL_SIZE = 50;
+export const CELL_SIZE = 32;
 export const CELL_PADDING = 2;
 export const INITIAL_CELL_COUNT = 1200;
 

--- a/src/components/common/animatedGrid.utils.ts
+++ b/src/components/common/animatedGrid.utils.ts
@@ -1,0 +1,86 @@
+import {
+  ANIMATION_VARIANTS,
+  CELL_PADDING,
+  CELL_SIZE,
+  FAST_ACCENT_REDUCTION_PROBABILITY,
+  FAST_ANIMATION_DURATION_VARIANCE,
+  FAST_MIN_ANIMATION_DURATION,
+  FAST_NEGATIVE_DELAY_WINDOW,
+  GRAY_TONES,
+  INITIAL_CELL_COUNT,
+  PALETTE,
+  SLOW_ANIMATION_DURATION_VARIANCE,
+  SLOW_MIN_ANIMATION_DURATION,
+  SLOW_NEGATIVE_DELAY_WINDOW,
+  type ToneTiming,
+} from "./animatedGrid.constants";
+
+export type CellVisualProfile = {
+  color: string;
+  timing: ToneTiming;
+  opacity: number;
+  duration: number;
+  delay: number;
+  animationVariant: string;
+};
+
+// Deterministic pseudo-random helper for stable per-cell output.
+export function pseudoRandom(seed: number) {
+  const x = Math.sin(seed * 9999.91) * 10000;
+  return x - Math.floor(x);
+}
+
+// Calculates how many cells are needed to cover the current viewport.
+export function getCellCount() {
+  if (typeof window === "undefined") {
+    return INITIAL_CELL_COUNT;
+  }
+
+  const columns = Math.ceil(window.innerWidth / CELL_SIZE) + CELL_PADDING;
+  const rows = Math.ceil(window.innerHeight / CELL_SIZE) + CELL_PADDING;
+
+  return columns * rows;
+}
+
+export function getCellVisualProfile(index: number): CellVisualProfile {
+  const tone = PALETTE[Math.floor(pseudoRandom(index + 1) * PALETTE.length)];
+  let { color, timing } = tone;
+
+  // Reduces fast accent frequency to avoid visual overload.
+  if (
+    timing === "fast" &&
+    pseudoRandom(index + 59) < FAST_ACCENT_REDUCTION_PROBABILITY
+  ) {
+    color =
+      GRAY_TONES[Math.floor(pseudoRandom(index + 61) * GRAY_TONES.length)];
+    timing = "slow";
+  }
+
+  // Independent flicker profile per cell (opacity, speed, phase, keyframe variant).
+  const opacity = 0.3 + pseudoRandom(index + 7) * 0.22;
+  const durationSeed = pseudoRandom(index + 13);
+  const delaySeed = pseudoRandom(index + 31);
+  const duration =
+    timing === "fast"
+      ? FAST_MIN_ANIMATION_DURATION +
+        durationSeed * FAST_ANIMATION_DURATION_VARIANCE
+      : SLOW_MIN_ANIMATION_DURATION +
+        durationSeed * SLOW_ANIMATION_DURATION_VARIANCE;
+  const delay =
+    timing === "fast"
+      ? -delaySeed * FAST_NEGATIVE_DELAY_WINDOW
+      : -delaySeed * SLOW_NEGATIVE_DELAY_WINDOW;
+  const animationVariant =
+    ANIMATION_VARIANTS[
+      Math.floor(pseudoRandom(index + 47) * ANIMATION_VARIANTS.length)
+    ];
+
+  return {
+    color,
+    timing,
+    opacity,
+    duration,
+    delay,
+    animationVariant,
+  };
+}

--- a/src/components/conversor/ConversorPage.tsx
+++ b/src/components/conversor/ConversorPage.tsx
@@ -7,7 +7,7 @@ import { ConversorTitle } from "./ConversorTitle";
 
 function ConversorPageContent() {
   return (
-    <div className="flex min-h-[calc(100dvh-4rem)] w-full flex-col items-center justify-center bg-transparent">
+    <div className="flex w-full flex-col items-center justify-center bg-transparent">
       <div className="conversor-fit-scale w-full max-w-xl space-y-6 px-4">
         <ConversorTitle />
         <PriceReferences />

--- a/src/components/conversor/ConversorTitle.tsx
+++ b/src/components/conversor/ConversorTitle.tsx
@@ -1,10 +1,10 @@
 export function ConversorTitle() {
   return (
-    <div className="space-y-4 bg-white/25 px-4 py-5 text-center backdrop-blur-[1px] md:px-6">
+    <div className="max-h-37.5 mb-12 mt-6 bg-white/55 px-4 text-center backdrop-blur-[6px] md:px-6 md:mt-8">
       <h1 className="text-5xl leading-tight font-semibold tracking-tight text-black md:text-6xl">
         Conversor
       </h1>
-      <p className="mx-auto max-w-lg text-lg text-gray-500 md:text-xl">
+      <p className="mx-auto max-w-lg text-md text-gray-500 md:text-xl">
         Confira preços recentes do EVA, Bitcoin, Dólar e Real.
       </p>
     </div>

--- a/src/components/conversor/CurrencyBadge.tsx
+++ b/src/components/conversor/CurrencyBadge.tsx
@@ -15,9 +15,9 @@ export function CurrencyBadge({
   dec,
 }: CurrencyBadgeProps) {
   return (
-    <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-1.5 shadow-sm">
+    <div className="flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-1.5 shadow-sm">
       <Icon className="h-4 w-4" color={color} />
-      <span className="font-medium text-black">
+      <span className="text-[1.1rem] md:text-lg font-medium text-black">
         1 {prefix} = $
         {val.toLocaleString("en-US", {
           minimumFractionDigits: 2,

--- a/src/components/conversor/PriceReferences.tsx
+++ b/src/components/conversor/PriceReferences.tsx
@@ -7,7 +7,7 @@ export function PriceReferences() {
   const { rates } = useConversorContext();
 
   return (
-    <div className="flex justify-center gap-3 text-sm font-medium">
+    <div className="flex flex-col md:flex-row justify-center gap-3 text-sm font-medium">
       <CurrencyBadge
         val={rates.EVA_USD}
         icon={Hexagon}


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TMPLT-<ISSUE_ID>] - Same title as issue**_

closes #41 

## Description

This pull request refactors and enhances the animated grid background component, making the codebase more modular and visually dynamic. The main changes include extracting constants and utility functions into dedicated files, introducing new animation variants for grid cells, and improving the visual diversity and accessibility of the background animation.

*Accessibility and Environment Setup:*
- Marked the animated grid background as decorative-only (`aria-hidden="true"`) to improve accessibility for screen readers.
- Added new environment variable examples for services such as Arbitrum, Arbiscan, Coingecko, and Supabase in `.env.example`.

**Animated Grid Refactoring and Visual Improvements:**
- Extracted grid-related constants (such as cell size, color palettes, and animation timing) into a new `animatedGrid.constants.ts` file for better maintainability and clarity.
- Moved utility functions (like pseudo-random generation, cell count calculation, and cell visual profile logic) into a new `animatedGrid.utils.ts` file, enhancing code organization and testability.
- Updated the grid cell rendering logic to randomly assign one of several animation variants to each cell, increasing the visual dynamism of the background.
- Improved color palette and animation timing logic, including accent colors for market movement and reduced frequency of fast accent cells to avoid visual overload.

## Evidences

Attach some prints, gifs or videos of the new change

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
