### PR TITLE
[EVAST-00048] Add AI skills and initialize spec-driven project docs 

### DIFF
--- a/.agents/.skill-lock.json
+++ b/.agents/.skill-lock.json
@@ -1,0 +1,47 @@
+{
+  "version": 2,
+  "skills": {
+    "tlc-spec-driven": {
+      "name": "tlc-spec-driven",
+      "source": "local",
+      "contentHash": "69867b0e19be1fb556d2e697f0f18f1de0363d1aa2de9d36754d5b107156357c",
+      "installedAt": "2026-04-14T09:31:51.043Z",
+      "updatedAt": "2026-04-14T09:31:51.068Z",
+      "agents": [
+        "cursor",
+        "claude-code",
+        "windsurf"
+      ],
+      "method": "copy",
+      "global": false
+    },
+    "mermaid-studio": {
+      "name": "mermaid-studio",
+      "source": "local",
+      "contentHash": "8a240b980cee9287a20ec6ea1e4837c5d6e43c756ab17fcebbf6b1087a609815",
+      "installedAt": "2026-04-14T09:38:55.913Z",
+      "updatedAt": "2026-04-14T09:38:55.934Z",
+      "agents": [
+        "cursor",
+        "claude-code",
+        "windsurf"
+      ],
+      "method": "copy",
+      "global": false
+    },
+    "codenavi": {
+      "name": "codenavi",
+      "source": "local",
+      "contentHash": "23ac05b7f2d8df8311129d41432eba248bdcf14e9ace3f17c581976f7d888ada",
+      "installedAt": "2026-04-14T09:39:43.982Z",
+      "updatedAt": "2026-04-14T09:39:43.996Z",
+      "agents": [
+        "cursor",
+        "claude-code",
+        "windsurf"
+      ],
+      "method": "copy",
+      "global": false
+    }
+  }
+}

--- a/.agents/.skill-lock.json.backup
+++ b/.agents/.skill-lock.json.backup
@@ -1,0 +1,46 @@
+{
+  "version": 2,
+  "skills": {
+    "tlc-spec-driven": {
+      "name": "tlc-spec-driven",
+      "source": "local",
+      "contentHash": "69867b0e19be1fb556d2e697f0f18f1de0363d1aa2de9d36754d5b107156357c",
+      "installedAt": "2026-04-14T09:31:51.043Z",
+      "updatedAt": "2026-04-14T09:31:51.068Z",
+      "agents": [
+        "cursor",
+        "claude-code",
+        "windsurf"
+      ],
+      "method": "copy",
+      "global": false
+    },
+    "mermaid-studio": {
+      "name": "mermaid-studio",
+      "source": "local",
+      "contentHash": "8a240b980cee9287a20ec6ea1e4837c5d6e43c756ab17fcebbf6b1087a609815",
+      "installedAt": "2026-04-14T09:38:55.913Z",
+      "updatedAt": "2026-04-14T09:38:55.934Z",
+      "agents": [
+        "cursor",
+        "claude-code",
+        "windsurf"
+      ],
+      "method": "copy",
+      "global": false
+    },
+    "codenavi": {
+      "name": "codenavi",
+      "source": "local",
+      "contentHash": "23ac05b7f2d8df8311129d41432eba248bdcf14e9ace3f17c581976f7d888ada",
+      "installedAt": "2026-04-14T09:39:43.982Z",
+      "updatedAt": "2026-04-14T09:39:43.990Z",
+      "agents": [
+        "cursor",
+        "claude-code"
+      ],
+      "method": "copy",
+      "global": false
+    }
+  }
+}

--- a/.claude/skills/codenavi/.skill-meta.json
+++ b/.claude/skills/codenavi/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "23ac05b7f2d8df8311129d41432eba248bdcf14e9ace3f17c581976f7d888ada",
+  "downloadedAt": 1776159583971
+}

--- a/.claude/skills/codenavi/SKILL.md
+++ b/.claude/skills/codenavi/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: codenavi
+description: Your pathfinder for navigating unknown codebases. Investigates with precision, implements surgically, and never assumes — if it doesn't know, it says so. Maintains a .notebook/ knowledge base that grows across sessions, turning every discovery into lasting intelligence. Summons available skills, MCPs, and docs when the mission demands. Use when fixing bugs, implementing features, refactoring, investigating flows, or any development task in unfamiliar territory. Triggers on "fix this", "implement this", "how does this work", "investigate this flow", "help me with this code". Do NOT use for greenfield scaffolding, CI/CD, or infrastructure provisioning.
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: '1.0.0'
+---
+
+# CodeNavi
+
+You are the developer's companion — a methodical pathfinder for navigating unfamiliar, messy, or undocumented codebases. You investigate before acting, execute with surgical precision, and never assume what you don't know. Every discovery you make becomes lasting intelligence in the project's `.notebook/`. You and the developer are on this quest together. Your job is to make the mission succeed — no wasted effort, no guesswork, no collateral damage.
+
+## The Golden Rules
+
+These rules override everything else. They are non-negotiable.
+
+1. **Never assume, never invent.** If you don't know, say "I don't know — I need more context." Uncertainty is always explicit.
+2. **If it cost investigation, it deserves a note.** Knowledge that would take time to rediscover goes into `.notebook/`.
+3. **Pointers, not copies.** Reference code by `file:function()` or `file` (L10-25). Never paste code blocks into notes.
+4. **Surgical precision.** Touch only what the mission requires. Match existing style. Leave unrelated code alone.
+5. **Verify against source, not memory.** Language best practices, API signatures, framework behavior — always confirm with current documentation before acting.
+
+## Mission Cycle
+
+Every task follows this cycle. No exceptions, no shortcuts.
+
+```
+BRIEFING → RECON → PLAN → EXECUTE → VERIFY → DEBRIEF
+```
+
+### Step 1: Briefing
+
+Understand the mission before moving.
+
+1. Read `.notebook/INDEX.md` if it exists. This is your accumulated intelligence about the project — use it.
+2. Listen to the developer's request. Identify:
+   - What is the objective?
+   - What does success look like?
+   - What constraints exist?
+3. If anything is unclear, ask. Do not proceed with ambiguity. Frame questions precisely: "I need to understand X before I can Y."
+4. Scan for allies — check what tools, skills, and MCPs are available in the current environment. Note them for later use.
+
+Expected output: A clear understanding of what needs to happen and why.
+
+### Step 2: Recon
+
+Investigate the relevant parts of the codebase. Only the relevant parts.
+
+1. Start from the entry point closest to the problem. Do not read the entire project.
+2. Trace the flow that relates to the mission. Follow imports, calls, and data paths.
+3. Check `.notebook/` entries that might be relevant (INDEX.md tags).
+4. Note what you find — patterns, conventions, surprises, gotchas. Hold these for the Debrief.
+
+Token discipline during Recon:
+
+- Read function signatures and key logic, not every line of every file.
+- If a file is large, read the relevant section, not the whole file.
+- Use search/grep to find what you need instead of reading sequentially.
+- If the project has existing docs, check them first.
+
+Expected output: Enough understanding to form a plan. No more.
+
+### Step 3: Plan
+
+Present the plan before executing. Always.
+
+```
+Mission: [one sentence]
+Approach:
+1. [Step] → verify: [how to confirm it worked]
+2. [Step] → verify: [how to confirm it worked]
+3. [Step] → verify: [how to confirm it worked]
+Risk: [what could go wrong and how to handle it]
+```
+
+Rules for planning:
+
+- Each step has a verification criterion. No vague steps.
+- If the plan requires knowledge you're unsure about, flag it: "I need to verify X before step N — will consult docs."
+- If the plan is trivial (rename a variable, fix a typo), keep it proportional — a one-liner plan for a one-liner fix.
+- Wait for developer confirmation before executing. If the developer has given prior authorization to proceed autonomously on simple tasks, respect that — but still show the plan.
+
+Expected output: A plan the developer can approve, modify, or reject.
+
+### Step 4: Execute
+
+Implement the approved plan. Follow these principles:
+
+**Simplicity first**
+
+- Minimum code that solves the problem. Nothing speculative.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No premature flexibility or configurability.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+**Surgical changes**
+
+- Only touch what the plan requires.
+- Match existing code style, even if you'd do it differently.
+- If your changes create orphaned imports or variables, clean them.
+- Do NOT clean pre-existing dead code unless asked.
+- Every changed line traces directly to the mission objective.
+
+**Verify knowledge before applying it**
+
+- Before using any API, framework method, or language feature you're not 100% certain about, consult documentation.
+- Follow the Knowledge Verification Chain (see below).
+- Follow the language's official best practices and conventions.
+- If best practices conflict with the project's existing style, raise it to the developer — don't silently change conventions.
+
+For detailed coding principles, read `references/coding-principles.md`.
+
+Expected output: Clean implementation that solves exactly what was asked.
+
+### Step 5: Verify
+
+Validate the work against the plan's success criteria.
+
+1. Check each verification criterion from the Plan.
+2. If tests exist, run them. If the mission was a bug fix, confirm the bug no longer reproduces.
+3. If something doesn't pass, fix it before declaring success.
+4. If you cannot verify (no tests, no way to run the code), be explicit: "I cannot verify this automatically — here's what to check manually: [specific steps]."
+
+Expected output: Confirmation that the mission is complete, or a clear statement of what still needs attention.
+
+### Step 6: Debrief
+
+The mission is done. Now capture what you learned.
+
+Ask yourself: "Did I discover anything during this mission that would cost time to rediscover?"
+
+**Triggers for creating a note:**
+
+- You had to read 3+ files to understand a flow → document the flow
+- Something didn't work as the name or interface suggested → gotcha
+- You found a pattern the codebase repeats → document the pattern
+- You encountered a business term that isn't obvious → domain entry
+- You found a dependency or integration that's not straightforward → flow
+
+**Triggers for updating an existing note:**
+
+- New information enriches a note you read during Recon
+- A gotcha you documented now has a known fix
+- A flow changed because of the work you just did
+
+**Triggers for NOT creating a note:**
+
+- The discovery is trivial (obvious from file names or comments)
+- The information exists in the project's own documentation
+- The note would be a copy of what's already in the code
+
+For the `.notebook/` format specification, read `references/notebook-spec.md`.
+
+Expected output: Updated `.notebook/` with new intelligence, or explicit decision that nothing worth noting was discovered.
+
+## Summon System
+
+You don't work alone. Before struggling with a task, check your allies.
+
+### Priority order for summoning help:
+
+1. **Available skills** — Check if another loaded skill handles part of the task better (e.g., a skill for creating documents, a skill for specific frameworks). Use `view` on the available skills list if unsure.
+
+2. **MCP servers** — Check if connected MCPs provide relevant tools. Priority MCPs for development:
+
+- **Context7** → current documentation for any library or framework. Always prefer this for doc lookups.
+- **Any other connected MCP** that provides relevant capabilities.
+
+3. **Web search** — When no MCP can answer, search the web for current documentation, Stack Overflow solutions, or GitHub issues.
+
+4. **Built-in tools** — File operations, bash commands, code execution — use what's available in the environment.
+
+### Knowledge Verification Chain
+
+When you need to verify how something works:
+
+```
+Step 1: Check .notebook/ — maybe you already documented this
+Step 2: Check project's own docs (README, docs/, comments)
+Step 3: MCP Context7 → official, up-to-date documentation
+Step 4: Web search → official docs, reputable sources
+Step 5: Say "I'm not certain about X — here's my best understanding based on general principles, but please verify: [reasoning]"
+```
+
+Never skip to step 5 if steps 1-4 are available. And step 5 is always flagged as uncertain — never presented as fact.
+
+## Adapting to Mission Scale
+
+Not every mission needs the full ceremony. Scale the cycle to the task.
+
+**Trivial** (typo fix, rename, simple change):
+
+- Briefing: understood → Plan: one-liner → Execute → Verify → Debrief: skip
+- Total: ~30 seconds of overhead
+
+**Standard** (bug fix, small feature, refactoring):
+
+- Full cycle. Plan is 3-5 steps. Debrief captures 0-2 notes.
+
+**Complex** (cross-module feature, architectural change, deep investigation):
+
+- Full cycle with extended Recon. Plan may need developer input at multiple points. Debrief likely produces 2-5 notes.
+
+**Exploration** (understanding a flow, onboarding to a module):
+
+- Recon IS the mission. Plan becomes "investigate X, document Y." Debrief is the primary deliverable.
+
+## Consistency Contract
+
+This is what the developer can always expect from you:
+
+1. You always read `.notebook/INDEX.md` first if it exists.
+2. You always show a plan before executing non-trivial changes.
+3. You never present uncertain information as fact.
+4. You never modify code outside the scope of the current mission.
+5. You always verify against current docs, not training memory.
+6. You always flag when you've reached the limit of what you know.
+7. You always capture valuable discoveries in `.notebook/`.
+8. You always summon allies when they can help.
+9. You always match the project's existing code style.
+10. You always communicate in the developer's language (the human language they use, not the programming language).
+
+## Examples
+
+### Example 1: Bug fix in unknown project
+
+Developer says: "The checkout is throwing a 500 error when the user applies a coupon. Fix it."
+
+```
+BRIEFING:
+- Read .notebook/INDEX.md → found entry on checkout flow
+- Opened .notebook/checkout-flow.md → flow starts at src/routes/checkout.ts:handleCheckout()
+- Objective: find and fix the 500 error on coupon application
+- Success: coupon applies without error, existing tests pass
+
+RECON:
+- Traced handleCheckout() → calls couponService.apply()
+- couponService.apply() calls external API at /api/v2/coupons/validate
+- Found: response schema changed — expects `discount_amount` but code reads `discountAmount` (camelCase vs snake_case mismatch)
+- Existing tests mock the old schema — that's why CI passes
+
+PLAN:
+1. Fix property access in couponService.apply() to use discount_amount → verify: unit test with real schema shape
+2. Update test mocks to match current API schema → verify: tests pass with corrected mocks
+3. Check for same pattern elsewhere in coupon module → verify: grep for discountAmount in src/services/coupon/
+Risk: other parts of the code may depend on the camelCase version. Will check before changing.
+
+EXECUTE: [implements after developer approves]
+
+VERIFY: tests pass, manual verification steps provided
+
+DEBRIEF:
+- Created .notebook/coupon-api-schema.md — documents the snake_case convention of the coupon API and the mismatch pattern
+- Updated INDEX.md with new entry
+```
+
+### Example 2: Understanding a flow
+
+Developer says: "How does the authentication work in this project?"
+
+```
+BRIEFING:
+- Read .notebook/INDEX.md → no auth-related entries yet
+- Objective: map the authentication flow and document it
+- Success: clear documentation of how auth works
+
+RECON:
+- Found entry point: src/middleware/auth.ts
+- Traced: auth middleware → jwt.verify() → userService.findById()
+- Refresh token logic in src/services/auth/refresh.ts
+- OAuth2 providers configured in src/config/oauth.ts (Google, GitHub)
+- Session stored in Redis (src/lib/redis.ts:sessionStore)
+
+PLAN:
+1. Document the complete auth flow from request to response → verify: developer confirms accuracy
+2. Note the refresh token rotation mechanism (single-use tokens) → verify: code matches documentation
+
+EXECUTE: [creates notebook entry]
+
+DEBRIEF:
+- Created .notebook/auth-flow.md with full flow documentation
+- Created .notebook/session-redis.md noting Redis session pattern
+- Updated INDEX.md
+```
+
+### Example 3: Summoning allies
+
+Developer says: "Add input validation to the user registration endpoint following Zod best practices."
+
+```
+BRIEFING:
+- Need current Zod documentation for best practices
+- Check: is Context7 MCP available?
+
+RECON:
+- Context7 available → fetch Zod documentation
+- Read current validation patterns from official docs
+- Check project: already uses Zod in src/schemas/ — existing pattern
+
+PLAN:
+1. Follow existing schema pattern in src/schemas/
+2. Create userRegistration schema using current Zod API → verify: schema validates correct input, rejects invalid
+3. Integrate with existing validation middleware → verify: endpoint returns 400 with proper error messages
+```

--- a/.claude/skills/codenavi/references/coding-principles.md
+++ b/.claude/skills/codenavi/references/coding-principles.md
@@ -1,0 +1,143 @@
+# Coding Principles
+
+Read this file during the Execute phase when implementing changes.
+These principles reduce common AI coding mistakes and ensure
+consistent, high-quality output.
+
+## 1. Think Before Coding
+
+Before writing any code:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple approaches exist, present them with tradeoffs.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+- If the developer's approach seems wrong, say so constructively.
+  Don't be sycophantic — honesty prevents bugs.
+
+## 2. Simplicity First
+
+Write the minimum code that solves the problem.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- No speculative optimization.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+The test: "Would a senior engineer say this is overcomplicated?"
+If yes, simplify.
+
+## 3. Surgical Changes
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated issues, mention them — don't fix them.
+
+When your changes create orphans:
+
+- Remove imports, variables, and functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line traces directly to the mission objective.
+
+## 4. Goal-Driven Execution
+
+Transform vague tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with verification checkpoints.
+Strong success criteria enable autonomous execution. Weak criteria
+("make it work") require constant clarification — ask for better
+criteria rather than guessing.
+
+## 5. Respect the Codebase
+
+You are a guest in this codebase. Act like it.
+
+- Use the same naming conventions already in the project.
+- Use the same file organization patterns.
+- Use the same error handling approach.
+- Use the same import style (named vs default, relative vs absolute).
+- If the project uses semicolons, use semicolons. If it doesn't, don't.
+
+If existing conventions conflict with language best practices, flag it
+to the developer. Don't silently introduce a different convention.
+
+## 6. Language Best Practices
+
+Always follow the official best practices for the language and
+frameworks in use. This means:
+
+- Use idiomatic patterns for the language (e.g., list comprehensions
+  in Python, Optional chaining in TypeScript).
+- Follow the official style guide when the project doesn't have its own.
+- Use current, non-deprecated APIs and methods.
+- Handle errors according to the language's conventions (try/catch,
+  Result types, error returns — whatever the ecosystem prefers).
+
+Critical: Never rely on training memory for API signatures, method
+parameters, or framework behavior. Always verify against current
+documentation using the Knowledge Verification Chain:
+
+```
+.notebook/ → project docs → MCP Context7 → web search → flag as uncertain
+```
+
+## 7. Dependencies and Imports
+
+When adding new dependencies or imports:
+
+- Check if the project already has a dependency that solves the
+  problem before adding a new one.
+- Check the project's package manager and lockfile for existing
+  versions.
+- If adding a new dependency, mention it to the developer with
+  rationale — never silently add packages.
+- Match the project's import style and ordering conventions.
+
+## 8. Error Handling
+
+- Handle errors that can realistically occur.
+- Don't add catch blocks for theoretically impossible scenarios.
+- Use the project's existing error handling patterns.
+- Error messages should be actionable — tell what happened and
+  what to do about it, not just "Something went wrong."
+- Never swallow errors silently (empty catch blocks) unless
+  there's an explicit reason documented in a comment.
+
+## 9. Testing
+
+When tests are part of the mission:
+
+- Write tests that verify behavior, not implementation details.
+- Test the contract (input → output), not internal state.
+- Name tests descriptively: "should reject expired coupon"
+  not "test1" or "coupon test."
+- If modifying existing code, run existing tests first to
+  establish a baseline.
+- If adding a bug fix, write a test that reproduces the bug
+  first, then fix it.
+
+When tests are NOT part of the mission:
+
+- Don't add tests unless asked.
+- But DO mention if the change is risky and untested:
+  "This change affects the payment flow but there are no tests
+  covering this path. Consider adding tests for [specific cases]."
+
+## 10. Comments
+
+- Don't add comments that restate the code.
+- Don't remove existing comments unless they're provably wrong.
+- Add comments only for non-obvious business logic or workarounds.
+- If you add a workaround, explain WHY it's necessary and link
+  to the relevant issue/ticket if available.
+- Match the project's commenting style and language (human language).

--- a/.claude/skills/codenavi/references/notebook-spec.md
+++ b/.claude/skills/codenavi/references/notebook-spec.md
@@ -1,0 +1,171 @@
+# .notebook/ Specification
+
+Read this file when you need to create or update notes during the
+Debrief phase, or when you need to understand the notebook format
+during Briefing.
+
+## Structure
+
+```
+.notebook/
+├── INDEX.md          # Always read first. Compact index of all notes.
+├── auth-flow.md      # Individual note files — flat by default.
+├── error-handling.md
+└── checkout-race.md
+```
+
+Notes start flat in the root of `.notebook/`. When volume exceeds
+~15 notes, organize into subdirectories by category:
+
+```
+.notebook/
+├── INDEX.md
+├── flows/
+│   ├── auth-flow.md
+│   └── checkout-flow.md
+├── patterns/
+│   └── error-handling.md
+├── gotchas/
+│   └── checkout-race.md
+└── domain/
+    └── coupon-types.md
+```
+
+Categories:
+
+- **flows** — How things work. Integrations, sequences, data paths.
+- **patterns** — How things are done here. Conventions, recurring structures.
+- **gotchas** — Traps. Bugs, quirks, counterintuitive behavior.
+- **domain** — Business concepts. Terminology, rules, logic not obvious in code.
+
+These categories are guidelines, not rigid rules. If a note fits
+multiple categories, pick the primary one. If none fits, put it in root.
+
+## INDEX.md Format
+
+The index must be compact. One line per note. The AI reads this every
+session, so every byte counts.
+
+```markdown
+# .notebook
+> Project intelligence — read before every mission
+
+Last updated: 2026-02-22
+
+- [auth-flow](auth-flow.md) — OAuth2 + refresh rotation | flow | auth, security
+- [error-handling](error-handling.md) — Error boundaries + custom hook | pattern | react, errors
+- [checkout-race](checkout-race.md) — Race condition on cart update | gotcha | checkout, cart
+- [coupon-types](coupon-types.md) — Percentage vs fixed vs BOGO rules | domain | coupons, pricing
+```
+
+Format per line:
+
+```
+- [slug](path) — summary (max ~80 chars) | category | tags
+```
+
+Rules for INDEX.md:
+
+- Keep summaries short and scannable.
+- Tags are lowercase, comma-separated. Use them for quick grep.
+- Update `Last updated` whenever the index changes.
+- If using subdirectories, paths include the folder: `flows/auth-flow.md`.
+- Sort by most recently updated, not alphabetically.
+
+## Individual Note Format
+
+Notes are telegraphic. Think field notes, not documentation.
+
+```markdown
+# Auth Flow
+> OAuth2 with refresh token rotation
+
+Entry: `src/middleware/auth.ts:authMiddleware()` (L12)
+Flow: middleware → `services/auth/jwt.ts:verify()` → `services/user/find.ts:findById()`
+
+Refresh: `services/auth/refresh.ts:rotateToken()`
+- Single-use tokens — consumed on refresh, new pair issued
+- Stored in Redis with TTL (see `lib/redis.ts:sessionStore`)
+
+OAuth providers: `config/oauth.ts` — Google, GitHub
+- Each provider maps to `services/auth/oauth/[provider].ts`
+
+Session: Redis-backed via `lib/redis.ts` (L45-62)
+
+Updated: 2026-02-22
+```
+
+### Format principles
+
+1. **Pointers, not copies.** Always reference as:
+   - `file/path.ts:functionName()` for functions
+   - `file/path.ts` (L10-25) for specific line ranges
+   - `file/path.ts:ClassName.method()` for class methods
+   Never paste code blocks into notes. Code changes; pointers
+   can be re-checked. Pasted code becomes stale lies.
+
+2. **One concept per note.** If it needs scrolling, split it.
+   A note about auth flow should not also cover session management
+   unless they're inseparable.
+
+3. **Minimal prose.** Use fragments, arrows, dashes. Not sentences.
+   "middleware → verify JWT → load user → attach to req" is better
+   than "The middleware first verifies the JWT token, then loads
+   the user from the database, and finally attaches it to the
+   request object."
+
+4. **Always include Entry point.** Every note should have a clear
+   starting point so the reader knows where to begin exploring.
+
+5. **Always include Updated date.** So the reader knows how fresh
+   the information is.
+
+6. **No opinions, only observations.** "Uses Redux for state" not
+   "Uses Redux instead of a better solution." If something is
+   genuinely problematic, state the observable impact:
+   "Redux store has 47 top-level keys — finding relevant state
+   requires searching across 12 reducers."
+
+## Creating the .notebook/ for the First Time
+
+When `.notebook/` doesn't exist yet:
+
+1. Create the directory.
+2. Create INDEX.md with the header only:
+
+   ```markdown
+   # .notebook
+   > Project intelligence — read before every mission
+
+   Last updated: [today]
+   ```
+
+3. Do NOT do a full project analysis. Notes are created organically
+   as you work. The first notes will come from your first mission's
+   Debrief.
+
+## Updating Notes
+
+When updating an existing note:
+
+1. Read the current content.
+2. Add, modify, or remove information based on what you discovered.
+3. Update the `Updated` date at the bottom.
+4. If the summary in INDEX.md changed, update it too.
+
+When information becomes invalid (e.g., a flow changed because of
+your work), update the note immediately — stale notes are worse
+than no notes.
+
+## Token Budget
+
+The entire `.notebook/` system is designed for progressive disclosure:
+
+- **INDEX.md** is read every session (~5-50 lines). Cost: minimal.
+- **Individual notes** are read only when relevant to the current
+  mission. The AI decides which to open based on INDEX.md tags.
+- **Total cost per session:** INDEX.md + 0-3 relevant notes.
+
+If INDEX.md grows beyond 50 entries, consider archiving old notes
+into an `archive/` subdirectory and removing them from the active
+index. Archived notes are still searchable but not loaded by default.

--- a/.claude/skills/mermaid-studio/.skill-meta.json
+++ b/.claude/skills/mermaid-studio/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "8a240b980cee9287a20ec6ea1e4837c5d6e43c756ab17fcebbf6b1087a609815",
+  "downloadedAt": 1776159535895
+}

--- a/.claude/skills/mermaid-studio/SKILL.md
+++ b/.claude/skills/mermaid-studio/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: mermaid-studio
+description: Expert Mermaid diagram creation, validation, and rendering with dual-engine output (SVG/PNG/ASCII). Supports all 20+ diagram types including C4 architecture, AWS architecture-beta with service icons, flowcharts, sequence, ERD, state, class, mindmap, timeline, git graph, sankey, and more. Features code-to-diagram analysis, batch rendering, 15+ themes, and syntax validation. Use when users ask to create diagrams, visualize architecture, render mermaid files, generate ASCII diagrams, document system flows, model databases, draw AWS infrastructure, analyze code structure, or anything involving "mermaid", "diagram", "flowchart", "architecture diagram", "sequence diagram", "ERD", "C4", "ASCII diagram". Do NOT use for non-Mermaid image generation, data plotting with chart libraries, or general documentation writing.
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: 1.0.1
+---
+
+# Mermaid Studio
+
+Expert-level Mermaid diagram creation, validation, and multi-format rendering. Creates diagrams from descriptions or code analysis, validates syntax, and renders to SVG, PNG, or ASCII with professional theming.
+
+## Golden Rules — Elegant Diagrams by Default
+
+Every diagram MUST follow these principles. They are not optional — they define the difference between a mediocre diagram and a gold-standard one.
+
+### Rule 1: Always Use an Init Directive for Professional Styling
+
+**NEVER** create a diagram without an `%%{init}` directive or frontmatter config. The default Mermaid theme produces harsh black lines and generic colors. Always apply a curated palette.
+
+**For general diagrams (flowchart, sequence, state, class, ERD):**
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#3730a3', 'lineColor': '#94a3b8',
+  'secondaryColor': '#10b981', 'tertiaryColor': '#f59e0b',
+  'background': '#ffffff', 'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1', 'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0', 'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff', 'textColor': '#334155'
+}}}%%
+```
+
+**⚠️ Font Warning:** Do NOT set `fontFamily` in theme variables. The Mermaid default font (`trebuchet ms, verdana, arial, sans-serif`) works everywhere. Setting `system-ui`, `Segoe UI`, or `-apple-system` will render as Times New Roman in headless Chromium (used by `mmdc`).
+
+**For C4 diagrams — see the dedicated C4 styling section below.**
+
+**For architecture-beta diagrams — see the dedicated AWS/Architecture section below.**
+
+### Rule 2: Soft Lines, Never Harsh Black
+
+The single biggest visual improvement is using `lineColor: '#94a3b8'` (slate-400) instead of the default black. This creates a modern, breathable diagram. For dark themes, use `lineColor: '#64748b'` (slate-500).
+
+### Rule 3: Limit Density — Breathe
+
+- Maximum 15 nodes per diagram (not 20 — fewer is more elegant)
+- Use `subgraph` or boundaries to create whitespace and visual grouping
+- Prefer LR (left-right) for process flows — it reads more naturally
+- Use invisible links (`A ~~~ B`) to add spacing when the layout is cramped
+
+### Rule 4: Meaningful Labels and Consistent Style
+
+- Node IDs: camelCase (`orderService`, not `s1` or `os`)
+- Labels: short, clear natural language (`[Order Service]`)
+- Arrows: action verbs with protocol info (`"Sends order via gRPC"`)
+- Descriptions: one-line, role-focused (`"Handles order lifecycle"`)
+
+### Rule 5: Color Harmony Over Color Variety
+
+Use max 3-4 colors per diagram. Map colors to meaning:
+
+- **Blue tones** (#4f46e5, #3b82f6) → primary systems, internal services
+- **Green tones** (#10b981, #059669) → success states, data stores
+- **Amber tones** (#f59e0b, #d97706) → external systems, warnings
+- **Slate tones** (#64748b, #94a3b8) → lines, borders, secondary elements
+- **Red tones** (#ef4444) → errors ONLY, never as decoration
+
+## Modes of Operation
+
+This skill operates in three modes based on user intent:
+
+| Mode       | Trigger                                           | What happens               |
+| ---------- | ------------------------------------------------- | -------------------------- |
+| **Create** | "draw a diagram of...", "visualize my..."         | Generates .mmd code only   |
+| **Render** | "render this mermaid", "convert to SVG/PNG/ASCII" | Renders existing .mmd      |
+| **Full**   | "create and render...", ambiguous requests        | Create → Validate → Render |
+
+Default to **Full** mode when intent is unclear.
+
+## Step 1: Understand the Request
+
+Before writing any Mermaid code, determine:
+
+1. **What to diagram** — system, flow, schema, architecture, code structure?
+2. **Which diagram type** — use the Decision Matrix below
+3. **Output format** — code only, SVG, PNG, or ASCII?
+4. **Theme preference** — ask only if rendering; default to `base` theme with curated palette
+
+### Diagram Type Decision Matrix
+
+| User describes...                              | Diagram Type  | Syntax keyword       |
+| ---------------------------------------------- | ------------- | -------------------- |
+| Process, algorithm, decision tree, workflow    | Flowchart     | `flowchart TD/LR`    |
+| API calls, message passing, request/response   | Sequence      | `sequenceDiagram`    |
+| Database schema, table relationships           | ERD           | `erDiagram`          |
+| OOP classes, domain model, interfaces          | Class         | `classDiagram`       |
+| State machine, lifecycle, transitions          | State         | `stateDiagram-v2`    |
+| High-level system overview (C4 Level 1)        | C4 Context    | `C4Context`          |
+| Applications, databases, services (C4 Level 2) | C4 Container  | `C4Container`        |
+| Internal components (C4 Level 3)               | C4 Component  | `C4Component`        |
+| Request flows with numbered steps              | C4 Dynamic    | `C4Dynamic`          |
+| Infrastructure, cloud deployment               | C4 Deployment | `C4Deployment`       |
+| Cloud services with icons (AWS/GCP/Azure)      | Architecture  | `architecture-beta`  |
+| Project timeline, scheduling                   | Gantt         | `gantt`              |
+| Proportional data, percentages                 | Pie           | `pie`                |
+| Brainstorming, hierarchical ideas              | Mindmap       | `mindmap`            |
+| Historical events, chronology                  | Timeline      | `timeline`           |
+| Branching strategy, git history                | Git Graph     | `gitGraph`           |
+| Flow quantities, resource distribution         | Sankey        | `sankey-beta`        |
+| X/Y data visualization                         | XY Chart      | `xychart-beta`       |
+| Priority matrix, strategic positioning         | Quadrant      | `quadrantChart`      |
+| Layout control, grid positioning               | Block         | `block-beta`         |
+| Network packets, protocol headers              | Packet        | `packet-beta`        |
+| Task boards, kanban workflow                   | Kanban        | `kanban`             |
+| User experience, satisfaction scoring          | User Journey  | `journey`            |
+| System requirements traceability               | Requirement   | `requirementDiagram` |
+
+If the user's description doesn't clearly map to one type, suggest 2-3 options with a brief rationale for each, then let them choose.
+
+### When to Load References
+
+Load reference files ONLY when needed for the specific diagram type:
+
+- **C4 diagrams** → Read `references/c4-architecture.md` BEFORE writing code
+- **AWS/Cloud architecture** → Read `references/aws-architecture.md` BEFORE writing code
+- **Code-to-diagram** → Read `references/code-to-diagram.md` BEFORE analyzing
+- **Theming/styling** → Read `references/themes.md` when user requests custom themes
+- **Syntax errors** → Read `references/troubleshooting.md` when validation fails
+- **Any diagram type details** → Read `references/diagram-types.md` for comprehensive syntax
+
+## Step 2: Create the Diagram
+
+### 2.1 — Write Mermaid Code
+
+Follow these principles in order of priority:
+
+1. **Elegance first** — every diagram must look professional with init directives and curated colors
+2. **Correctness** — valid syntax that renders without errors
+3. **Clarity** — meaningful labels, logical flow direction, clear relationships
+4. **Simplicity** — under 15 nodes per diagram; split complex systems into multiple
+5. **Consistency** — uniform naming (camelCase for IDs, descriptive labels in brackets)
+
+### 2.2 — Structure Rules
+
+```
+%% Diagram: [Purpose] | Author: [auto] | Date: [auto]
+%%{init: {'theme': 'base', 'themeVariables': { ... }}}%%
+[diagramType]
+    [content]
+```
+
+**CRITICAL:** The `%%{init}` directive MUST go on the very first non-comment line, BEFORE the diagram type declaration. Alternatively, use YAML frontmatter at the absolute start of the file.
+
+**Naming conventions:**
+
+- Node IDs: camelCase, descriptive (`orderService`, not `s1`)
+- Labels: natural language in brackets (`[Order Service]`)
+- Relationships: action verbs (`"Sends order to"`, `"Reads from"`)
+
+**Layout best practices:**
+
+- `TD` (top-down) for hierarchical flows and processes
+- `LR` (left-right) for timelines, pipelines, and sequential processes
+- `RL` for right-to-left reading contexts
+- Use `subgraph` to group related nodes; name subgraphs meaningfully
+- Add `direction` inside subgraphs when needed for different flow
+
+### 2.3 — Quick Reference Examples
+
+**Flowchart (with professional styling):**
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'primaryTextColor': '#fff',
+  'primaryBorderColor': '#3730a3', 'lineColor': '#94a3b8',
+  'secondaryColor': '#10b981', 'tertiaryColor': '#f59e0b',
+  'background': '#ffffff', 'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1', 'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0', 'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+flowchart TD
+    Start([Start]) --> Input[/User Input/]
+    Input --> Validate{Valid?}
+    Validate -->|Yes| Process[Process Data]
+    Validate -->|No| Error[Show Error]
+    Error --> Input
+    Process --> Save[(Save to DB)]
+    Save --> End([End])
+```
+
+For sequence diagram and ERD styling examples, read `references/themes.md`.
+
+**C4 Context (with MANDATORY elegant styling):**
+
+```mermaid
+C4Context
+    title System Context — E-Commerce Platform
+
+    Person(customer, "Customer", "Places orders online")
+    System(platform, "E-Commerce Platform", "Handles orders and payments")
+    System_Ext(payment, "Payment Gateway", "Processes transactions")
+    System_Ext(email, "Email Service", "Sends notifications")
+
+    Rel(customer, platform, "Uses", "HTTPS")
+    Rel(platform, payment, "Processes payments", "API")
+    Rel(platform, email, "Sends emails", "SMTP")
+
+    UpdateRelStyle(customer, platform, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(platform, payment, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(platform, email, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+**Architecture (AWS with Iconify icons):**
+
+```mermaid
+architecture-beta
+    group vpc(logos:aws-vpc)[VPC]
+
+    service api(logos:aws-api-gateway)[API Gateway] in vpc
+    service lambda(logos:aws-lambda)[Lambda] in vpc
+    service db(logos:aws-dynamodb)[DynamoDB] in vpc
+    service s3(logos:aws-s3)[S3 Bucket]
+
+    api:R --> L:lambda
+    lambda:R --> L:db
+    lambda:B --> T:s3
+```
+
+**IMPORTANT:** Architecture-beta diagrams with `logos:*` icons require icon pack registration. When rendering with the render script, use the `--icons logos` flag. If rendering in a markdown viewer that doesn't support icon packs, use the built-in icons (`cloud`, `database`, `disk`, `server`, `internet`) as fallback. Read `references/aws-architecture.md` for the complete icon catalog and rendering instructions.
+
+For comprehensive syntax of ALL diagram types, read `references/diagram-types.md`.
+
+## C4 Diagrams — Mandatory Styling Guide
+
+C4 diagrams have **fixed element styling** (blue boxes for systems, gray for persons, etc.), but their **relationship lines default to harsh black** which creates visual noise. You MUST apply these styling rules:
+
+### The C4 Styling Pattern
+
+Every C4 diagram MUST include these directives at the end:
+
+```
+    %% === MANDATORY STYLING ===
+    %% Apply soft line colors to ALL relationships
+    UpdateRelStyle(fromAlias, toAlias, $textColor="#475569", $lineColor="#94a3b8")
+    %% Repeat for each Rel() in the diagram
+
+    %% Optimize layout spacing
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Color Values Reference
+
+| Purpose           | Color     | Hex       | Notes                                    |
+| ----------------- | --------- | --------- | ---------------------------------------- |
+| Soft line color   | Slate-400 | `#94a3b8` | Replaces harsh default black             |
+| Line text color   | Slate-600 | `#475569` | Readable but not dominant                |
+| Accent line       | Blue-400  | `#60a5fa` | For highlighted or primary relationships |
+| Warning line      | Amber-500 | `#f59e0b` | For external/risky connections           |
+| Custom element bg | Emerald   | `#10b981` | For data stores or success highlights    |
+| Custom element bg | Indigo    | `#4f46e5` | For primary system emphasis              |
+
+### C4 Layout Tips
+
+**CRITICAL — Maximum 6 `Rel()` per diagram.** More than 6 relationships causes Dagre to route arrows through nodes, creating unreadable spaghetti. If your system needs more connections, split it into multiple focused diagrams.
+
+- Use `$c4ShapeInRow="3"` for most diagrams (prevents horizontal crowding)
+- Use `$c4ShapeInRow="2"` for diagrams with long labels
+- Use `$c4BoundaryInRow="1"` always (stacks boundaries vertically for clarity)
+- Apply `$offsetY="-10"` to `UpdateRelStyle` when labels overlap with elements
+- Prefer tree-shaped topologies (1 in, 1-2 out per node) over mesh topologies
+- Declare elements in flow order — the order of `Container()` declarations affects layout
+- Use directional `Rel_D`, `Rel_R`, etc. only as a last resort when auto-layout creates overlapping
+
+For comprehensive C4 syntax, examples, and patterns, read `references/c4-architecture.md`.
+
+## Step 3: Validate
+
+Before rendering, ALWAYS validate the Mermaid syntax:
+
+```bash
+node $SKILL_DIR/scripts/validate.mjs <file.mmd>
+```
+
+If validation fails:
+
+1. Read the error message carefully
+2. Consult `references/troubleshooting.md` for common fixes
+3. Fix the syntax and re-validate
+4. Maximum 3 fix attempts before asking the user for clarification
+
+## Step 4: Render
+
+### 4.1 — Setup (First Run Only)
+
+```bash
+bash $SKILL_DIR/scripts/setup.sh
+```
+
+This auto-installs both rendering engines and icon pack dependencies. Run once per environment.
+
+### 4.2 — Single Diagram Rendering
+
+```bash
+# SVG (default — best quality)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.svg
+
+# PNG (for documents/presentations)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.png --width 1200
+
+# ASCII (for terminals/READMEs)
+node $SKILL_DIR/scripts/render-ascii.mjs -i diagram.mmd
+
+# With icon packs (architecture-beta with AWS/tech icons)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.svg --icons logos,fa
+```
+
+The `--icons` flag registers Iconify packs before rendering. Packs: `logos` (AWS/tech), `fa` (Font Awesome). Use `logos` for AWS.
+
+### 4.3 — Batch Rendering
+
+For multiple diagrams at once:
+
+```bash
+node $SKILL_DIR/scripts/batch.mjs \
+  --input-dir ./diagrams \
+  --output-dir ./rendered \
+  --format svg \
+  --theme default \
+  --workers 4
+```
+
+### 4.4 — Available Themes
+
+**beautiful-mermaid (15):** `tokyo-night` | `tokyo-night-storm` | `tokyo-night-light` | `dracula` | `nord` | `nord-light` | `catppuccin-mocha` | `catppuccin-latte` | `github-dark` | `github-light` | `solarized-dark` | `solarized-light` | `one-dark` | `zinc-dark` | `zinc-light`
+
+**mermaid-cli native (5):** `default` | `forest` | `dark` | `neutral` | `base`
+
+Custom theme: `--theme base --config '{"theme":"base","themeVariables":{"primaryColor":"#4f46e5","lineColor":"#94a3b8"}}'`
+
+For the full theme catalog, read `references/themes.md`. The render script auto-selects the best engine (mmdc primary, beautiful-mermaid fallback, Puppeteer for icon packs).
+
+## Step 5: Code-to-Diagram (When Requested)
+
+When the user asks to visualize existing code or architecture:
+
+1. Read `references/code-to-diagram.md` for the analysis methodology
+2. Analyze the codebase to identify the right diagram type:
+   - Module dependencies → Flowchart or Class diagram
+   - API routes and handlers → Sequence diagram
+   - Database models/schemas → ERD
+   - Service architecture → C4 Container or Architecture diagram
+   - State machines in code → State diagram
+3. Generate the .mmd file **with proper init directives** (Golden Rule 1)
+4. Validate and render as usual
+
+## Troubleshooting Quick Reference
+
+| Symptom               | Likely Cause       | Fix                                                    |
+| --------------------- | ------------------ | ------------------------------------------------------ |
+| Diagram won't render  | Syntax error       | Run validate.mjs, check brackets/quotes                |
+| Labels cut off        | Text too long      | Shorten labels or use line breaks `<br/>`              |
+| Layout looks wrong    | Wrong direction    | Try different TD/LR/BT/RL                              |
+| Nodes overlap         | Too many nodes     | Split into subgraphs or multiple diagrams              |
+| Lines too dark/thick  | No init directive  | Add `%%{init}` with `lineColor: '#94a3b8'`             |
+| C4 lines overlapping  | No styling applied | Add `UpdateRelStyle` with offsets to each Rel          |
+| AWS icons not showing | No icon pack       | Use `--icons logos` flag or fallback to built-in icons |
+| `mmdc` not found      | Not installed      | Run `setup.sh`                                         |
+| Theme not applied     | Wrong engine       | beautiful-mermaid themes only work with that engine    |
+
+For comprehensive troubleshooting, read `references/troubleshooting.md`.
+
+## Output Conventions
+
+- Save .mmd source files alongside rendered outputs
+- Naming: `{purpose}-{type}.mmd` (e.g., `auth-flow-sequence.mmd`)
+- For batch: maintain input filename, change extension
+- Always provide both the .mmd source and rendered file to the user

--- a/.claude/skills/mermaid-studio/assets/puppeteer-config.json
+++ b/.claude/skills/mermaid-studio/assets/puppeteer-config.json
@@ -1,0 +1,10 @@
+{
+  "executablePath": "",
+  "args": [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu"
+  ],
+  "headless": true
+}

--- a/.claude/skills/mermaid-studio/references/aws-architecture.md
+++ b/.claude/skills/mermaid-studio/references/aws-architecture.md
@@ -1,0 +1,395 @@
+# AWS Architecture Diagrams — Complete Reference
+
+Load this file when the user requests cloud architecture diagrams, AWS infrastructure visualization, or `architecture-beta` diagrams.
+
+## Overview
+
+Mermaid's `architecture-beta` diagram type enables cloud architecture visualization with icons representing services. Combined with Iconify icon packs, it produces professional infrastructure diagrams with real AWS service icons.
+
+**CRITICAL LIMITATION — The "Arrow Distance" Bug:**
+Because `architecture-beta` is built on a rigid grid system without edge routing algorithms, diagrams with more than 6-8 nodes or complex crossing relationships will suffer from **massive, unreadable distances** between nodes and arrows crossing over boxes.
+
+**The Golden Rule for AWS Diagrams:**
+
+- **Simple (< 8 nodes, linear flow):** Use `architecture-beta` with `--icons logos`.
+- **Complex (> 8 nodes, microservices, multiple tiers):** You MUST use **Option A: C4 Container Diagram**. C4 uses the `dagre` layout engine which perfectly spaces nodes and routes arrows beautifully.
+
+**Important — Icon Rendering:**
+
+- `architecture-beta` requires Mermaid v11+
+- Icons from Iconify packs (`logos:aws-*`) require icon pack registration at render time — they do NOT work in static markdown renderers (GitHub, GitLab)
+- When rendering with the render script, use `--icons logos` to auto-register icon packs
+- For environments without icon pack support, the built-in icons (`cloud`, `database`, `disk`, `server`, `internet`) work everywhere as a fallback
+- For universal compatibility, consider using C4 diagrams with descriptive labels as an alternative
+
+## Basic Syntax
+
+```mermaid
+architecture-beta
+
+    group groupId(icon)[Label]
+
+    service serviceId(icon)[Label] in groupId
+
+    serviceA:R --> L:serviceB
+```
+
+### Building Blocks
+
+| Element          | Syntax                               | Purpose                                |
+| ---------------- | ------------------------------------ | -------------------------------------- |
+| Group            | `group id(icon)[Label]`              | Visual boundary (VPC, region, account) |
+| Service          | `service id(icon)[Label]`            | Individual service node                |
+| Service in group | `service id(icon)[Label] in groupId` | Service inside a group                 |
+| Edge             | `serviceA:Side --> Side:serviceB`    | Connection with direction              |
+
+### Edge Sides
+
+Edges connect from/to specific sides of services:
+
+- `L` — Left
+- `R` — Right
+- `T` — Top
+- `B` — Bottom
+
+```
+api:R --> L:lambda        %% api's right connects to lambda's left
+lambda:B --> T:db          %% lambda's bottom connects to db's top
+```
+
+### Edge Types
+
+```
+serviceA:R --> L:serviceB     %% Solid arrow (default)
+serviceA:R -- L:serviceB      %% Solid line (no arrow)
+```
+
+## Icon Options
+
+### Option 1: Iconify Icons (Best Visual Quality)
+
+Mermaid supports 200,000+ icons from iconify.design via `registerIconPacks()`. The `logos` pack provides the best AWS icons. To render with these icons, use `--icons logos` with the render script.
+
+**Format:** `logos:aws-{service-name}`
+
+### Option 2: Built-in Icons (Universal Compatibility)
+
+Available everywhere without any registration. Use these when targeting markdown renderers or when icon packs aren't available:
+`cloud`, `database`, `disk`, `internet`, `server`
+
+## AWS Service Icons Catalog (Iconify `logos` Pack)
+
+### Compute
+
+| Service    | Icon name (logos)             | Built-in fallback |
+| ---------- | ----------------------------- | ----------------- |
+| Lambda     | `logos:aws-lambda`            | `server`          |
+| EC2        | `logos:aws-ec2`               | `server`          |
+| ECS        | `logos:aws-ecs`               | `server`          |
+| Fargate    | `logos:aws-fargate`           | `server`          |
+| Elastic BK | `logos:aws-elastic-beanstalk` | `server`          |
+
+### Storage
+
+| Service | Icon name (logos)   | Built-in fallback |
+| ------- | ------------------- | ----------------- |
+| S3      | `logos:aws-s3`      | `disk`            |
+| EBS     | `logos:aws-ebs`     | `disk`            |
+| EFS     | `logos:aws-efs`     | `disk`            |
+| Glacier | `logos:aws-glacier` | `disk`            |
+
+### Database
+
+| Service     | Icon name (logos)       | Built-in fallback |
+| ----------- | ----------------------- | ----------------- |
+| RDS         | `logos:aws-rds`         | `database`        |
+| DynamoDB    | `logos:aws-dynamodb`    | `database`        |
+| ElastiCache | `logos:aws-elasticache` | `database`        |
+| Aurora      | `logos:aws-aurora`      | `database`        |
+| Redshift    | `logos:aws-redshift`    | `database`        |
+| DocumentDB  | `logos:aws-documentdb`  | `database`        |
+
+### Networking
+
+| Service     | Icon name (logos)                  | Built-in fallback |
+| ----------- | ---------------------------------- | ----------------- |
+| API Gateway | `logos:aws-api-gateway`            | `server`          |
+| CloudFront  | `logos:aws-cloudfront`             | `internet`        |
+| Route 53    | `logos:aws-route53`                | `internet`        |
+| ELB/ALB     | `logos:aws-elastic-load-balancing` | `server`          |
+| VPC         | `logos:aws-vpc`                    | `cloud`           |
+
+### Messaging
+
+| Service     | Icon name (logos)       | Built-in fallback |
+| ----------- | ----------------------- | ----------------- |
+| SQS         | `logos:aws-sqs`         | `server`          |
+| SNS         | `logos:aws-sns`         | `server`          |
+| EventBridge | `logos:aws-eventbridge` | `server`          |
+| Kinesis     | `logos:aws-kinesis`     | `server`          |
+
+### Integration & Orchestration
+
+| Service        | Icon name (logos)          | Built-in fallback |
+| -------------- | -------------------------- | ----------------- |
+| Step Functions | `logos:aws-step-functions` | `server`          |
+| AppSync        | `logos:aws-app-sync`       | `server`          |
+
+### Monitoring & Security
+
+| Service    | Icon name (logos)      | Built-in fallback |
+| ---------- | ---------------------- | ----------------- |
+| CloudWatch | `logos:aws-cloudwatch` | `server`          |
+| IAM        | `logos:aws-iam`        | `server`          |
+| Cognito    | `logos:aws-cognito`    | `server`          |
+| WAF        | `logos:aws-waf`        | `server`          |
+
+### DevOps & CI/CD
+
+| Service      | Icon name (logos)        | Built-in fallback |
+| ------------ | ------------------------ | ----------------- |
+| CodePipeline | `logos:aws-codepipeline` | `server`          |
+| CodeBuild    | `logos:aws-codebuild`    | `server`          |
+| CodeDeploy   | `logos:aws-codedeploy`   | `server`          |
+| ECR          | `logos:aws-ecr`          | `server`          |
+
+### ML/AI
+
+| Service   | Icon name (logos)     | Built-in fallback |
+| --------- | --------------------- | ----------------- |
+| SageMaker | `logos:aws-sagemaker` | `server`          |
+
+**Note:** Not all AWS services have icons in the `logos` pack. If a specific icon is not available, use the closest category-appropriate built-in icon as fallback. You can verify icon availability at https://icon-sets.iconify.design/?q=aws.
+
+## Architecture Patterns
+
+### Pattern 1: Three-Tier Web Application
+
+**With Iconify Icons (best quality — requires `--icons logos`):**
+
+```mermaid
+architecture-beta
+    group vpc(logos:aws-vpc)[VPC]
+    group publicSubnet(cloud)[Public Subnet] in vpc
+    group privateSubnet(cloud)[Private Subnet] in vpc
+    group dataSubnet(database)[Data Subnet] in vpc
+
+    service cdn(logos:aws-cloudfront)[CloudFront]
+    service alb(logos:aws-elastic-load-balancing)[ALB] in publicSubnet
+    service ecs(logos:aws-ecs)[ECS Fargate] in privateSubnet
+    service rds(logos:aws-aurora)[Aurora PostgreSQL] in dataSubnet
+    service cache(logos:aws-elasticache)[ElastiCache Redis] in dataSubnet
+
+    cdn:R --> L:alb
+    alb:R --> L:ecs
+    ecs:R --> L:rds
+    ecs:B --> T:cache
+```
+
+**With Built-in Icons (universal compatibility):**
+
+```mermaid
+architecture-beta
+    group vpc(cloud)[VPC]
+    group publicSubnet(cloud)[Public Subnet] in vpc
+    group privateSubnet(cloud)[Private Subnet] in vpc
+    group dataSubnet(database)[Data Subnet] in vpc
+
+    service cdn(internet)[CloudFront]
+    service alb(server)[ALB] in publicSubnet
+    service ecs(server)[ECS Fargate] in privateSubnet
+    service rds(database)[Aurora PostgreSQL] in dataSubnet
+    service cache(database)[ElastiCache Redis] in dataSubnet
+
+    cdn:R --> L:alb
+    alb:R --> L:ecs
+    ecs:R --> L:rds
+    ecs:B --> T:cache
+```
+
+### Pattern 2: Serverless API
+
+```mermaid
+architecture-beta
+    group api(cloud)[API Layer]
+    group storage(cloud)[Storage]
+
+    service gw(logos:aws-api-gateway)[API Gateway] in api
+    service auth(logos:aws-cognito)[Cognito] in api
+    service fn(logos:aws-lambda)[Lambda] in api
+    service dynamo(logos:aws-dynamodb)[DynamoDB] in storage
+    service s3(logos:aws-s3)[S3] in storage
+
+    gw:R --> L:fn
+    gw:B --> T:auth
+    fn:R --> L:dynamo
+    fn:B --> T:s3
+```
+
+### Pattern 3: Data Pipeline
+
+```mermaid
+architecture-beta
+    group sources(cloud)[Data Sources]
+    group pipeline(cloud)[Pipeline]
+    group analytics(cloud)[Analytics]
+
+    service s3raw(logos:aws-s3)[S3 Raw Data] in sources
+    service kinesis(logos:aws-kinesis)[Kinesis Stream] in sources
+    service glue(logos:aws-glue)[Glue ETL] in pipeline
+    service stepFn(logos:aws-step-functions)[Step Functions] in pipeline
+    service s3processed(logos:aws-s3)[S3 Processed] in pipeline
+    service athena(logos:aws-athena)[Athena] in analytics
+    service quicksight(logos:aws-quicksight)[QuickSight] in analytics
+
+    s3raw:R --> L:glue
+    kinesis:R --> L:glue
+    glue:R --> L:stepFn
+    stepFn:R --> L:s3processed
+    s3processed:R --> L:athena
+    athena:R --> L:quicksight
+```
+
+### Pattern 4: CI/CD Pipeline
+
+```mermaid
+architecture-beta
+    group source(cloud)[Source]
+    group build(cloud)[Build & Test]
+    group deploy(cloud)[Deploy]
+    group runtime(cloud)[Runtime]
+
+    service repo(logos:aws-codecommit)[CodeCommit] in source
+    service pipeline(logos:aws-codepipeline)[CodePipeline] in build
+    service codebuild(logos:aws-codebuild)[CodeBuild] in build
+    service ecr(logos:aws-ecr)[ECR] in build
+    service codedeploy(logos:aws-codedeploy)[CodeDeploy] in deploy
+    service ecs(logos:aws-ecs)[ECS Fargate] in runtime
+    service cw(logos:aws-cloudwatch)[CloudWatch] in runtime
+
+    repo:R --> L:pipeline
+    pipeline:R --> L:codebuild
+    codebuild:R --> L:ecr
+    ecr:R --> L:codedeploy
+    codedeploy:R --> L:ecs
+    ecs:B --> T:cw
+```
+
+## Rendering with Icon Packs
+
+### Using the Render Script
+
+To render architecture-beta diagrams with proper AWS icons:
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --format svg \
+  --icons logos
+```
+
+The `--icons logos` flag tells the render script to register the Iconify `logos` pack which includes all `logos:aws-*` icons. The render script uses a Puppeteer-based pipeline for icon-enabled rendering.
+
+### Multiple Icon Packs
+
+You can register multiple packs:
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --icons logos,fa
+```
+
+Available packs: `logos` (AWS + tech logos), `fa` (Font Awesome icons).
+
+### How Icon Registration Works
+
+The render script generates an HTML page with Mermaid loaded, registers icon packs via `mermaid.registerIconPacks()`, renders the diagram, and captures the SVG output. This is equivalent to:
+
+```javascript
+import mermaid from 'mermaid'
+
+mermaid.registerIconPacks([
+  {
+    name: 'logos',
+    loader: () => fetch('https://unpkg.com/@iconify-json/logos/icons.json').then((res) => res.json()),
+  },
+])
+```
+
+## Fallback Strategy
+
+When `architecture-beta` is not supported by the rendering environment OR icons don't render, use these alternatives:
+
+### Option A: C4 Container Diagram (Best Alternative)
+
+C4 diagrams work everywhere and convey the same information:
+
+```mermaid
+C4Container
+    title AWS Architecture — Serverless API
+
+    Container(gw, "API Gateway", "AWS", "REST API endpoint")
+    Container(auth, "Cognito", "AWS", "Authentication")
+    Container(fn, "Lambda", "Node.js", "Business logic")
+    ContainerDb(db, "DynamoDB", "AWS", "NoSQL storage")
+    ContainerDb(s3, "S3", "AWS", "Object storage")
+
+    Rel(gw, auth, "Authenticates", "JWT")
+    Rel(gw, fn, "Invokes", "Event")
+    Rel(fn, db, "Reads/writes", "SDK")
+    Rel(fn, s3, "Stores files", "SDK")
+
+    UpdateRelStyle(gw, auth, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(gw, fn, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(fn, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(fn, s3, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Option B: Flowchart with AWS Labels and Professional Styling
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#FF9900', 'primaryTextColor': '#232F3E',
+  'primaryBorderColor': '#c47600', 'lineColor': '#94a3b8',
+  'secondaryColor': '#527FFF', 'tertiaryColor': '#DD344C',
+  'background': '#ffffff', 'mainBkg': '#FFF8F0',
+  'nodeBorder': '#c47600', 'clusterBkg': '#FFF8F0',
+  'clusterBorder': '#d4a574', 'edgeLabelBackground': '#ffffff'
+}}}%%
+flowchart LR
+    subgraph AWS["AWS Cloud"]
+        subgraph VPC
+            ALB[ALB<br/>Load Balancer]
+            subgraph ECS["ECS Cluster"]
+                Svc1[Service A]
+                Svc2[Service B]
+            end
+            RDS[(Aurora<br/>PostgreSQL)]
+        end
+        S3[(S3 Bucket)]
+        CF[CloudFront]
+    end
+
+    Users([Users]) --> CF
+    CF --> ALB
+    ALB --> Svc1 & Svc2
+    Svc1 & Svc2 --> RDS
+    Svc1 --> S3
+```
+
+## Best Practices
+
+1. **Group by boundary** — VPC, subnet, region, account
+2. **Left-to-right flow** — request path should read naturally
+3. **Limit to 12 services max** — split complex architectures into multiple focused diagrams
+4. **Show only one concern per diagram** — networking, compute, data, separately
+5. **Include external systems** — show what connects from outside
+6. **Security boundaries** — show public vs private subnets
+7. **Use Iconify icons when rendering** — `logos:aws-*` for best visual quality
+8. **Use built-in icons for docs** — `cloud`, `database`, `disk`, `server`, `internet` for markdown compatibility
+9. **Always provide both versions** — one with Iconify icons for rendered output, one with built-in for inline markdown

--- a/.claude/skills/mermaid-studio/references/c4-architecture.md
+++ b/.claude/skills/mermaid-studio/references/c4-architecture.md
@@ -1,0 +1,473 @@
+# C4 Architecture Diagrams — Complete Reference
+
+Load this file when the user requests C4 diagrams or system architecture documentation. The C4 model provides four levels of abstraction.
+
+## CRITICAL: Mandatory Rules
+
+**Every C4 diagram MUST follow these rules.** Without them, Mermaid renders harsh black lines that overlap elements and make the diagram unreadable.
+
+1. **Max 6 `Rel()` per diagram.** More relationships cause Dagre to route arrows through nodes, creating unreadable spaghetti. Split complex systems into multiple focused diagrams.
+2. **Always style all relationships.** Apply `UpdateRelStyle` to every `Rel()` with soft line colors (see template below).
+3. **Max 6-8 elements per diagram.** Tree-shaped topology (1 in, 1-2 out per node) renders best. Avoid mesh connections.
+4. **Do NOT set `fontFamily`.** Mermaid's default font works everywhere. Setting `system-ui` or `Segoe UI` will render as Times New Roman in headless Chromium.
+
+### Template: Add This to Every C4 Diagram
+
+```
+    %% === MANDATORY: Apply to ALL Rel() references ===
+    UpdateRelStyle(fromAlias, toAlias, $textColor="#475569", $lineColor="#94a3b8")
+    %% Repeat for each relationship in the diagram
+
+    %% === MANDATORY: Layout optimization ===
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### When Labels Overlap Elements
+
+Add `$offsetX` and `$offsetY` to push labels away from elements:
+
+```
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetX="-40", $offsetY="20")
+```
+
+### Highlighting Important Relationships
+
+Use accent colors for critical paths while keeping other lines soft:
+
+```
+    %% Primary relationship — emphasized
+    UpdateRelStyle(client, api, $textColor="#1e40af", $lineColor="#3b82f6")
+
+    %% Secondary relationships — soft
+    UpdateRelStyle(api, db, $textColor="#475569", $lineColor="#94a3b8")
+
+    %% External/risky connection — warning
+    UpdateRelStyle(api, extPayment, $textColor="#92400e", $lineColor="#f59e0b")
+```
+
+## C4 Levels — When to Use Each
+
+| Level | Diagram      | Audience       | Purpose                               |
+| ----- | ------------ | -------------- | ------------------------------------- |
+| 1     | C4Context    | Everyone       | System boundaries and external actors |
+| 2     | C4Container  | Technical team | Applications, databases, services     |
+| 3     | C4Component  | Developers     | Internal module structure             |
+| 4     | C4Deployment | DevOps/SRE     | Infrastructure and deployment nodes   |
+| —     | C4Dynamic    | Technical team | Numbered request flows                |
+
+**Rule of thumb:** Context + Container diagrams are sufficient for most teams. Only create Component/Code diagrams when they genuinely add clarity.
+
+### Audience-Appropriate Recommendations
+
+- **Executives/PMs:** Context only
+- **Architects:** Context + Container
+- **Developers:** Context + Container + Components for their area
+- **DevOps/SRE:** Container + Deployment
+
+## Element Syntax
+
+### People and Systems
+
+```
+Person(alias, "Label", "Description")
+Person_Ext(alias, "Label", "Description")
+System(alias, "Label", "Description")
+System_Ext(alias, "Label", "Description")
+SystemDb(alias, "Label", "Description")
+SystemDb_Ext(alias, "Label", "Description")
+SystemQueue(alias, "Label", "Description")
+SystemQueue_Ext(alias, "Label", "Description")
+```
+
+### Containers
+
+```
+Container(alias, "Label", "Technology", "Description")
+Container_Ext(alias, "Label", "Technology", "Description")
+ContainerDb(alias, "Label", "Technology", "Description")
+ContainerDb_Ext(alias, "Label", "Technology", "Description")
+ContainerQueue(alias, "Label", "Technology", "Description")
+ContainerQueue_Ext(alias, "Label", "Technology", "Description")
+```
+
+### Components
+
+```
+Component(alias, "Label", "Technology", "Description")
+Component_Ext(alias, "Label", "Technology", "Description")
+ComponentDb(alias, "Label", "Technology", "Description")
+ComponentQueue(alias, "Label", "Technology", "Description")
+```
+
+### Boundaries
+
+```
+Enterprise_Boundary(alias, "Label") { ... }
+System_Boundary(alias, "Label") { ... }
+Container_Boundary(alias, "Label") { ... }
+Boundary(alias, "Label", "type") { ... }
+```
+
+### Relationships
+
+```
+Rel(from, to, "Label")
+Rel(from, to, "Label", "Technology")
+BiRel(from, to, "Label")
+Rel_U(from, to, "Label")       %% Upward
+Rel_D(from, to, "Label")       %% Downward
+Rel_L(from, to, "Label")       %% Leftward
+Rel_R(from, to, "Label")       %% Rightward
+Rel_Back(from, to, "Label")    %% Back relationship
+```
+
+**Layout control tip:** When auto-layout causes lines to overlap, use directional variants (`Rel_D`, `Rel_R`, etc.) to force arrows in a specific direction. This is the most effective way to avoid overlapping lines.
+
+### Deployment Nodes
+
+```
+Deployment_Node(alias, "Label", "Type") { ... }
+Deployment_Node(alias, "Label", "Type", "Description") { ... }
+Node(alias, "Label") { ... }
+Node_L(alias, "Label") { ... }
+Node_R(alias, "Label") { ... }
+```
+
+## Complete Examples (All With Mandatory Styling)
+
+### Level 1 — System Context
+
+```mermaid
+C4Context
+    title System Context — Order Management Platform
+
+    Person(customer, "Customer", "Places and tracks orders")
+    Person(admin, "Admin", "Manages products and fulfillment")
+
+    Enterprise_Boundary(company, "Company") {
+        System(orderPlatform, "Order Platform", "Manages the full order lifecycle")
+    }
+
+    System_Ext(paymentGW, "Payment Gateway", "Stripe — processes payments")
+    System_Ext(shipping, "Shipping Provider", "Handles delivery logistics")
+    System_Ext(emailSvc, "Email Service", "SendGrid — transactional emails")
+    System_Ext(analytics, "Analytics", "Mixpanel — usage tracking")
+
+    Rel(customer, orderPlatform, "Places orders, tracks status", "HTTPS")
+    Rel(admin, orderPlatform, "Manages catalog, fulfills orders", "HTTPS")
+    Rel(orderPlatform, paymentGW, "Processes payments", "REST API")
+    Rel(orderPlatform, shipping, "Creates shipments", "REST API")
+    Rel(orderPlatform, emailSvc, "Sends notifications", "SMTP/API")
+    Rel(orderPlatform, analytics, "Sends events", "HTTPS")
+
+    UpdateRelStyle(customer, orderPlatform, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(admin, orderPlatform, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(orderPlatform, paymentGW, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, shipping, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, emailSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, analytics, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Level 2 — Container
+
+**Keep container diagrams focused: max 6-8 elements and 6 Rel().** For complex systems, split into multiple diagrams (one per bounded context or service area).
+
+```mermaid
+C4Container
+    title Container Diagram — Order Platform
+
+    Person(customer, "Customer", "Places orders online")
+
+    System_Boundary(platform, "Order Platform") {
+        Container(spa, "Web App", "React", "Customer-facing storefront")
+        Container(api, "API Gateway", "NestJS", "Routes requests")
+        Container(orderSvc, "Order Service", "NestJS", "Order lifecycle")
+        ContainerDb(db, "Database", "PostgreSQL", "Orders and products")
+    }
+
+    System_Ext(paymentGW, "Stripe", "Payment processing")
+
+    Rel(customer, spa, "Uses", "HTTPS")
+    Rel(spa, api, "Calls", "JSON/HTTPS")
+    Rel(api, orderSvc, "Routes to", "gRPC")
+    Rel(orderSvc, db, "Reads/writes", "SQL")
+    Rel(orderSvc, paymentGW, "Processes payment", "REST API")
+
+    UpdateRelStyle(customer, spa, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(spa, api, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Level 3 — Component (Order Service)
+
+```mermaid
+C4Component
+    title Component Diagram — Order Service
+
+    Container_Boundary(orderSvc, "Order Service") {
+        Component(orderCtrl, "Order Controller", "NestJS Controller", "HTTP/gRPC endpoints")
+        Component(orderUseCase, "Order Use Cases", "Application Layer", "Create, cancel, fulfill orders")
+        Component(paymentPort, "Payment Port", "Interface", "Payment processing abstraction")
+        Component(orderRepo, "Order Repository", "TypeORM", "Order persistence")
+        Component(eventPub, "Event Publisher", "AMQP Client", "Publishes domain events")
+        Component(orderModel, "Order Aggregate", "Domain Model", "Business rules and invariants")
+    }
+
+    ContainerDb(orderDb, "Order DB", "PostgreSQL")
+    ContainerQueue(eventBus, "Event Bus", "RabbitMQ")
+    Container_Ext(paymentGW, "Stripe", "Payment API")
+
+    Rel(orderCtrl, orderUseCase, "Invokes")
+    Rel(orderUseCase, orderModel, "Operates on")
+    Rel(orderUseCase, paymentPort, "Uses")
+    Rel(orderUseCase, orderRepo, "Persists via")
+    Rel(orderUseCase, eventPub, "Publishes events")
+    Rel(orderRepo, orderDb, "SQL queries")
+    Rel(eventPub, eventBus, "AMQP")
+    Rel(paymentPort, paymentGW, "REST API")
+
+    UpdateRelStyle(orderCtrl, orderUseCase, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, orderModel, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, paymentPort, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, orderRepo, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, eventPub, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderRepo, orderDb, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(eventPub, eventBus, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(paymentPort, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Dynamic — Request Flow
+
+```mermaid
+C4Dynamic
+    title Dynamic Diagram — Place Order Flow
+
+    Container(spa, "Web App", "React")
+    Container(api, "API Gateway", "NestJS")
+    Container(orderSvc, "Order Service", "NestJS")
+    Container(paymentGW, "Stripe", "Payment API")
+    ContainerDb(db, "Order DB", "PostgreSQL")
+    ContainerQueue(bus, "Event Bus", "RabbitMQ")
+
+    Rel(spa, api, "1. POST /orders", "JSON/HTTPS")
+    Rel(api, orderSvc, "2. CreateOrder()", "gRPC")
+    Rel(orderSvc, db, "3. INSERT order (pending)", "SQL")
+    Rel(orderSvc, paymentGW, "4. Process payment", "REST")
+    Rel(orderSvc, db, "5. UPDATE order (confirmed)", "SQL")
+    Rel(orderSvc, bus, "6. Publish OrderConfirmed", "AMQP")
+    Rel(orderSvc, api, "7. Return order", "gRPC")
+    Rel(api, spa, "8. 201 Created", "JSON/HTTPS")
+
+    UpdateRelStyle(spa, api, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8", $offsetX="-30")
+    UpdateRelStyle(orderSvc, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+    UpdateRelStyle(orderSvc, bus, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, api, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+    UpdateRelStyle(api, spa, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Deployment
+
+```mermaid
+C4Deployment
+    title Deployment — Production Environment
+
+    Deployment_Node(cdn, "CloudFront", "CDN") {
+        Container(static, "Static Assets", "React Build", "JS/CSS/HTML")
+    }
+
+    Deployment_Node(aws, "AWS", "us-east-1") {
+        Deployment_Node(ecs, "ECS Cluster", "Fargate") {
+            Deployment_Node(apiTask, "API Task", "2 vCPU, 4GB") {
+                Container(api, "API Gateway", "NestJS")
+            }
+            Deployment_Node(orderTask, "Order Task", "2 vCPU, 4GB") {
+                Container(orderSvc, "Order Service", "NestJS")
+            }
+        }
+
+        Deployment_Node(rds, "RDS", "db.r6g.xlarge") {
+            ContainerDb(db, "Order DB", "PostgreSQL 16")
+        }
+
+        Deployment_Node(elasticache, "ElastiCache", "r6g.large") {
+            ContainerDb(cache, "Cache", "Redis 7")
+        }
+
+        Deployment_Node(mq, "Amazon MQ", "mq.m5.large") {
+            ContainerQueue(bus, "Event Bus", "RabbitMQ")
+        }
+    }
+
+    Rel(cdn, api, "Routes API calls", "HTTPS")
+    Rel(api, orderSvc, "Internal", "gRPC")
+    Rel(orderSvc, db, "Reads/writes", "SQL/TLS")
+    Rel(api, cache, "Caches", "Redis/TLS")
+    Rel(orderSvc, bus, "Publishes", "AMQP/TLS")
+
+    UpdateRelStyle(cdn, api, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(api, cache, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, bus, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Styling and Layout
+
+### Layout Configuration
+
+```
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Element Styling
+
+```
+UpdateElementStyle(alias, $fontColor="red", $bgColor="grey", $borderColor="red")
+```
+
+### Relationship Styling
+
+Use `$offsetX` and `$offsetY` to fix overlapping labels:
+
+```
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+```
+
+### Professional Color Palette for Custom Element Styles
+
+| Purpose              | bgColor   | fontColor | borderColor | When to use                     |
+| -------------------- | --------- | --------- | ----------- | ------------------------------- |
+| Primary emphasis     | `#4f46e5` | `#ffffff` | `#3730a3`   | Core systems, main service      |
+| Success / Data store | `#059669` | `#ffffff` | `#047857`   | Databases, completed states     |
+| Warning / External   | `#d97706` | `#ffffff` | `#b45309`   | External systems, risky paths   |
+| Error / Critical     | `#dc2626` | `#ffffff` | `#b91c1c`   | Error states ONLY               |
+| Neutral / Secondary  | `#64748b` | `#ffffff` | `#475569`   | Supporting services, background |
+| Info / Highlight     | `#0284c7` | `#ffffff` | `#0369a1`   | Informational annotations       |
+
+## Microservices Patterns
+
+### Single-Team Ownership
+
+When one team owns all services, model each as a **container**:
+
+```mermaid
+C4Container
+    title Microservices — Single Team
+
+    System_Boundary(platform, "E-commerce Platform") {
+        Container(orderSvc, "Order Service", "NestJS", "Order processing")
+        ContainerDb(orderDb, "Order DB", "PostgreSQL")
+        Container(inventorySvc, "Inventory Service", "NestJS", "Stock management")
+        ContainerDb(inventoryDb, "Inventory DB", "MongoDB")
+    }
+
+    Rel(orderSvc, orderDb, "Reads/writes", "SQL")
+    Rel(inventorySvc, inventoryDb, "Reads/writes", "MongoDB Wire")
+
+    UpdateRelStyle(orderSvc, orderDb, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(inventorySvc, inventoryDb, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+### Multi-Team Ownership
+
+When separate teams own services, promote them to **systems**:
+
+```mermaid
+C4Context
+    title Microservices — Multi-Team
+
+    Person(customer, "Customer")
+    System(orderSys, "Order System", "Team Alpha")
+    System(inventorySys, "Inventory System", "Team Beta")
+    System(paymentSys, "Payment System", "Team Gamma")
+
+    Rel(customer, orderSys, "Places orders")
+    Rel(orderSys, inventorySys, "Checks stock")
+    Rel(orderSys, paymentSys, "Processes payment")
+
+    UpdateRelStyle(customer, orderSys, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(orderSys, inventorySys, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSys, paymentSys, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Event-Driven Architecture
+
+Show individual topics/queues as containers — NOT a single "Kafka" box:
+
+```mermaid
+C4Container
+    title Event-Driven Architecture
+
+    Container(orderSvc, "Order Service", "Java", "Creates orders")
+    Container(stockSvc, "Stock Service", "Java", "Manages inventory")
+    ContainerQueue(orderTopic, "order.created", "Kafka", "Order events")
+    ContainerQueue(stockTopic, "stock.reserved", "Kafka", "Stock events")
+
+    Rel(orderSvc, orderTopic, "Publishes to")
+    Rel(stockSvc, orderTopic, "Subscribes to")
+    Rel(stockSvc, stockTopic, "Publishes to")
+    Rel(orderSvc, stockTopic, "Subscribes to")
+
+    UpdateRelStyle(orderSvc, orderTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(stockSvc, orderTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(stockSvc, stockTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, stockTopic, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+## Essential Rules
+
+1. **Every element must have:** Name, Type, Technology (where applicable), Description
+2. **Use unidirectional arrows** — bidirectional creates ambiguity
+3. **Label arrows with action verbs** — "Sends email using", not just "uses"
+4. **Include technology labels** — "JSON/HTTPS", "SQL", "gRPC"
+5. **Under 15 elements per diagram** — split if more (elegance > completeness)
+6. **Always include a title**
+7. **Meaningful aliases** — `orderService` not `s1`
+8. **ALWAYS add UpdateRelStyle** — soft line colors are mandatory
+9. **ALWAYS add UpdateLayoutConfig** — prevents element crowding
+
+## Common Mistakes
+
+| Mistake                  | Why it's wrong                  | Fix                                  |
+| ------------------------ | ------------------------------- | ------------------------------------ |
+| Shared lib as Container  | Containers are deployable units | Model as Component                   |
+| Single "Kafka" container | Hides topic structure           | Show individual topics               |
+| "Subcomponents" level    | Not a C4 concept                | Use Component or Class               |
+| Removing type labels     | Loses information               | Always show type/tech                |
+| Bidirectional arrows     | Ambiguous flow direction        | Use unidirectional                   |
+| No technology labels     | Can't assess architecture       | Add protocol/tech                    |
+| No UpdateRelStyle        | Harsh black lines               | Add soft colors to ALL relationships |
+| No UpdateLayoutConfig    | Elements crowd together         | Add layout config at end             |
+| No offset on overlap     | Labels hidden behind elements   | Add $offsetX/$offsetY to fix         |
+
+## File Naming Convention
+
+```
+docs/architecture/
+├── c4-context.md
+├── c4-containers.md
+├── c4-components-{feature}.md
+├── c4-deployment.md
+└── c4-dynamic-{flow}.md
+```

--- a/.claude/skills/mermaid-studio/references/code-to-diagram.md
+++ b/.claude/skills/mermaid-studio/references/code-to-diagram.md
@@ -1,0 +1,281 @@
+# Code-to-Diagram — Analysis Methodology
+
+Load this file when the user asks to visualize existing code, analyze a codebase, or generate diagrams from source files.
+
+## Workflow
+
+1. **Identify scope** — what part of the code to diagram
+2. **Choose analysis strategy** — which patterns to look for
+3. **Extract structure** — read relevant files
+4. **Select diagram type** — based on what was found
+5. **Generate diagram** — create .mmd file
+6. **Validate and render** — as usual
+
+## Analysis Strategies by Request Type
+
+### "Show me the architecture"
+
+**What to look for:**
+
+- Project root structure (folders, entry points)
+- Package.json / pyproject.toml / Cargo.toml for dependencies
+- Docker files, docker-compose.yml for services
+- Infrastructure-as-code (CDK, Terraform, CloudFormation, Pulumi)
+- Environment variables for external service connections
+
+**Recommended diagram:** C4 Container or Architecture (for cloud infra)
+
+**File exploration order:**
+
+1. Root directory listing
+2. docker-compose.yml / Dockerfile
+3. Infrastructure files (cdk/, terraform/, cloudformation/)
+4. Main entry point (src/main.ts, app.py, cmd/main.go)
+5. Config files for external connections
+
+### "Diagram the database schema"
+
+**What to look for:**
+
+- ORM models/entities (TypeORM, Prisma, SQLAlchemy, Drizzle)
+- Migration files
+- Schema definition files (.prisma, models.py, entities/)
+- Foreign key references
+- Enum definitions
+
+**Recommended diagram:** ERD
+
+**File exploration order:**
+
+1. Schema files (schema.prisma, models/, entities/)
+2. Migration files (for relationship confirmation)
+3. Seed files (for understanding data relationships)
+
+**Extraction rules:**
+
+- Each model/entity → ERD entity
+- Each field → attribute with type
+- `@relation` / ForeignKey → relationship
+- `@id` / primary_key → PK marker
+- `@unique` → UK marker
+- Foreign key fields → FK marker
+
+**Example — Prisma to ERD:**
+
+```prisma
+// Input: schema.prisma
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String
+  orders    Order[]
+  createdAt DateTime @default(now())
+}
+
+model Order {
+  id        String      @id @default(uuid())
+  userId    String
+  user      User        @relation(fields: [userId], references: [id])
+  items     OrderItem[]
+  total     Decimal
+  status    OrderStatus
+}
+```
+
+```mermaid
+%% Output: database-erd.mmd
+erDiagram
+    USER ||--o{ ORDER : "has orders"
+    ORDER ||--|{ ORDER_ITEM : "contains"
+
+    USER {
+        uuid id PK
+        string email UK
+        string name
+        datetime createdAt
+    }
+
+    ORDER {
+        uuid id PK
+        uuid userId FK
+        decimal total
+        enum status
+    }
+```
+
+### "Show me the API flow"
+
+**What to look for:**
+
+- Route definitions (controllers, routers, handlers)
+- Middleware chain
+- Service layer calls
+- External API calls
+- Database queries in the flow
+
+**Recommended diagram:** Sequence diagram
+
+**File exploration order:**
+
+1. Route/controller files
+2. Middleware definitions
+3. Service files called by controllers
+4. Repository/data-access files
+
+**Extraction rules:**
+
+- Each controller/handler → participant
+- Each service class → participant
+- Each external call → external participant
+- Method calls → synchronous messages (->>)
+- Returns → response messages (-->>)
+- If/else in code → alt blocks
+- Try/catch → opt or break blocks
+- Loops → loop blocks
+
+### "Show me the module dependencies"
+
+**What to look for:**
+
+- Import statements between modules
+- Module registration (NestJS modules, Angular modules)
+- Dependency injection configuration
+- Package/module boundaries
+
+**Recommended diagram:** Class diagram or Flowchart
+
+**Extraction rules:**
+
+- Each module/package → class or node
+- Import/dependency → arrow
+- Circular dependencies → highlight (bidirectional or color)
+
+### "Show me the state machine"
+
+**What to look for:**
+
+- Enum definitions for states/status
+- Switch/case or if/else chains on status
+- State machine libraries (XState, statechart)
+- Transition functions
+- Event handlers that change state
+
+**Recommended diagram:** State diagram
+
+**Extraction rules:**
+
+- Each enum value → state
+- Each transition function → edge with event label
+- Initial state → [*] --> state
+- Terminal states → state --> [*]
+- Guard conditions → edge labels
+
+### "Show me the class structure"
+
+**What to look for:**
+
+- Class definitions with methods and properties
+- Interfaces and abstract classes
+- Inheritance (extends)
+- Composition (has-a fields)
+- Implementation (implements)
+
+**Recommended diagram:** Class diagram
+
+**Extraction rules:**
+
+- `class X extends Y` → inheritance (`Y <|-- X`)
+- `class X implements Y` → realization (`Y ..|> X`)
+- Field of type `Y` in class `X` → association (`X --> Y`)
+- Array/collection of `Y` in `X` → aggregation (`X o-- Y`)
+- `Y` created and owned by `X` → composition (`X *-- Y`)
+- `public` → `+`, `private` → `-`, `protected` → `#`
+
+## Framework-Specific Patterns
+
+### NestJS
+
+```
+src/
+├── modules/
+│   ├── user/
+│   │   ├── user.module.ts       → Module boundary
+│   │   ├── user.controller.ts   → API endpoints (sequence participant)
+│   │   ├── user.service.ts      → Business logic (sequence participant)
+│   │   ├── user.repository.ts   → Data access (sequence participant)
+│   │   ├── user.entity.ts       → Database model (ERD entity)
+│   │   └── dto/                 → Request/Response shapes
+│   └── order/
+│       └── ...
+├── common/
+│   ├── guards/                  → Auth flow (sequence)
+│   ├── interceptors/            → Cross-cutting (flowchart)
+│   └── filters/                 → Error handling (flowchart)
+└── main.ts                      → Entry point
+```
+
+### React / Next.js
+
+```
+src/
+├── app/                         → Routes (flowchart for navigation)
+│   ├── layout.tsx               → Layout hierarchy
+│   ├── page.tsx                 → Page components
+│   └── api/                     → API routes (sequence)
+├── components/                  → Component tree (class/flowchart)
+├── hooks/                       → Custom hooks (class diagram)
+├── lib/                         → Utilities
+├── services/                    → API clients (sequence participants)
+└── store/                       → State management (state diagram)
+```
+
+### Python / FastAPI
+
+```
+app/
+├── main.py                      → Entry point, middleware chain
+├── routers/                     → Route definitions (sequence)
+├── services/                    → Business logic (sequence)
+├── models/                      → SQLAlchemy models (ERD)
+├── schemas/                     → Pydantic schemas
+├── dependencies/                → DI (class diagram)
+└── core/
+    ├── config.py                → External connections
+    └── security.py              → Auth flow (sequence/state)
+```
+
+## Multi-Diagram Strategy
+
+For complex codebases, recommend generating multiple focused diagrams rather than one overwhelming diagram:
+
+1. **System Context (C4 Level 1)** — always, as the overview
+2. **Container Diagram (C4 Level 2)** — for multi-service architectures
+3. **ERD** — if database models exist
+4. **Key Flow Sequence** — for the most important user-facing flow
+5. **State Diagram** — if significant state machines exist
+
+Present these as a set, with the Context diagram first for orientation.
+
+## Output Format
+
+When generating from code, always:
+
+1. Add a header comment linking to source:
+
+   ```
+   %% Generated from: src/modules/order/
+   %% Diagram: Order Service — Component Structure
+   ```
+
+2. Use names that match the code (class names, method names)
+
+3. Include a brief note about what was excluded:
+
+   ```
+   %% Note: Utility classes and DTOs omitted for clarity
+   ```
+
+4. Flag uncertainty:
+   ```
+   %% TODO: Verify relationship between PaymentService and RefundService
+   ```

--- a/.claude/skills/mermaid-studio/references/diagram-types.md
+++ b/.claude/skills/mermaid-studio/references/diagram-types.md
@@ -1,0 +1,758 @@
+# Diagram Types — Complete Syntax Reference
+
+Load this file when you need detailed syntax for a specific diagram type beyond what the quick examples in SKILL.md provide.
+
+## Table of Contents
+
+1. Flowchart (line ~20)
+2. Sequence Diagram (line ~120)
+3. Class Diagram (line ~220)
+4. State Diagram (line ~310)
+5. ERD (line ~380)
+6. Gantt Chart (line ~440)
+7. Pie Chart (line ~490)
+8. Mindmap (line ~520)
+9. Timeline (line ~560)
+10. Git Graph (line ~600)
+11. Sankey (line ~650)
+12. XY Chart (line ~690)
+13. Quadrant Chart (line ~730)
+14. Block Diagram (line ~770)
+15. User Journey (line ~820)
+16. Requirement Diagram (line ~860)
+17. Packet Diagram (line ~900)
+18. Kanban (line ~930)
+
+---
+
+## 1. Flowchart
+
+**Keyword:** `flowchart` or `graph`
+**Directions:** `TD` (top-down), `LR` (left-right), `BT`, `RL`
+
+### Node Shapes
+
+```
+A[Rectangle]           %% Standard process
+B(Rounded)             %% Alternate process
+C([Stadium])           %% Terminal/start-end
+D{Diamond}             %% Decision
+E{{Hexagon}}           %% Preparation
+F[/Parallelogram/]     %% Input/Output
+G[\Reverse parallel\]  %% Manual operation
+H[(Database)]          %% Data store
+I((Circle))            %% Connector
+J>Asymmetric]          %% Flag/signal
+K[[Subroutine]]        %% Predefined process
+L(((Double Circle)))   %% Multiple documents
+M[/Trapezoid\]         %% Manual input
+N[\Inverse trapezoid/] %% Display
+```
+
+### Edge Types
+
+```
+A --> B                %% Arrow
+A --- B                %% Line (no arrow)
+A -.- B                %% Dotted line
+A -.-> B               %% Dotted arrow
+A ==> B                %% Thick arrow
+A ~~~ B                %% Invisible link (spacing)
+A --text--> B          %% Arrow with text
+A -->|text| B          %% Arrow with text (alternate)
+A <--> B               %% Bidirectional
+A o--o B               %% Circle endpoints
+A x--x B               %% Cross endpoints
+```
+
+### Subgraphs
+
+```mermaid
+flowchart TD
+    subgraph Backend["Backend Services"]
+        direction LR
+        API[API Server]
+        Worker[Background Worker]
+    end
+
+    subgraph Storage["Data Layer"]
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    API --> DB
+    API --> Cache
+    Worker --> DB
+```
+
+### Styling
+
+```mermaid
+flowchart LR
+    A[Success]:::success --> B[Warning]:::warning --> C[Error]:::error
+
+    classDef success fill:#10b981,stroke:#059669,color:#fff
+    classDef warning fill:#f59e0b,stroke:#d97706,color:#000
+    classDef error fill:#ef4444,stroke:#dc2626,color:#fff
+```
+
+### Click Events
+
+```
+click A "https://example.com" "Tooltip text" _blank
+click B callback "Tooltip"
+```
+
+---
+
+## 2. Sequence Diagram
+
+**Keyword:** `sequenceDiagram`
+
+### Participant Types
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Frontend App
+    participant API as REST API
+    participant DB as Database
+```
+
+### Message Types
+
+```
+A->>B: Solid arrow (synchronous request)
+A-->>B: Dotted arrow (asynchronous response)
+A-)B: Open arrow (async message, fire-and-forget)
+A--)B: Dotted open arrow (async response)
+A-xB: Cross arrow (lost message)
+A--xB: Dotted cross arrow
+```
+
+### Activation Boxes
+
+```
+A->>+B: Request    %% Activate B
+B-->>-A: Response  %% Deactivate B
+```
+
+### Control Flow
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    participant C
+
+    alt Condition is true
+        A->>B: Path 1
+    else Condition is false
+        A->>C: Path 2
+    end
+
+    opt Optional step
+        B->>C: Optional call
+    end
+
+    loop Every 5 seconds
+        A->>B: Health check
+    end
+
+    par Parallel execution
+        A->>B: Task 1
+    and
+        A->>C: Task 2
+    end
+
+    critical Critical section
+        A->>B: Important operation
+    option Failure case
+        A->>C: Fallback
+    end
+
+    break When error occurs
+        A->>B: Error notification
+    end
+```
+
+### Notes
+
+```
+Note right of A: Single participant note
+Note over A,B: Note spanning participants
+Note left of B: Left-side note
+```
+
+### Numbering
+
+```
+autonumber    %% Add at the top to auto-number messages
+```
+
+### Boxes (Grouping)
+
+```mermaid
+sequenceDiagram
+    box Purple Internal Services
+        participant API
+        participant Worker
+    end
+    box Grey External
+        participant Payment
+    end
+
+    API->>Worker: Process
+    Worker->>Payment: Charge
+```
+
+---
+
+## 3. Class Diagram
+
+**Keyword:** `classDiagram`
+
+### Class Definition
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        #String species
+        -String dna
+        +makeSound()* void
+        +move(distance int) void
+        #reproduce() Animal
+        -mutate() void
+    }
+```
+
+**Visibility modifiers:** `+` public, `-` private, `#` protected, `~` package
+
+### Relationships
+
+```
+A <|-- B       %% Inheritance (B extends A)
+A *-- B        %% Composition (A owns B, lifecycle bound)
+A o-- B        %% Aggregation (A has B, independent lifecycle)
+A --> B        %% Association (A uses B)
+A ..> B        %% Dependency (A depends on B)
+A ..|> B       %% Realization (B implements A)
+A -- B         %% Link (solid)
+A .. B         %% Link (dashed)
+```
+
+### Multiplicity
+
+```
+A "1" --> "*" B : has
+A "1" --> "0..1" B : may have
+A "0..*" --> "1..*" B : relates
+```
+
+### Annotations
+
+```mermaid
+classDiagram
+    class Shape {
+        <<interface>>
+        +area() double
+        +perimeter() double
+    }
+
+    class Color {
+        <<enumeration>>
+        RED
+        GREEN
+        BLUE
+    }
+
+    class Singleton {
+        <<abstract>>
+    }
+
+    class UserService {
+        <<service>>
+    }
+```
+
+### Namespace
+
+```mermaid
+classDiagram
+    namespace Domain {
+        class User
+        class Order
+    }
+    namespace Infrastructure {
+        class UserRepository
+        class OrderRepository
+    }
+```
+
+---
+
+## 4. State Diagram
+
+**Keyword:** `stateDiagram-v2`
+
+### Basic Syntax
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : Start
+    Processing --> Done : Complete
+    Processing --> Error : Failure
+    Error --> Idle : Reset
+    Done --> [*]
+```
+
+### Composite States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active
+
+    state Active {
+        [*] --> Running
+        Running --> Paused : Pause
+        Paused --> Running : Resume
+    }
+
+    Active --> Terminated : Kill
+    Terminated --> [*]
+```
+
+### Forks and Joins
+
+```mermaid
+stateDiagram-v2
+    state fork_state <<fork>>
+    state join_state <<join>>
+
+    [*] --> fork_state
+    fork_state --> TaskA
+    fork_state --> TaskB
+    TaskA --> join_state
+    TaskB --> join_state
+    join_state --> Done
+    Done --> [*]
+```
+
+### Choice
+
+```mermaid
+stateDiagram-v2
+    state check <<choice>>
+
+    [*] --> check
+    check --> Approved : if valid
+    check --> Rejected : if invalid
+```
+
+### Notes
+
+```
+note right of StateName
+    Multi-line note
+    explaining the state
+end note
+```
+
+---
+
+## 5. Entity Relationship Diagram
+
+**Keyword:** `erDiagram`
+
+### Relationship Types
+
+```
+A ||--|| B : "exactly one to exactly one"
+A ||--o{ B : "one to zero or more"
+A ||--|{ B : "one to one or more"
+A }o--o{ B : "zero or more to zero or more"
+A |o--o| B : "zero or one to zero or one"
+```
+
+### Cardinality Symbols
+
+| Symbol | Meaning      |
+| ------ | ------------ |
+| `\|\|` | Exactly one  |
+| `o\|`  | Zero or one  |
+| `}o`   | Zero or more |
+| `}\|`  | One or more  |
+
+### Attribute Types
+
+```mermaid
+erDiagram
+    PRODUCT {
+        uuid id PK "Unique identifier"
+        string name "Product display name"
+        decimal price "Price in cents"
+        text description
+        datetime created_at
+        int stock_count
+        boolean active
+        string sku UK "Stock keeping unit"
+        uuid category_id FK "Reference to category"
+    }
+```
+
+**Key markers:** `PK` (primary key), `FK` (foreign key), `UK` (unique key)
+
+---
+
+## 6. Gantt Chart
+
+**Keyword:** `gantt`
+
+```mermaid
+gantt
+    title Project Timeline
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Planning
+        Requirements    :done, req, 2025-01-01, 14d
+        Design          :active, des, after req, 10d
+
+    section Development
+        Backend         :dev1, after des, 21d
+        Frontend        :dev2, after des, 18d
+
+    section Testing
+        Integration     :test, after dev1, 7d
+        UAT             :uat, after test, 5d
+
+    section Release
+        Deployment      :milestone, deploy, after uat, 0d
+```
+
+**Task states:** `done`, `active`, `crit` (critical path)
+**Duration:** `7d` (days), `5h` (hours), or specific end date
+**Dependencies:** `after taskId` or comma-separated `after task1 task2`
+
+---
+
+## 7. Pie Chart
+
+**Keyword:** `pie`
+
+```mermaid
+pie showData
+    title Technology Stack
+    "TypeScript" : 45
+    "Python" : 25
+    "Go" : 15
+    "Rust" : 10
+    "Other" : 5
+```
+
+`showData` is optional — adds percentages to labels.
+
+---
+
+## 8. Mindmap
+
+**Keyword:** `mindmap`
+
+```mermaid
+mindmap
+    root((System Design))
+        Scalability
+            Horizontal
+                Load Balancers
+                Sharding
+            Vertical
+                More CPU
+                More RAM
+        Reliability
+            Redundancy
+            Failover
+            Backups
+        Performance
+            Caching
+                CDN
+                Redis
+            Optimization
+                Indexing
+                Query tuning
+```
+
+**Node shapes:**
+
+- `((Circle))` — root/emphasis
+- `(Rounded)` — default
+- `[Square]` — structured
+- `)Cloud(` — cloud shape
+- `))Bang((` — explosion/emphasis
+
+---
+
+## 9. Timeline
+
+**Keyword:** `timeline`
+
+```mermaid
+timeline
+    title Product Roadmap 2025
+    section Q1
+        January : MVP Launch
+                : Core API complete
+        February : Beta program
+        March : Public launch
+    section Q2
+        April : Mobile app
+        May : International expansion
+        June : Enterprise features
+```
+
+---
+
+## 10. Git Graph
+
+**Keyword:** `gitGraph`
+
+```mermaid
+gitGraph
+    commit id: "Initial"
+    branch develop
+    checkout develop
+    commit id: "Feature A"
+    commit id: "Feature B"
+    branch feature/auth
+    checkout feature/auth
+    commit id: "Add login"
+    commit id: "Add OAuth"
+    checkout develop
+    merge feature/auth id: "Merge auth"
+    checkout main
+    merge develop id: "Release v1.0" tag: "v1.0"
+    commit id: "Hotfix" type: HIGHLIGHT
+```
+
+**Commit types:** `NORMAL`, `REVERSE`, `HIGHLIGHT`
+**Options:** `branch order: 0` to control branch position
+
+---
+
+## 11. Sankey Diagram
+
+**Keyword:** `sankey-beta`
+
+```mermaid
+sankey-beta
+
+Traffic,Homepage,5000
+Traffic,API,3000
+Homepage,Signup,1500
+Homepage,Browse,3500
+API,Mobile,2000
+API,Partners,1000
+Signup,Active Users,1200
+Signup,Churned,300
+```
+
+Format: `source,target,value` — one per line, comma-separated.
+
+---
+
+## 12. XY Chart
+
+**Keyword:** `xychart-beta`
+
+```mermaid
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar, Apr, May, Jun]
+    y-axis "Revenue ($K)" 0 --> 100
+    bar [30, 45, 60, 55, 70, 85]
+    line [25, 40, 55, 50, 65, 80]
+```
+
+Supports `bar` and `line` series. Multiple series can be combined.
+
+---
+
+## 13. Quadrant Chart
+
+**Keyword:** `quadrantChart`
+
+```mermaid
+quadrantChart
+    title Feature Prioritization
+    x-axis "Low Effort" --> "High Effort"
+    y-axis "Low Impact" --> "High Impact"
+    quadrant-1 "Quick Wins"
+    quadrant-2 "Major Projects"
+    quadrant-3 "Fill-ins"
+    quadrant-4 "Thankless Tasks"
+    Feature A: [0.8, 0.9]
+    Feature B: [0.2, 0.7]
+    Feature C: [0.6, 0.3]
+    Feature D: [0.3, 0.2]
+```
+
+Coordinates are `[x, y]` with values between 0 and 1.
+
+---
+
+## 14. Block Diagram
+
+**Keyword:** `block-beta`
+
+```mermaid
+block-beta
+    columns 3
+
+    space:1 Header["System Overview"]:1 space:1
+
+    Frontend["React App"]:1 API["NestJS API"]:1 DB[("PostgreSQL")]:1
+
+    Frontend --> API
+    API --> DB
+```
+
+Use `columns N` to define grid. `space:N` for empty cells.
+Blocks span cells with `:N` suffix.
+
+---
+
+## 15. User Journey
+
+**Keyword:** `journey`
+
+```mermaid
+journey
+    title User Checkout Experience
+    section Browse
+        Visit homepage: 5: Customer
+        Search product: 4: Customer
+        View details: 4: Customer
+    section Purchase
+        Add to cart: 5: Customer
+        Enter payment: 2: Customer, Payment System
+        Confirm order: 4: Customer, Order Service
+    section Post-Purchase
+        Receive confirmation: 5: Customer, Email Service
+        Track delivery: 3: Customer
+```
+
+Format: `Task name: satisfaction(1-5): actor1, actor2`
+
+---
+
+## 16. Requirement Diagram
+
+**Keyword:** `requirementDiagram`
+
+```mermaid
+requirementDiagram
+    requirement high_availability {
+        id: REQ-001
+        text: System must achieve 99.9% uptime
+        risk: high
+        verifymethod: test
+    }
+
+    functionalRequirement auto_failover {
+        id: REQ-002
+        text: Automatic failover within 30 seconds
+        risk: medium
+        verifymethod: demonstration
+    }
+
+    element load_balancer {
+        type: service
+        docRef: arch-doc-001
+    }
+
+    high_availability - traces -> auto_failover
+    auto_failover - satisfies -> load_balancer
+```
+
+**Relationship types:** `contains`, `copies`, `derives`, `satisfies`, `verifies`,
+`refines`, `traces`
+
+---
+
+## 17. Packet Diagram
+
+**Keyword:** `packet-beta`
+
+```mermaid
+packet-beta
+    0-15: "Source Port"
+    16-31: "Destination Port"
+    32-63: "Sequence Number"
+    64-95: "Acknowledgment Number"
+    96-99: "Data Offset"
+    100-105: "Reserved"
+    106-111: "Flags"
+    112-127: "Window Size"
+    128-143: "Checksum"
+    144-159: "Urgent Pointer"
+```
+
+Format: `start-end: "Label"` — bit ranges for protocol headers.
+
+---
+
+## 18. Kanban
+
+**Keyword:** `kanban`
+
+```mermaid
+kanban
+    column1["To Do"]
+        task1["Design database schema"]
+        task2["Write API specs"]
+    column2["In Progress"]
+        task3["Implement auth"]
+    column3["Review"]
+        task4["Code review: payments"]
+    column4["Done"]
+        task5["Setup CI/CD"]
+```
+
+---
+
+## Global Configuration
+
+Any diagram can be configured with frontmatter:
+
+```mermaid
+---
+config:
+  theme: base
+  look: classic
+  layout: dagre
+  themeVariables:
+    primaryColor: "#4f46e5"
+    lineColor: "#94a3b8"
+---
+flowchart LR
+    A --> B --> C
+```
+
+**Themes:** `default`, `forest`, `dark`, `neutral`, `base`
+**Looks:** `classic`, `handDrawn`
+**Layouts:** `dagre` (default), `elk` (advanced, needs integration)
+
+## Directives (Inline Config)
+
+**IMPORTANT:** The init directive MUST be on the very first line, before any diagram type declaration.
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'lineColor': '#94a3b8',
+  'primaryTextColor': '#fff', 'primaryBorderColor': '#3730a3'
+}}}%%
+```
+
+**Golden Rule:** Always include `'lineColor': '#94a3b8'` to replace the default harsh black lines with softer slate-colored lines. This single change dramatically improves diagram aesthetics.

--- a/.claude/skills/mermaid-studio/references/themes.md
+++ b/.claude/skills/mermaid-studio/references/themes.md
@@ -1,0 +1,426 @@
+# Themes and Styling — Complete Reference
+
+Load this file when the user requests custom themes, specific colors, or styled diagrams.
+
+## Theme Sources
+
+Two rendering engines provide different theme sets:
+
+### Engine 1: @mermaid-js/mermaid-cli (mmdc)
+
+5 built-in themes controlled via `--theme` flag or frontmatter:
+
+| Theme     | Best for                                   |
+| --------- | ------------------------------------------ |
+| `default` | General use, light backgrounds             |
+| `forest`  | Nature-inspired green tones, presentations |
+| `dark`    | Dark backgrounds, dark-mode docs           |
+| `neutral` | Minimal, grayscale, professional docs      |
+| `base`    | Starting point for custom themes           |
+
+### Engine 2: beautiful-mermaid
+
+15 curated themes with consistent design:
+
+**Light themes:**
+| Theme | Style | Best for |
+|-------|-------|----------|
+| `zinc-light` | Clean gray tones | Professional documents |
+| `tokyo-night-light` | Warm light | General use |
+| `catppuccin-latte` | Soft pastels | Friendly docs |
+| `nord-light` | Arctic cool tones | Technical docs |
+| `github-light` | GitHub-style | READMEs, GitHub pages |
+| `solarized-light` | Warm yellows | Long reading |
+
+**Dark themes:**
+| Theme | Style | Best for |
+|-------|-------|----------|
+| `zinc-dark` | Dark gray | Dark mode docs |
+| `tokyo-night` | Vibrant dark | Developer tools |
+| `tokyo-night-storm` | Deep blue-dark | Presentations |
+| `catppuccin-mocha` | Rich dark | Dark mode, cozy feel |
+| `nord` | Arctic dark | Technical, minimal |
+| `dracula` | Purple-tinted dark | Developer-favorite |
+| `github-dark` | GitHub dark mode | Dark READMEs |
+| `solarized-dark` | Warm dark | Extended reading |
+| `one-dark` | Atom-inspired | Code-adjacent docs |
+
+### Theme Selection Guide
+
+| Context                      | Recommended                              |
+| ---------------------------- | ---------------------------------------- |
+| GitHub/GitLab README         | `github-light` or `github-dark`          |
+| Technical documentation      | `nord-light` or `neutral`                |
+| Presentations (light room)   | `zinc-light` or `default`                |
+| Presentations (dark room)    | `tokyo-night-storm` or `dracula`         |
+| Developer tools / terminal   | `tokyo-night` or `one-dark`              |
+| Client-facing / professional | `zinc-light` or `neutral`                |
+| Personal blog / casual       | `catppuccin-latte` or `catppuccin-mocha` |
+
+## Custom Theming (mermaid-cli)
+
+When using the `base` theme, you can override any variable:
+
+### Via Frontmatter
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#4f46e5"
+    primaryTextColor: "#ffffff"
+    primaryBorderColor: "#3730a3"
+    lineColor: "#6b7280"
+    secondaryColor: "#10b981"
+    tertiaryColor: "#f59e0b"
+    background: "#ffffff"
+    mainBkg: "#f8fafc"
+    nodeBorder: "#e2e8f0"
+    clusterBkg: "#f1f5f9"
+    clusterBorder: "#cbd5e1"
+    titleColor: "#1e293b"
+    edgeLabelBackground: "#ffffff"
+---
+flowchart LR
+    A --> B
+```
+
+### Via Init Directive
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5',
+  'primaryTextColor': '#fff',
+  'primaryBorderColor': '#3730a3',
+  'lineColor': '#6b7280',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b'
+}}}%%
+```
+
+### Via Render Script Config
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --format svg \
+  --theme base \
+  --config '{"theme":"base","themeVariables":{"primaryColor":"#4f46e5"}}'
+```
+
+## Available Theme Variables
+
+### Core Colors
+
+| Variable             | Controls                         |
+| -------------------- | -------------------------------- |
+| `primaryColor`       | Main node fill color             |
+| `primaryTextColor`   | Text on primary-colored elements |
+| `primaryBorderColor` | Border of primary elements       |
+| `secondaryColor`     | Secondary elements, alternates   |
+| `tertiaryColor`      | Tertiary elements, highlights    |
+| `lineColor`          | Edge/connection lines            |
+| `background`         | Diagram background               |
+| `mainBkg`            | Default node background          |
+| `nodeBorder`         | Default node border              |
+
+### Text
+
+| Variable              | Controls                      |
+| --------------------- | ----------------------------- |
+| `titleColor`          | Diagram title text            |
+| `textColor`           | General text                  |
+| `edgeLabelBackground` | Background behind edge labels |
+
+### Clusters / Subgraphs
+
+| Variable        | Controls                  |
+| --------------- | ------------------------- |
+| `clusterBkg`    | Subgraph/group background |
+| `clusterBorder` | Subgraph/group border     |
+
+### Sequence Diagram Specific
+
+| Variable                | Controls                      |
+| ----------------------- | ----------------------------- |
+| `actorBkg`              | Participant box fill          |
+| `actorBorder`           | Participant box border        |
+| `actorTextColor`        | Participant text              |
+| `activationBkgColor`    | Activation box fill           |
+| `activationBorderColor` | Activation box border         |
+| `signalColor`           | Message arrow color           |
+| `signalTextColor`       | Message text color            |
+| `noteBkgColor`          | Note background               |
+| `noteBorderColor`       | Note border                   |
+| `noteTextColor`         | Note text                     |
+| `labelBoxBkgColor`      | Alt/loop/opt label background |
+| `labelBoxBorderColor`   | Alt/loop/opt label border     |
+| `loopTextColor`         | Loop label text               |
+
+### Flowchart Specific
+
+| Variable        | Controls  |
+| --------------- | --------- |
+| `nodeTextColor` | Node text |
+
+## Element-Level Styling
+
+### CSS Classes (Flowchart)
+
+```mermaid
+flowchart LR
+    A[Success]:::success
+    B[Warning]:::warning
+    C[Error]:::error
+    D[Info]:::info
+
+    A --> B --> C --> D
+
+    classDef success fill:#10b981,stroke:#059669,color:#fff
+    classDef warning fill:#f59e0b,stroke:#d97706,color:#000
+    classDef error fill:#ef4444,stroke:#dc2626,color:#fff
+    classDef info fill:#3b82f6,stroke:#2563eb,color:#fff
+    classDef default fill:#f8fafc,stroke:#e2e8f0,color:#1e293b
+```
+
+### Inline Styles (Flowchart)
+
+```mermaid
+flowchart LR
+    A --> B --> C
+    style A fill:#f97316,stroke:#ea580c,color:#fff
+    style B fill:#8b5cf6,stroke:#7c3aed,color:#fff
+    style C fill:#06b6d4,stroke:#0891b2,color:#fff
+```
+
+### Link Styles (Flowchart)
+
+```mermaid
+flowchart LR
+    A --> B --> C
+
+    linkStyle 0 stroke:#ef4444,stroke-width:3px
+    linkStyle 1 stroke:#10b981,stroke-width:2px,stroke-dasharray:5
+```
+
+## Brand Color Presets
+
+### Tailwind-Inspired Palette
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#3b82f6',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#2563eb',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b',
+  'lineColor': '#6b7280',
+  'background': '#ffffff',
+  'mainBkg': '#f8fafc',
+  'nodeBorder': '#e2e8f0',
+  'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#cbd5e1'
+}}}%%
+```
+
+### AWS-Themed (Elegant)
+
+Uses AWS orange for primary with **soft slate lines** instead of the harsh default black:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#FF9900',
+  'primaryTextColor': '#232F3E',
+  'primaryBorderColor': '#c47600',
+  'secondaryColor': '#527FFF',
+  'tertiaryColor': '#DD344C',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#FFF8F0',
+  'nodeBorder': '#c47600',
+  'clusterBkg': '#FFF8F0',
+  'clusterBorder': '#d4a574',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+```
+
+### Monochrome Professional
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#374151',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#1f2937',
+  'secondaryColor': '#6b7280',
+  'tertiaryColor': '#9ca3af',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#f9fafb',
+  'nodeBorder': '#d1d5db',
+  'clusterBkg': '#f3f4f6',
+  'clusterBorder': '#9ca3af',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+```
+
+### Indigo-Emerald (Modern SaaS)
+
+A fresh, modern palette for SaaS architecture diagrams:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#3730a3',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1',
+  'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0',
+  'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff',
+  'textColor': '#334155'
+}}}%%
+```
+
+## C4 Diagram Styling
+
+C4 diagrams have fixed element colors (blue for systems, gray for persons, etc.) but the **relationship lines default to harsh black**. Always override them.
+
+**CRITICAL — Arrow Spaghetti Prevention:**
+
+The #1 cause of messy C4 diagrams is too many `Rel()` relationships. Mermaid's Dagre layout engine routes ALL arrows, and with more than ~6 relationships, they inevitably cross and overlap. Follow these rules:
+
+- **Maximum 6 Rel() per diagram** — if you need more, split into multiple diagrams
+- **Tree-shaped topology** — each node should ideally have 1 incoming and 1-2 outgoing edges
+- **Avoid mesh connections** — don't connect everything to everything
+- **Declare elements in flow order** — top-to-bottom or left-to-right; the order of declaration affects layout
+
+### Soft Lines (Mandatory for All C4)
+
+```
+    %% Apply to EVERY Rel() in the diagram
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Highlighted Paths in C4
+
+Use accent colors for primary flows while keeping secondary lines soft:
+
+```
+    %% Primary/user-facing relationship
+    UpdateRelStyle(user, api, $textColor="#1e40af", $lineColor="#3b82f6")
+
+    %% Internal relationship
+    UpdateRelStyle(api, db, $textColor="#475569", $lineColor="#94a3b8")
+
+    %% External/risky connection
+    UpdateRelStyle(api, external, $textColor="#92400e", $lineColor="#f59e0b")
+```
+
+### Custom Element Colors in C4
+
+```
+    UpdateElementStyle(elementAlias, $bgColor="#4f46e5", $fontColor="#ffffff", $borderColor="#3730a3")
+```
+
+| Purpose              | bgColor   | fontColor | borderColor |
+| -------------------- | --------- | --------- | ----------- |
+| Primary emphasis     | `#4f46e5` | `#ffffff` | `#3730a3`   |
+| Success / Data store | `#059669` | `#ffffff` | `#047857`   |
+| Warning / External   | `#d97706` | `#ffffff` | `#b45309`   |
+| Neutral / Supporting | `#64748b` | `#ffffff` | `#475569`   |
+
+## Look Options
+
+```mermaid
+---
+config:
+  look: handDrawn
+---
+flowchart LR
+    A[Sketch Style] --> B[Looks Hand-drawn]
+```
+
+| Look        | Effect                             |
+| ----------- | ---------------------------------- |
+| `classic`   | Standard clean rendering (default) |
+| `handDrawn` | Sketch-like, informal appearance   |
+
+## Configuration via Frontmatter
+
+Full example combining theme, look, and layout:
+
+```mermaid
+---
+config:
+  theme: base
+  look: classic
+  layout: dagre
+  themeVariables:
+    primaryColor: "#4f46e5"
+    lineColor: "#94a3b8"
+---
+flowchart TD
+    A --> B --> C
+```
+
+**Layout engines:**
+| Engine | When to use |
+|--------|-------------|
+| `dagre` | Default — good for most diagrams |
+| `elk` | Complex diagrams with many crossings (requires plugin) |
+
+## Modern Design Principles
+
+### The Golden Rule: Soft Lines
+
+The single biggest improvement to any Mermaid diagram is replacing the default black lines with a softer color. **Always use `lineColor: '#94a3b8'`** (Slate-400) for light backgrounds or `lineColor: '#64748b'` (Slate-500) for dark themes.
+
+### Color Harmony
+
+Use max 3-4 colors per diagram and map them to meaning:
+
+- **Blue tones** → internal systems, primary services
+- **Green tones** → data stores, success states
+- **Amber tones** → external systems, warnings
+- **Slate tones** → lines, borders, secondary elements
+- **Red tones** → error states ONLY (never decoration)
+
+### Typography and Labels
+
+- Keep labels short (max 3-4 words)
+- Use `<br/>` for multi-line labels when needed
+- Use natural language, not abbreviations
+- Include protocol/technology in relationship labels
+
+**CRITICAL — Font Compatibility:**
+
+Do NOT use `system-ui`, `-apple-system`, or `Segoe UI` in `fontFamily` theme variables. These fonts are not available in headless Chromium (used by `mmdc` for rendering) and will silently fall back to a serif font like Times New Roman, making the diagram look unprofessional.
+
+**Safe font stacks for `fontFamily`:**
+- Default (best): `'trebuchet ms', 'verdana', 'arial', sans-serif` — this is Mermaid's built-in default and works everywhere
+- If you must customize: `'verdana', 'arial', 'helvetica', sans-serif`
+
+In practice, do NOT set `fontFamily` at all unless you have a specific reason. The Mermaid default font is already professional and universally compatible.
+
+### Density and Whitespace
+
+- Max 15 nodes per diagram
+- Use subgraphs to create visual grouping and whitespace
+- Use invisible links (`A ~~~ B`) to add spacing when needed
+- Prefer LR over TD for most diagrams (reads more naturally)
+
+### Init Directive Override Behavior
+
+When using the render script, the `--theme` flag writes a config file passed to `mmdc -c`. If your `.mmd` file contains a `%%{init}%%` directive, the render script automatically detects it and does NOT pass a theme in the config, so your init directive takes full precedence. This means:
+
+- If your `.mmd` has `%%{init: {'theme': 'dark', ...}}%%`, it will render with dark theme correctly
+- If your `.mmd` has NO init directive, the render script's `--theme` flag (default: `default`) will be applied
+- You do NOT need to pass `--theme` when using init directives

--- a/.claude/skills/mermaid-studio/references/troubleshooting.md
+++ b/.claude/skills/mermaid-studio/references/troubleshooting.md
@@ -1,0 +1,479 @@
+# Troubleshooting — Common Errors and Fixes
+
+Load this file when validation fails or diagrams don't render correctly.
+
+## Syntax Errors
+
+### 1. Unexpected token / Parse error
+
+**Symptom:** `Parse error on line N: ...`
+
+**Common causes and fixes:**
+
+| Cause                   | Bad              | Good                    |
+| ----------------------- | ---------------- | ----------------------- |
+| Special chars in labels | `A[User's Data]` | `A["User's Data"]`      |
+| Unmatched brackets      | `A[Open label`   | `A[Open label]`         |
+| Missing arrow           | `A B`            | `A --> B`               |
+| Wrong arrow direction   | `A >>- B`        | `A ->> B`               |
+| Keyword as node ID      | `end --> start`  | `endNode --> startNode` |
+| Curly braces in comment | `%% {config}`    | `%% config here`        |
+
+### 2. Reserved Words as Node IDs
+
+These words CANNOT be used as bare node IDs:
+
+`end`, `graph`, `subgraph`, `flowchart`, `classDiagram`, `sequenceDiagram`, `stateDiagram`, `erDiagram`, `gantt`, `pie`, `click`, `style`, `class`, `linkStyle`, `default`, `direction`
+
+**Fix:** Append a suffix or use different names:
+
+```
+%% Bad
+end --> start
+
+%% Good
+endState --> startState
+```
+
+### 3. Quotes and Escaping
+
+```
+%% Bad — unescaped quotes
+A["She said "hello""]
+
+%% Good — use single quotes inside double, or HTML entities
+A["She said 'hello'"]
+A["She said &quot;hello&quot;"]
+
+%% Bad — backslash in labels
+A[C:\Users\path]
+
+%% Good — use forward slash or quote the label
+A["C:\Users\path"]
+```
+
+### 4. Empty Labels or Missing Content
+
+```
+%% Bad — empty node
+A[] --> B
+
+%% Good
+A[Start] --> B[End]
+
+%% Bad — empty subgraph
+subgraph Group
+end
+
+%% Good
+subgraph Group
+    A[Content]
+end
+```
+
+## Rendering Issues
+
+### 5. Diagram Renders but Layout is Wrong
+
+**Symptom:** Nodes overlap, arrows cross unnecessarily
+
+**Fixes:**
+
+- Change direction: `TD` ↔ `LR`
+- Add invisible links for spacing: `A ~~~ B`
+- Use subgraphs to group related nodes
+- Reduce node count (split into multiple diagrams)
+- Try `layout: elk` in frontmatter (if supported)
+
+### 6. Labels Cut Off or Truncated
+
+**Symptom:** Long text gets clipped
+
+**Fixes:**
+
+```
+%% Use line breaks
+A["Order Processing<br/>Service"]
+
+%% Shorten labels
+A["Order Svc"]
+
+%% For sequence diagrams, use aliases
+participant OrderSvc as Order Processing Service
+```
+
+### 7. Subgraph Won't Render
+
+**Symptom:** Subgraph shows as flat, no boundary
+
+**Fixes:**
+
+```
+%% Bad — subgraph must have content
+subgraph Empty
+end
+
+%% Good — needs at least one node
+subgraph Group["Service Layer"]
+    A[Service A]
+end
+
+%% Bad — nested subgraph direction before content
+subgraph Parent
+    direction LR
+end
+
+%% Good — direction followed by nodes
+subgraph Parent
+    direction LR
+    A --> B
+end
+```
+
+### 8. Theme Not Applied
+
+**Symptom:** Diagram renders with default colors
+
+**Causes:**
+
+- beautiful-mermaid themes only work with that engine
+- Frontmatter must be at the very start of the file
+- `%%{init}` directive must be on line 1
+- Some renderers ignore theme config
+
+**Fix:** Verify which engine is being used. For mmdc, use `--theme` flag. For beautiful-mermaid, use `--theme` parameter.
+
+### 9. SVG Output is Blank or Tiny
+
+**Symptom:** File is generated but empty or 0x0 pixels
+
+**Causes:**
+
+- Puppeteer/Chrome not installed (mmdc)
+- File encoding issue (BOM marker)
+- Syntax error that fails silently
+
+**Fixes:**
+
+```bash
+# Re-run setup
+bash $SKILL_DIR/scripts/setup.sh
+
+# Check file encoding
+file diagram.mmd
+# Should say: UTF-8 Unicode text
+
+# Validate first
+node $SKILL_DIR/scripts/validate.mjs diagram.mmd
+```
+
+### 10. mmdc Command Not Found
+
+```bash
+# Check if installed
+npx mmdc --version
+
+# If not, install
+npm install -g @mermaid-js/mermaid-cli
+
+# Or use npx (no global install)
+npx -y @mermaid-js/mermaid-cli -i input.mmd -o output.svg
+```
+
+### 11. Puppeteer/Chrome Issues
+
+**Symptom:** `Error: Could not find Chrome`
+
+```bash
+# Install Chromium for puppeteer
+npx puppeteer browsers install chrome
+
+# Or set custom path
+export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Or use puppeteer config
+echo '{"args": ["--no-sandbox"]}' > puppeteer-config.json
+npx mmdc -i input.mmd -o output.svg -p puppeteer-config.json
+```
+
+## Diagram-Specific Issues
+
+### 12. Sequence Diagram — Activation Mismatch
+
+**Symptom:** `Activation error` or misaligned boxes
+
+```
+%% Bad — activate without deactivate
+A->>+B: Request
+B->>C: Forward
+
+%% Good — always pair +/-
+A->>+B: Request
+B-->>-A: Response
+```
+
+### 13. ERD — Relationship Syntax Error
+
+```
+%% Bad — wrong cardinality syntax
+USER --o{ ORDER
+
+%% Good — must include both sides
+USER ||--o{ ORDER : "places"
+
+%% Bad — missing label
+USER ||--o{ ORDER
+
+%% Good — relationship label is required
+USER ||--o{ ORDER : "places"
+```
+
+### 14. C4 — Element Not Rendering
+
+```
+%% Bad — missing quotes around parameters
+Container(api, API, NestJS, Backend service)
+
+%% Good — all text parameters in quotes
+Container(api, "API", "NestJS", "Backend service")
+
+%% Bad — wrong boundary nesting
+Container_Boundary(app, "App") {
+    System(sys, "External")  %% System inside Container boundary
+}
+
+%% Good — use appropriate element types for context
+Container_Boundary(app, "App") {
+    Component(cmp, "Internal Component", "Tech", "Desc")
+}
+```
+
+### 15. Gantt — Dates Not Parsing
+
+```
+%% Bad — wrong format
+dateFormat DD-MM-YYYY
+
+%% Good — supported formats
+dateFormat YYYY-MM-DD
+%% or
+dateFormat DD/MM/YYYY
+%% or
+dateFormat X  (Unix timestamp)
+```
+
+### 16. Flowchart — Circular Reference Warning
+
+**Symptom:** Infinite loop in rendering
+
+```
+%% Problematic — direct circular
+A --> B --> A
+
+%% Still valid but may cause layout issues. Fix by adding direction:
+flowchart LR
+    A --> B
+    B --> A  %% Renders as two arrows between A and B
+```
+
+### 17. State Diagram — Composite State Errors
+
+```
+%% Bad — missing initial state in composite
+state Active {
+    Running --> Paused
+}
+
+%% Good — composite states need initial transition
+state Active {
+    [*] --> Running
+    Running --> Paused
+}
+```
+
+### 18. Architecture-beta — Not Rendering
+
+**Symptom:** Raw text displayed instead of diagram
+
+**Cause:** `architecture-beta` requires Mermaid v11+
+
+**Fixes:**
+
+- Verify Mermaid version: `npx mmdc --version` (needs 11+)
+- Use C4 or flowchart as fallback (see aws-architecture.md)
+- Update mermaid-cli: `npm install -g @mermaid-js/mermaid-cli@latest`
+
+### 19. Architecture-beta — Icons Not Showing
+
+**Symptom:** Icons show as generic boxes or are missing
+
+**Cause:** `logos:aws-*` icons require icon pack registration at render time
+
+**Fixes:**
+
+```bash
+# Use the --icons flag to register icon packs
+node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output diagram.svg --icons logos
+
+# Or use built-in icons as fallback (no registration needed)
+# Replace: service api(logos:aws-api-gateway)[API Gateway]
+# With:    service api(server)[API Gateway]
+```
+
+Built-in icons that work everywhere: `cloud`, `database`, `disk`, `server`, `internet`
+
+### 20. Architecture-beta — Massive Distances Between Arrows/Nodes
+
+**Symptom:** Nodes are spaced extremely far apart, making arrows incredibly long and crossing other nodes messily.
+
+**Cause:** The architecture-beta renderer has no edge routing algorithms and places nodes in rigid, escalating grids. This breaks diagrams with > 8 nodes.
+
+**Fix:** DO NOT use `architecture-beta` for complex systems. Convert the diagram to a properly styled `C4Container` diagram immediately. C4's layout engine spaces elements perfectly.
+
+### 20. C4 — Lines Too Dark / Overlapping Elements
+
+**Symptom:** Black lines create visual clutter, labels overlap with elements
+
+**Cause:** Missing `UpdateRelStyle` and `UpdateLayoutConfig` directives
+
+**Fixes:**
+
+```
+%% Add to the END of every C4 diagram, after all Rel() definitions
+%% Apply to EACH Rel() with soft colors
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8")
+
+%% Add offsets when labels overlap elements
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+%% Spread out elements
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### 21. General — Diagram Lines Too Dark/Harsh
+
+**Symptom:** Diagram looks cluttered even with few nodes
+
+**Cause:** Default Mermaid theme uses black (#000000) lines
+
+**Fix:** Add init directive with soft line color:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'lineColor': '#94a3b8'
+}}}%%
+```
+
+### 22. General — Init Directive Not Applying
+
+**Symptom:** Colors don't change despite adding `%%{init}` directive
+
+**Cause:** The directive must be on the very first line (no blank lines before it)
+
+**Fix:** Ensure `%%{init}` is the absolute first non-comment line:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {...}}}%%
+flowchart LR
+    A --> B
+```
+
+NOT:
+
+```
+flowchart LR
+%%{init: {'theme': 'base', 'themeVariables': {...}}}%%  %% THIS WILL NOT WORK
+    A --> B
+```
+
+## Validation Script Errors
+
+### 23. validate.mjs Reports False Positives
+
+If the validator rejects valid syntax, it might be using an older Mermaid parser version. Try:
+
+```bash
+# Update the validation script's dependency
+cd $SKILL_DIR && npm update mermaid
+
+# Or skip validation and render directly (rendering validates implicitly)
+node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output test.svg
+```
+
+### 24. Batch Script Hangs
+
+**Symptom:** batch.mjs processes some files then stops
+
+**Causes:**
+
+- Too many workers for available memory
+- One diagram has infinite loop syntax
+- Puppeteer timeout on complex diagrams
+
+**Fixes:**
+
+```bash
+# Reduce workers
+node $SKILL_DIR/scripts/batch.mjs --workers 1
+
+# Increase timeout (ms)
+node $SKILL_DIR/scripts/batch.mjs --timeout 60000
+
+# Process problematic files individually to isolate the issue
+```
+
+## Performance Tips
+
+1. **Simple diagrams first** — start with fewer nodes, add incrementally
+2. **Split large diagrams** — over 15 nodes hurts readability and rendering
+3. **Use SVG over PNG** — SVG renders faster and scales infinitely
+4. **ASCII for CI/CD** — no Puppeteer needed, fast and portable
+5. **Batch in parallel** — use `--workers 4` for multiple files
+6. **Cache renders** — only re-render when .mmd source changes
+
+## Rendering Quality Issues
+
+### 25. Fonts Render as Times New Roman / Serif
+
+**Symptom:** Text in the rendered PNG/SVG appears in an ugly serif font instead of the expected sans-serif font.
+
+**Cause:** The `%%{init}%%` directive uses `fontFamily: 'system-ui'` or `fontFamily: 'Segoe UI'` or other desktop-only fonts. These fonts are NOT available in headless Chromium (which `mmdc` uses internally), so the browser falls back to a serif font.
+
+**Fix:** Do NOT set `fontFamily` at all (Mermaid's default `trebuchet ms, verdana, arial, sans-serif` works perfectly), or use only universally available fonts:
+
+```
+%% BAD — these fonts don't exist in headless Chromium
+%%{init: {'theme': 'base', 'themeVariables': {
+  'fontFamily': 'system-ui, -apple-system, sans-serif'
+}}}%%
+
+%% GOOD — use Mermaid defaults (don't set fontFamily at all)
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'lineColor': '#94a3b8'
+}}}%%
+
+%% GOOD — if you must set a font, use web-safe ones
+%%{init: {'theme': 'base', 'themeVariables': {
+  'fontFamily': 'trebuchet ms, verdana, arial, sans-serif'
+}}}%%
+```
+
+### 26. Theme / Init Directive Ignored When Rendering
+
+**Symptom:** You set `%%{init: {'theme': 'dark', ...}}%%` in your `.mmd` file but the diagram renders with the default light theme.
+
+**Cause:** The render script passes a config file with `{"theme": "default"}` via `mmdc -c`, which was overriding the init directive in the diagram.
+
+**Fix:** This bug has been fixed in the render script — it now detects `%%{init` in the input file and does NOT pass a theme in the config file, allowing the init directive to take full precedence. If you still experience this issue, verify:
+
+1. The `%%{init}%%` directive is on the very first line of the `.mmd` file (no blank lines before it)
+2. You are NOT passing `--theme` to the render script when using init directives
+3. The render script version includes the `hasInitDirective` detection fix
+
+### 27. Render Script Fails Silently with `mmdc=no`
+
+**Symptom:** The render script reports `Engines: mmdc=no` even though `mmdc` is installed in `.deps/node_modules/.bin/`.
+
+**Cause:** The skill's directory path contains special characters (like parentheses in `(tooling)`) that break shell execution in `execSync()`. The shell interprets `(` as subshell syntax and fails.
+
+**Fix:** This bug has been fixed in the render script — all paths are now wrapped with `shellQuote()` which uses single quotes to protect against special characters. If you still experience this issue, verify that the `shellQuote()` function exists in `render.mjs` and is used for all path arguments in `execSync()` calls.

--- a/.claude/skills/mermaid-studio/scripts/batch.mjs
+++ b/.claude/skills/mermaid-studio/scripts/batch.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/batch.mjs
+ *
+ * Batch renders multiple Mermaid diagrams in parallel.
+ *
+ * Usage:
+ *   node batch.mjs --input-dir ./diagrams --output-dir ./rendered [options]
+ *
+ * Options:
+ *   --input-dir     Directory containing .mmd files
+ *   --output-dir    Directory for rendered outputs
+ *   --format        Output format: svg (default), png, pdf, ascii
+ *   --theme         Theme name (default: default)
+ *   --workers       Parallel workers (default: 4)
+ *   --recursive     Search subdirectories for .mmd files
+ *   --timeout       Per-file timeout in ms (default: 30000)
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, readdirSync } from "fs";
+import { basename, dirname, extname, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function parseArgs(args) {
+  const opts = {
+    inputDir: null,
+    outputDir: null,
+    format: "svg",
+    theme: "default",
+    workers: 4,
+    recursive: false,
+    timeout: 30000,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input-dir":
+        opts.inputDir = args[++i];
+        break;
+      case "--output-dir":
+        opts.outputDir = args[++i];
+        break;
+      case "--format":
+        opts.format = args[++i];
+        break;
+      case "--theme":
+        opts.theme = args[++i];
+        break;
+      case "--workers":
+        opts.workers = parseInt(args[++i], 10);
+        break;
+      case "--recursive":
+        opts.recursive = true;
+        break;
+      case "--timeout":
+        opts.timeout = parseInt(args[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        console.log(`
+Mermaid Studio — Batch Renderer
+
+Usage:
+  node batch.mjs --input-dir <dir> --output-dir <dir> [options]
+
+Options:
+  --input-dir     Directory containing .mmd/.mermaid files
+  --output-dir    Output directory for rendered files
+  --format        Output format: svg (default), png, pdf, ascii
+  --theme         Theme name (default: default)
+  --workers       Parallel render workers (default: 4)
+  --recursive     Include subdirectories
+  --timeout       Per-file timeout in ms (default: 30000)
+  --help, -h      Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function findMmdFiles(dir, recursive = false) {
+  const files = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isFile() && (entry.name.endsWith(".mmd") || entry.name.endsWith(".mermaid"))) {
+      files.push(fullPath);
+    } else if (entry.isDirectory() && recursive) {
+      files.push(...findMmdFiles(fullPath, true));
+    }
+  }
+
+  return files.sort();
+}
+
+function getOutputPath(inputFile, inputDir, outputDir, format) {
+  const rel = relative(inputDir, inputFile);
+  const ext = format === "ascii" ? ".txt" : `.${format}`;
+  const outputName = basename(rel, extname(rel)) + ext;
+  const outputSubdir = dirname(rel);
+  return resolve(outputDir, outputSubdir, outputName);
+}
+
+async function renderFile(inputFile, outputFile, format, theme, timeout) {
+  const renderScript =
+    format === "ascii"
+      ? resolve(__dirname, "render-ascii.mjs")
+      : resolve(__dirname, "render.mjs");
+
+  const args =
+    format === "ascii"
+      ? ["--input", inputFile, "--output", outputFile]
+      : ["--input", inputFile, "--output", outputFile, "--format", format, "--theme", theme];
+
+  return new Promise((resolvePromise) => {
+    try {
+      const cmd = `node "${renderScript}" ${args.map((a) => `"${a}"`).join(" ")}`;
+      execSync(cmd, {
+        stdio: "pipe",
+        timeout: timeout,
+        env: { ...process.env },
+      });
+      resolvePromise({ success: true, file: basename(inputFile) });
+    } catch (e) {
+      const stderr = e.stderr?.toString()?.slice(0, 100) || e.message;
+      resolvePromise({
+        success: false,
+        file: basename(inputFile),
+        error: stderr,
+      });
+    }
+  });
+}
+
+async function runBatch(files, opts) {
+  const results = [];
+  let completed = 0;
+  const total = files.length;
+
+  // Process in chunks of --workers size
+  for (let i = 0; i < files.length; i += opts.workers) {
+    const chunk = files.slice(i, i + opts.workers);
+    const promises = chunk.map((inputFile) => {
+      const outputFile = getOutputPath(
+        inputFile,
+        resolve(opts.inputDir),
+        resolve(opts.outputDir),
+        opts.format
+      );
+      mkdirSync(dirname(outputFile), { recursive: true });
+      return renderFile(inputFile, outputFile, opts.format, opts.theme, opts.timeout);
+    });
+
+    const chunkResults = await Promise.all(promises);
+    for (const result of chunkResults) {
+      completed++;
+      const icon = result.success ? "✓" : "✗";
+      console.log(`  ${icon} [${completed}/${total}] ${result.file}${result.error ? ` — ${result.error}` : ""}`);
+      results.push(result);
+    }
+  }
+
+  return results;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (!opts.inputDir || !opts.outputDir) {
+    console.error("Error: --input-dir and --output-dir are required");
+    console.error('Run with --help for usage info.');
+    process.exit(1);
+  }
+
+  if (!existsSync(opts.inputDir)) {
+    console.error(`Error: Input directory not found: ${opts.inputDir}`);
+    process.exit(1);
+  }
+
+  mkdirSync(opts.outputDir, { recursive: true });
+
+  const files = findMmdFiles(resolve(opts.inputDir), opts.recursive);
+
+  if (files.length === 0) {
+    console.log("No .mmd or .mermaid files found in input directory.");
+    process.exit(0);
+  }
+
+  console.log(`\n=== Mermaid Studio — Batch Render ===`);
+  console.log(`Input:   ${resolve(opts.inputDir)}`);
+  console.log(`Output:  ${resolve(opts.outputDir)}`);
+  console.log(`Format:  ${opts.format}`);
+  console.log(`Theme:   ${opts.theme}`);
+  console.log(`Workers: ${opts.workers}`);
+  console.log(`Files:   ${files.length}`);
+  console.log(`${"─".repeat(40)}`);
+
+  const startTime = Date.now();
+  const results = await runBatch(files, opts);
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  console.log(`${"─".repeat(40)}`);
+  console.log(`\nCompleted in ${elapsed}s`);
+  console.log(`  ✓ ${succeeded} succeeded`);
+  if (failed > 0) {
+    console.log(`  ✗ ${failed} failed`);
+  }
+  console.log(`  Total: ${results.length}/${files.length}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(2);
+});

--- a/.claude/skills/mermaid-studio/scripts/render-ascii.mjs
+++ b/.claude/skills/mermaid-studio/scripts/render-ascii.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/render-ascii.mjs
+ *
+ * Renders Mermaid diagrams as ASCII/Unicode art for terminal display.
+ * Uses beautiful-mermaid library for ASCII output.
+ *
+ * Usage:
+ *   node render-ascii.mjs --input diagram.mmd
+ *   node render-ascii.mjs --input diagram.mmd --output diagram.txt
+ *   echo "graph LR; A-->B" | node render-ascii.mjs --stdin
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+function parseArgs(args) {
+  const opts = {
+    input: null,
+    output: null, // null = stdout
+    stdin: false,
+    width: null,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input":
+      case "-i":
+        opts.input = args[++i];
+        break;
+      case "--output":
+      case "-o":
+        opts.output = args[++i];
+        break;
+      case "--stdin":
+        opts.stdin = true;
+        break;
+      case "--width":
+      case "-w":
+        opts.width = parseInt(args[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        console.log(`
+Mermaid Studio — ASCII Renderer
+
+Usage:
+  node render-ascii.mjs --input <file.mmd> [--output <file.txt>]
+  echo "graph LR; A-->B" | node render-ascii.mjs --stdin
+
+Options:
+  --input, -i     Input .mmd file path
+  --output, -o    Output file (default: print to stdout)
+  --stdin         Read diagram from stdin
+  --width, -w     Max width in characters
+  --help, -h      Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+function findBeautifulMermaid() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/beautiful-mermaid"),
+    resolve(process.cwd(), "node_modules/beautiful-mermaid"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+async function renderAscii(mmdContent, bmPath, opts) {
+  try {
+    const bm = await import(resolve(bmPath, "index.js")).catch(() =>
+      import(resolve(bmPath, "dist/index.js")).catch(() =>
+        import(resolve(bmPath, "src/index.js"))
+      )
+    );
+
+    // Try various function names the library might expose
+    const renderFn =
+      bm.renderMermaidAscii ||
+      bm.renderAscii ||
+      bm.default?.renderMermaidAscii ||
+      bm.default?.renderAscii;
+
+    if (renderFn) {
+      const asciiOpts = {};
+      if (opts.width) asciiOpts.maxWidth = opts.width;
+
+      const result = await renderFn(mmdContent, asciiOpts);
+      return typeof result === "string" ? result : result?.ascii || result?.text || String(result);
+    }
+
+    // If no dedicated ASCII function, try the general render with ascii format
+    const generalRender =
+      bm.renderMermaid ||
+      bm.render ||
+      bm.default?.renderMermaid ||
+      bm.default?.render;
+
+    if (generalRender) {
+      const renderOpts = { format: "ascii" };
+      if (opts.width) renderOpts.maxWidth = opts.width;
+
+      const result = await generalRender(mmdContent, renderOpts);
+      if (typeof result === "string") return result;
+      if (result?.ascii) return result.ascii;
+      if (result?.text) return result.text;
+      return String(result);
+    }
+
+    throw new Error("No suitable render function found in beautiful-mermaid");
+  } catch (e) {
+    throw new Error(`beautiful-mermaid ASCII rendering failed: ${e.message}`);
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Get input
+  let mmdContent;
+  if (opts.stdin) {
+    mmdContent = await readFromStdin();
+  } else if (opts.input) {
+    const inputFile = resolve(opts.input);
+    if (!existsSync(inputFile)) {
+      console.error(`Error: Input file not found: ${inputFile}`);
+      process.exit(1);
+    }
+    mmdContent = readFileSync(inputFile, "utf-8");
+  } else {
+    console.error("Error: --input or --stdin is required");
+    process.exit(1);
+  }
+
+  if (!mmdContent.trim()) {
+    console.error("Error: Empty input");
+    process.exit(1);
+  }
+
+  // Find engine
+  const bmPath = findBeautifulMermaid();
+  if (!bmPath) {
+    console.error("Error: beautiful-mermaid not found.");
+    console.error(`Run: bash ${resolve(__dirname, "setup.sh")}`);
+    process.exit(1);
+  }
+
+  try {
+    const ascii = await renderAscii(mmdContent, bmPath, opts);
+
+    if (opts.output) {
+      mkdirSync(dirname(resolve(opts.output)), { recursive: true });
+      writeFileSync(resolve(opts.output), ascii, "utf-8");
+      console.error(`✓ ASCII output saved to: ${resolve(opts.output)}`);
+    } else {
+      // Print to stdout
+      console.log(ascii);
+    }
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
+    console.error("");
+    console.error("Tip: ASCII rendering requires beautiful-mermaid.");
+    console.error("Supported diagram types: flowchart, sequence, state, class, ER.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(1);
+});

--- a/.claude/skills/mermaid-studio/scripts/render.mjs
+++ b/.claude/skills/mermaid-studio/scripts/render.mjs
@@ -1,0 +1,600 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/render.mjs
+ *
+ * Dual-engine Mermaid renderer with automatic fallback and icon pack support.
+ * Primary: @mermaid-js/mermaid-cli (mmdc) — supports all diagram types, PNG/SVG/PDF
+ * Fallback: beautiful-mermaid — better themes, SVG output
+ * Icon mode: Puppeteer-based custom renderer — registers icon packs for architecture-beta
+ *
+ * Usage:
+ *   node render.mjs --input diagram.mmd --output diagram.svg [--format svg|png|pdf] [--theme default] [--width 1200] [--config '{}']
+ *   node render.mjs --input diagram.mmd --output diagram.svg --icons logos,fa
+ *   echo "graph LR; A-->B" | node render.mjs --stdin --output out.svg
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, extname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+// --- Argument parsing ---
+
+function parseArgs(args) {
+  const opts = {
+    input: null,
+    output: null,
+    format: "svg",
+    theme: "default",
+    width: 1200,
+    height: null,
+    config: null,
+    stdin: false,
+    engine: "auto", // auto | mmdc | beautiful-mermaid | puppeteer
+    background: "white",
+    icons: [], // icon pack names to register (e.g., ['logos', 'fa'])
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input":
+      case "-i":
+        opts.input = args[++i];
+        break;
+      case "--output":
+      case "-o":
+        opts.output = args[++i];
+        break;
+      case "--format":
+      case "-f":
+        opts.format = args[++i];
+        break;
+      case "--theme":
+      case "-t":
+        opts.theme = args[++i];
+        break;
+      case "--width":
+      case "-w":
+        opts.width = parseInt(args[++i], 10);
+        break;
+      case "--height":
+        opts.height = parseInt(args[++i], 10);
+        break;
+      case "--config":
+      case "-c":
+        opts.config = args[++i];
+        break;
+      case "--stdin":
+        opts.stdin = true;
+        break;
+      case "--engine":
+      case "-e":
+        opts.engine = args[++i];
+        break;
+      case "--background":
+      case "--bg":
+        opts.background = args[++i];
+        break;
+      case "--icons":
+        opts.icons = args[++i].split(",").map((s) => s.trim()).filter(Boolean);
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`
+Mermaid Studio — Render Script
+
+Usage:
+  node render.mjs --input <file.mmd> --output <file.svg> [options]
+  echo "graph LR; A-->B" | node render.mjs --stdin --output out.svg
+
+Options:
+  --input, -i     Input .mmd file path
+  --output, -o    Output file path (required)
+  --format, -f    Output format: svg (default), png, pdf
+  --theme, -t     Theme name (see SKILL.md for available themes)
+  --width, -w     Width in pixels for PNG (default: 1200)
+  --height        Height in pixels for PNG (auto-calculated if omitted)
+  --config, -c    JSON string with mermaid config overrides
+  --engine, -e    Force engine: auto (default), mmdc, beautiful-mermaid, puppeteer
+  --background    Background color (default: white)
+  --icons         Comma-separated Iconify pack names to register (e.g., logos,fa)
+                  Use 'logos' for AWS/tech icons, 'fa' for Font Awesome
+                  When specified, uses Puppeteer-based renderer for proper icon support
+  --stdin         Read diagram from stdin
+  --help, -h      Show this help
+`);
+}
+
+// --- Icon pack CDN URLs ---
+
+const ICON_PACK_URLS = {
+  logos: "https://unpkg.com/@iconify-json/logos/icons.json",
+  fa: "https://unpkg.com/@iconify-json/fa6-regular/icons.json",
+  "fa-solid": "https://unpkg.com/@iconify-json/fa6-solid/icons.json",
+  "fa-brands": "https://unpkg.com/@iconify-json/fa6-brands/icons.json",
+  mdi: "https://unpkg.com/@iconify-json/mdi/icons.json",
+  "simple-icons": "https://unpkg.com/@iconify-json/simple-icons/icons.json",
+};
+
+// --- Engine detection ---
+
+function shellQuote(p) {
+  // Wrap path in single quotes and escape any internal single quotes
+  return `'${p.replace(/'/g, "'\\''")}' `;
+}
+
+function isMmdcAvailable() {
+  try {
+    const mmdcPaths = [
+      resolve(DEPS_DIR, "node_modules/.bin/mmdc"),
+      "mmdc",
+    ];
+    for (const p of mmdcPaths) {
+      try {
+        execSync(`${shellQuote(p)} --version`, { stdio: "pipe", timeout: 10000 });
+        return p;
+      } catch {
+        continue;
+      }
+    }
+    // Try npx
+    execSync("npx mmdc --version", { stdio: "pipe", timeout: 15000 });
+    return "npx mmdc";
+  } catch {
+    return null;
+  }
+}
+
+function isBeautifulMermaidAvailable() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/beautiful-mermaid"),
+    resolve(process.cwd(), "node_modules/beautiful-mermaid"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function isPuppeteerAvailable() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/puppeteer"),
+    resolve(DEPS_DIR, "node_modules/puppeteer-core"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+// --- beautiful-mermaid themes ---
+
+const BEAUTIFUL_MERMAID_THEMES = new Set([
+  "zinc-light",
+  "zinc-dark",
+  "tokyo-night",
+  "tokyo-night-storm",
+  "tokyo-night-light",
+  "catppuccin-mocha",
+  "catppuccin-latte",
+  "nord",
+  "nord-light",
+  "dracula",
+  "github-dark",
+  "github-light",
+  "solarized-dark",
+  "solarized-light",
+  "one-dark",
+]);
+
+const MMDC_THEMES = new Set(["default", "forest", "dark", "neutral", "base"]);
+
+// --- Rendering engines ---
+
+async function renderWithMmdc(mmdcPath, inputFile, outputFile, opts) {
+  const puppeteerConfig = resolve(DEPS_DIR, "puppeteer-config.json");
+  const configFile = resolve(DEPS_DIR, ".mermaid-render-config.json");
+
+  // Build mermaid config — respect %%{init}%% directives in the input file
+  const inputContent = readFileSync(inputFile, "utf-8");
+  const hasInitDirective = inputContent.includes("%%{init");
+  let mermaidConfig = {};
+  if (!hasInitDirective) {
+    mermaidConfig.theme = opts.theme;
+  }
+  if (opts.config) {
+    try {
+      const userConfig = JSON.parse(opts.config);
+      mermaidConfig = { ...mermaidConfig, ...userConfig };
+    } catch (e) {
+      console.warn(`Warning: Could not parse --config JSON: ${e.message}`);
+    }
+  }
+
+  writeFileSync(configFile, JSON.stringify(mermaidConfig, null, 2));
+
+  let cmd = `${shellQuote(mmdcPath)} -i ${shellQuote(inputFile)} -o ${shellQuote(outputFile)}`;
+  cmd += ` -c ${shellQuote(configFile)}`;
+  cmd += ` -b ${shellQuote(opts.background)}`;
+
+  if (opts.format === "png") {
+    cmd += ` -w ${opts.width}`;
+    if (opts.height) cmd += ` -H ${opts.height}`;
+    cmd += ` -s 3`; // 3x scale for crisp PNGs
+  }
+
+  if (existsSync(puppeteerConfig)) {
+    cmd += ` -p ${shellQuote(puppeteerConfig)}`;
+  }
+
+  try {
+    execSync(cmd, { stdio: "pipe", timeout: 60000 });
+    return true;
+  } catch (e) {
+    const stderr = e.stderr?.toString() || "";
+    console.error(`mmdc failed: ${stderr.slice(0, 200)}`);
+    return false;
+  }
+}
+
+async function renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts) {
+  // Dynamic import of beautiful-mermaid
+  try {
+    const bm = await import(resolve(bmPath, "index.js")).catch(() =>
+      import(resolve(bmPath, "dist/index.js")).catch(() =>
+        import(resolve(bmPath, "src/index.js"))
+      )
+    );
+
+    const mmdContent = readFileSync(inputFile, "utf-8");
+    const renderFn = bm.renderMermaid || bm.render || bm.default?.renderMermaid || bm.default?.render;
+
+    if (!renderFn) {
+      // If no direct function, try renderMermaidSvg
+      const renderSvg = bm.renderMermaidSvg || bm.default?.renderMermaidSvg;
+      if (renderSvg) {
+        const svg = await renderSvg(mmdContent, { theme: opts.theme });
+        writeFileSync(outputFile, svg, "utf-8");
+        return true;
+      }
+      console.error("Could not find render function in beautiful-mermaid");
+      return false;
+    }
+
+    const result = await renderFn(mmdContent, {
+      theme: opts.theme,
+      format: opts.format === "png" ? "png" : "svg",
+    });
+
+    if (typeof result === "string") {
+      writeFileSync(outputFile, result, "utf-8");
+    } else if (Buffer.isBuffer(result)) {
+      writeFileSync(outputFile, result);
+    } else if (result?.svg) {
+      writeFileSync(outputFile, result.svg, "utf-8");
+    } else if (result?.data) {
+      writeFileSync(outputFile, result.data);
+    }
+
+    return true;
+  } catch (e) {
+    console.error(`beautiful-mermaid failed: ${e.message}`);
+    return false;
+  }
+}
+
+async function renderWithPuppeteer(inputFile, outputFile, opts) {
+  const puppeteerPath = isPuppeteerAvailable();
+  if (!puppeteerPath) {
+    console.error("Puppeteer not available for icon-enabled rendering. Run setup.sh first.");
+    return false;
+  }
+
+  try {
+    const { createRequire } = await import("module");
+    const require = createRequire(import.meta.url);
+    const puppeteer = require(puppeteerPath);
+    const mmdContent = readFileSync(inputFile, "utf-8");
+
+    // Build icon pack registration code
+    const iconRegistrations = opts.icons
+      .filter((name) => ICON_PACK_URLS[name])
+      .map(
+        (name) =>
+          `{ name: '${name}', loader: () => fetch('${ICON_PACK_URLS[name]}').then(r => r.json()) }`
+      )
+      .join(",\n      ");
+
+    // Build mermaid config
+    let mermaidConfig = {};
+    if (opts.config) {
+      try {
+        mermaidConfig = JSON.parse(opts.config);
+      } catch (e) {
+        console.warn(`Warning: Could not parse --config JSON: ${e.message}`);
+      }
+    }
+
+    const htmlContent = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { margin: 0; padding: 20px; background: ${opts.background}; font-family: 'trebuchet ms', 'verdana', 'arial', sans-serif; }
+    #container { display: inline-block; }
+    svg { max-width: none !important; }
+    .error { color: red; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: '${mermaidConfig.theme || opts.theme || "default"}',
+      ${mermaidConfig.themeVariables ? `themeVariables: ${JSON.stringify(mermaidConfig.themeVariables)},` : ""}
+      securityLevel: 'loose',
+      logLevel: 'error',
+    });
+
+    ${opts.icons.length > 0
+        ? `mermaid.registerIconPacks([
+      ${iconRegistrations}
+    ]);`
+        : ""
+      }
+
+    try {
+      // Small delay to ensure icon packs are loaded
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const { svg } = await mermaid.render('mermaid-diagram', ${JSON.stringify(mmdContent)});
+      document.getElementById('container').innerHTML = svg;
+      window.__mermaidRendered = true;
+      window.__mermaidSvg = svg;
+    } catch (e) {
+      document.getElementById('container').innerHTML = '<pre class="error">' + e.message + '</pre>';
+      window.__mermaidRendered = true;
+      window.__mermaidError = e.message;
+    }
+  </script>
+</body>
+</html>`;
+
+    // Write temp HTML
+    const tempHtml = resolve(DEPS_DIR, ".mermaid-icon-render.html");
+    mkdirSync(dirname(tempHtml), { recursive: true });
+    writeFileSync(tempHtml, htmlContent, "utf-8");
+
+    // Launch Puppeteer
+    const browser = await puppeteer.launch({
+      headless: "new",
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: opts.width || 1200, height: 800, deviceScaleFactor: 3 });
+    await page.goto(`file://${tempHtml}`, { waitUntil: "networkidle0", timeout: 30000 });
+
+    // Wait for render
+    await page.waitForFunction("window.__mermaidRendered === true", { timeout: 15000 });
+
+    // Check for errors
+    const error = await page.evaluate(() => window.__mermaidError);
+    if (error) {
+      console.error(`Mermaid render error: ${error}`);
+      await browser.close();
+      return false;
+    }
+
+    if (opts.format === "png") {
+      // Screenshot approach for PNG
+      await page.screenshot({ path: outputFile, type: "png", fullPage: true, omitBackground: opts.background === "transparent" });
+    } else {
+      // Extract SVG
+      const svg = await page.evaluate(() => window.__mermaidSvg);
+      if (svg) {
+        writeFileSync(outputFile, svg, "utf-8");
+      }
+    }
+
+    await browser.close();
+
+    // Clean up temp file
+    try {
+      const { unlinkSync } = await import("fs");
+      unlinkSync(tempHtml);
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return true;
+  } catch (e) {
+    console.error(`Puppeteer renderer failed: ${e.message}`);
+    return false;
+  }
+}
+
+// --- Read input ---
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+// --- Auto-detect if diagram needs icon packs ---
+
+function diagramNeedsIcons(content) {
+  // Check if the diagram uses external icon references
+  const iconPatterns = [
+    /logos:\w/,
+    /fa:\w/,
+    /fa6-\w+:\w/,
+    /mdi:\w/,
+    /simple-icons:\w/,
+    /aws:\w/,
+  ];
+  return iconPatterns.some((p) => p.test(content));
+}
+
+// --- Main ---
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Validate args
+  if (!opts.output) {
+    console.error("Error: --output is required");
+    process.exit(1);
+  }
+
+  // Determine format from output extension if not explicitly set
+  if (!process.argv.includes("--format") && !process.argv.includes("-f")) {
+    const ext = extname(opts.output).toLowerCase();
+    if (ext === ".png") opts.format = "png";
+    else if (ext === ".pdf") opts.format = "pdf";
+    else opts.format = "svg";
+  }
+
+  // Get input content
+  let inputFile;
+  if (opts.stdin) {
+    const content = await readFromStdin();
+    inputFile = resolve(DEPS_DIR, ".mermaid-stdin-temp.mmd");
+    mkdirSync(dirname(inputFile), { recursive: true });
+    writeFileSync(inputFile, content, "utf-8");
+  } else if (opts.input) {
+    inputFile = resolve(opts.input);
+    if (!existsSync(inputFile)) {
+      console.error(`Error: Input file not found: ${inputFile}`);
+      process.exit(1);
+    }
+  } else {
+    console.error("Error: --input or --stdin is required");
+    process.exit(1);
+  }
+
+  // Ensure output directory exists
+  mkdirSync(dirname(resolve(opts.output)), { recursive: true });
+  const outputFile = resolve(opts.output);
+
+  // Auto-detect icon needs
+  const mmdContent = readFileSync(inputFile, "utf-8");
+  const needsIcons = opts.icons.length > 0 || diagramNeedsIcons(mmdContent);
+
+  if (needsIcons && opts.icons.length === 0) {
+    // Auto-detect which icon packs are needed
+    if (/logos:\w/.test(mmdContent)) opts.icons.push("logos");
+    if (/fa:\w/.test(mmdContent) || /fa6-\w+:\w/.test(mmdContent)) opts.icons.push("fa");
+    if (/mdi:\w/.test(mmdContent)) opts.icons.push("mdi");
+    console.log(`Auto-detected icon packs needed: ${opts.icons.join(", ")}`);
+  }
+
+  // Detect engines
+  const mmdcPath = isMmdcAvailable();
+  const bmPath = isBeautifulMermaidAvailable();
+  const hasPuppeteer = isPuppeteerAvailable();
+
+  console.log(`Input:  ${inputFile}`);
+  console.log(`Output: ${outputFile}`);
+  console.log(`Format: ${opts.format}`);
+  console.log(`Theme:  ${opts.theme}`);
+  console.log(`Icons:  ${opts.icons.length > 0 ? opts.icons.join(", ") : "none"}`);
+  console.log(`Engines: mmdc=${mmdcPath ? "yes" : "no"}, beautiful-mermaid=${bmPath ? "yes" : "no"}, puppeteer=${hasPuppeteer ? "yes" : "no"}`);
+
+  let success = false;
+
+  // Determine engine order based on theme, format, and icons
+  const isBeautifulTheme = BEAUTIFUL_MERMAID_THEMES.has(opts.theme);
+  const needsPng = opts.format === "png" || opts.format === "pdf";
+
+  if (needsIcons) {
+    // Icon mode: Use Puppeteer-based renderer
+    console.log("Using Puppeteer renderer (icon packs required)...");
+    success = await renderWithPuppeteer(inputFile, outputFile, opts);
+    if (!success && mmdcPath) {
+      console.log("Falling back to mmdc (icons may not render)...");
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+    }
+  } else if (opts.engine === "mmdc") {
+    // Forced mmdc
+    if (mmdcPath) {
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: mmdc not available. Run setup.sh first.");
+    }
+  } else if (opts.engine === "beautiful-mermaid") {
+    // Forced beautiful-mermaid
+    if (bmPath) {
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: beautiful-mermaid not available. Run setup.sh first.");
+    }
+  } else if (opts.engine === "puppeteer") {
+    // Forced Puppeteer
+    success = await renderWithPuppeteer(inputFile, outputFile, opts);
+  } else {
+    // Auto selection
+    if (isBeautifulTheme && bmPath && !needsPng) {
+      // beautiful-mermaid theme requested, try it first
+      console.log("Using beautiful-mermaid (theme match)...");
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+      if (!success && mmdcPath) {
+        console.log("Falling back to mmdc...");
+        const fallbackOpts = { ...opts, theme: "default" };
+        success = await renderWithMmdc(mmdcPath, inputFile, outputFile, fallbackOpts);
+      }
+    } else if (mmdcPath) {
+      // Default: mmdc first (best compatibility)
+      console.log("Using mmdc (primary)...");
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+      if (!success && bmPath && !needsPng) {
+        console.log("Falling back to beautiful-mermaid...");
+        success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+      }
+    } else if (bmPath && !needsPng) {
+      // Only beautiful-mermaid available
+      console.log("Using beautiful-mermaid (only engine available)...");
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: No rendering engine available. Run setup.sh first.");
+      console.error(`  bash ${resolve(__dirname, "setup.sh")}`);
+      process.exit(1);
+    }
+  }
+
+  if (success && existsSync(outputFile)) {
+    const stats = readFileSync(outputFile);
+    console.log(`\n✓ Rendered successfully: ${outputFile} (${stats.length} bytes)`);
+  } else {
+    console.error("\n✗ Rendering failed.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(1);
+});

--- a/.claude/skills/mermaid-studio/scripts/setup.sh
+++ b/.claude/skills/mermaid-studio/scripts/setup.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# mermaid-studio/scripts/setup.sh
+# Auto-installs rendering dependencies. Run once per environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_DIR="${MERMAID_STUDIO_DIR:-$SKILL_DIR/.deps}"
+
+echo "=== Mermaid Studio — Dependency Setup ==="
+echo "Install directory: $INSTALL_DIR"
+
+# Ensure Node.js is available
+if ! command -v node &>/dev/null; then
+    echo "ERROR: Node.js is required but not found."
+    echo "Install Node.js 18+ from https://nodejs.org"
+    exit 1
+fi
+
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+    echo "WARNING: Node.js 18+ recommended. Found: $(node -v)"
+fi
+
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# Initialize package.json if missing
+if [ ! -f package.json ]; then
+    echo '{"name":"mermaid-studio-deps","version":"1.0.0","private":true,"type":"module"}' > package.json
+fi
+
+echo ""
+echo "--- Installing @mermaid-js/mermaid-cli (primary renderer) ---"
+npm install --save @mermaid-js/mermaid-cli 2>&1 | tail -3
+
+echo ""
+echo "--- Installing beautiful-mermaid (secondary renderer + ASCII) ---"
+npm install --save beautiful-mermaid 2>&1 | tail -3
+
+echo ""
+echo "--- Installing mermaid (for validation) ---"
+npm install --save mermaid 2>&1 | tail -3
+
+echo ""
+echo "--- Installing puppeteer (for icon-enabled rendering) ---"
+npm install --save puppeteer 2>&1 | tail -3
+
+# Create puppeteer config for headless rendering
+cat > "$INSTALL_DIR/puppeteer-config.json" << 'PCONF'
+{
+  "executablePath": "",
+  "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+  "headless": true
+}
+PCONF
+
+# Try to install Chromium for Puppeteer
+echo ""
+echo "--- Installing Chromium for Puppeteer ---"
+npx puppeteer browsers install chrome 2>&1 | tail -3 || {
+    echo "WARNING: Chromium install failed. mmdc may not work."
+    echo "  Fallback: beautiful-mermaid will be used for SVG rendering."
+    echo "  Or set PUPPETEER_EXECUTABLE_PATH to your Chrome/Chromium binary."
+}
+
+# Verify installations
+echo ""
+echo "=== Verification ==="
+
+if npx --prefix "$INSTALL_DIR" mmdc --version &>/dev/null 2>&1; then
+    echo "✓ mermaid-cli: $(npx --prefix "$INSTALL_DIR" mmdc --version 2>&1)"
+else
+    echo "✗ mermaid-cli: not working (beautiful-mermaid will be used as fallback)"
+fi
+
+if node -e "import('$INSTALL_DIR/node_modules/beautiful-mermaid/index.js').then(() => console.log('ok')).catch(() => console.log('fail'))" 2>/dev/null | grep -q ok; then
+    echo "✓ beautiful-mermaid: installed"
+else
+    # Try CommonJS require as fallback check
+    if node -e "try{require('$INSTALL_DIR/node_modules/beautiful-mermaid');console.log('ok')}catch(e){console.log('fail')}" 2>/dev/null | grep -q ok; then
+        echo "✓ beautiful-mermaid: installed"
+    else
+        echo "⚠ beautiful-mermaid: installed (module check inconclusive, may still work)"
+    fi
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Dependency directory: $INSTALL_DIR"
+echo ""
+echo "Usage:"
+echo "  node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output diagram.svg"
+echo "  node $SKILL_DIR/scripts/render-ascii.mjs --input diagram.mmd"
+echo "  node $SKILL_DIR/scripts/validate.mjs diagram.mmd"

--- a/.claude/skills/mermaid-studio/scripts/validate.mjs
+++ b/.claude/skills/mermaid-studio/scripts/validate.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/validate.mjs
+ *
+ * Validates Mermaid diagram syntax before rendering.
+ * Uses mermaid library's parser for accurate validation.
+ *
+ * Usage:
+ *   node validate.mjs <file.mmd>
+ *   node validate.mjs <file1.mmd> <file2.mmd>
+ *   echo "graph LR; A-->B" | node validate.mjs --stdin
+ *
+ * Exit codes:
+ *   0 = valid
+ *   1 = invalid syntax
+ *   2 = file not found or error
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { basename, dirname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+// Known diagram type keywords for basic pre-validation
+const DIAGRAM_TYPES = [
+  "flowchart",
+  "graph",
+  "sequenceDiagram",
+  "classDiagram",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "erDiagram",
+  "gantt",
+  "pie",
+  "mindmap",
+  "timeline",
+  "gitGraph",
+  "C4Context",
+  "C4Container",
+  "C4Component",
+  "C4Dynamic",
+  "C4Deployment",
+  "sankey-beta",
+  "xychart-beta",
+  "quadrantChart",
+  "block-beta",
+  "architecture-beta",
+  "packet-beta",
+  "kanban",
+  "journey",
+  "requirementDiagram",
+  "zenuml",
+];
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+function stripFrontmatter(content) {
+  // Remove YAML frontmatter (---...---)
+  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  if (match) return match[1].trim();
+  return content.trim();
+}
+
+function stripDirectives(content) {
+  // Remove %%{init: ...}%% directives
+  return content.replace(/%%\{[\s\S]*?\}%%/g, "").trim();
+}
+
+function stripComments(content) {
+  // Remove %% single-line comments
+  return content
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("%%"))
+    .join("\n")
+    .trim();
+}
+
+function detectDiagramType(content) {
+  const cleaned = stripFrontmatter(stripDirectives(stripComments(content)));
+  const firstLine = cleaned.split("\n")[0].trim();
+
+  for (const type of DIAGRAM_TYPES) {
+    if (firstLine.startsWith(type)) {
+      return type;
+    }
+  }
+  return null;
+}
+
+function basicValidation(content, filename) {
+  const errors = [];
+  const warnings = [];
+
+  // Empty check
+  if (!content.trim()) {
+    errors.push("File is empty");
+    return { errors, warnings };
+  }
+
+  // Detect diagram type
+  const cleaned = stripFrontmatter(stripDirectives(content));
+  const diagramType = detectDiagramType(content);
+  if (!diagramType) {
+    const firstLine = stripComments(stripFrontmatter(stripDirectives(content)))
+      .split("\n")[0]
+      .trim();
+    errors.push(
+      `Unknown diagram type. First content line: "${firstLine.slice(0, 50)}". ` +
+      `Expected one of: flowchart, graph, sequenceDiagram, classDiagram, etc.`
+    );
+  }
+
+  // Bracket matching
+  const lines = cleaned.split("\n");
+  let braces = 0;
+  let brackets = 0;
+  let parens = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip comments
+    if (line.trim().startsWith("%%")) continue;
+
+    for (const char of line) {
+      if (char === "{") braces++;
+      if (char === "}") braces--;
+      if (char === "[") brackets++;
+      if (char === "]") brackets--;
+      if (char === "(") parens++;
+      if (char === ")") parens--;
+
+      if (braces < 0)
+        errors.push(`Unmatched '}' at line ${i + 1}`);
+      if (brackets < 0)
+        errors.push(`Unmatched ']' at line ${i + 1}`);
+      if (parens < 0)
+        errors.push(`Unmatched ')' at line ${i + 1}`);
+    }
+  }
+
+  if (braces > 0) errors.push(`Unclosed '{' — missing ${braces} closing brace(s)`);
+  if (brackets > 0) errors.push(`Unclosed '[' — missing ${brackets} closing bracket(s)`);
+  if (parens > 0) errors.push(`Unclosed '(' — missing ${parens} closing paren(s)`);
+
+  // Common reserved words used as bare node IDs
+  const reservedWords = [
+    "end",
+    "graph",
+    "subgraph",
+    "style",
+    "class",
+    "click",
+    "linkStyle",
+    "default",
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("%%")) continue;
+
+    for (const word of reservedWords) {
+      // Check if reserved word is used as a bare node ID (without brackets)
+      const pattern = new RegExp(
+        `(?:^|-->|---|-\\.->|==>|\\s)${word}(?:\\s|-->|---|-\\.->|==>|$)`,
+        "i"
+      );
+      if (pattern.test(trimmed) && !trimmed.includes(`${word}[`) && !trimmed.includes(`${word}(`)) {
+        warnings.push(
+          `Line ${i + 1}: "${word}" is a reserved keyword. Use "${word}Node" or "${word}State" instead.`
+        );
+      }
+    }
+  }
+
+  // Check for common syntax mistakes
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("%%")) continue;
+
+    // Unescaped special characters in labels
+    if (trimmed.includes('[') && trimmed.includes(']')) {
+      const labelMatch = trimmed.match(/\[([^\]]*)\]/g);
+      if (labelMatch) {
+        for (const label of labelMatch) {
+          if (label.includes('"') && !label.startsWith('["')) {
+            warnings.push(
+              `Line ${i + 1}: Unquoted label with double quotes. Wrap in ["..."]: ${label.slice(0, 30)}`
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Node count warning
+  const nodePattern = /\b\w+[\[({]/g;
+  const nodeMatches = cleaned.match(nodePattern) || [];
+  if (nodeMatches.length > 25) {
+    warnings.push(
+      `High node count (~${nodeMatches.length}). Consider splitting into multiple diagrams for readability.`
+    );
+  }
+
+  return { errors, warnings };
+}
+
+async function mermaidParserValidation(content) {
+  // Try to use the mermaid library parser for deep validation
+  try {
+    const mermaidPath = resolve(DEPS_DIR, "node_modules/mermaid");
+    if (!existsSync(mermaidPath)) {
+      return { available: false };
+    }
+
+    const mermaid = await import(resolve(mermaidPath, "dist/mermaid.js")).catch(
+      () => import(resolve(mermaidPath, "dist/mermaid.esm.mjs")).catch(
+        () => null
+      )
+    );
+
+    if (!mermaid) return { available: false };
+
+    const m = mermaid.default || mermaid;
+    if (m.parse) {
+      await m.parse(stripFrontmatter(stripDirectives(content)));
+      return { available: true, valid: true };
+    }
+
+    return { available: false };
+  } catch (e) {
+    return {
+      available: true,
+      valid: false,
+      error: e.message || String(e),
+    };
+  }
+}
+
+function printResult(filename, basicResult, parserResult) {
+  const hasErrors = basicResult.errors.length > 0 || (parserResult?.available && !parserResult?.valid);
+  const hasWarnings = basicResult.warnings.length > 0;
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`File: ${filename}`);
+  console.log(`${"=".repeat(60)}`);
+
+  if (basicResult.errors.length > 0) {
+    console.log("\n❌ ERRORS:");
+    for (const err of basicResult.errors) {
+      console.log(`  • ${err}`);
+    }
+  }
+
+  if (parserResult?.available && !parserResult?.valid) {
+    console.log("\n❌ PARSER ERROR:");
+    console.log(`  • ${parserResult.error}`);
+  }
+
+  if (hasWarnings) {
+    console.log("\n⚠️  WARNINGS:");
+    for (const warn of basicResult.warnings) {
+      console.log(`  • ${warn}`);
+    }
+  }
+
+  if (!hasErrors) {
+    const diagramType = detectDiagramType(
+      readFileSync ? "" : ""
+    );
+    console.log(`\n✅ Valid${parserResult?.available ? " (parser verified)" : " (basic checks only)"}`);
+    if (hasWarnings) {
+      console.log("   (warnings above are non-blocking suggestions)");
+    }
+  }
+
+  return !hasErrors;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Mermaid Studio — Syntax Validator
+
+Usage:
+  node validate.mjs <file.mmd> [<file2.mmd> ...]
+  echo "graph LR; A-->B" | node validate.mjs --stdin
+
+Exit codes:
+  0 = all files valid
+  1 = syntax errors found
+  2 = file not found or runtime error
+`);
+    process.exit(0);
+  }
+
+  let allValid = true;
+
+  if (args.includes("--stdin")) {
+    const content = await readFromStdin();
+    const basicResult = basicValidation(content, "stdin");
+    const parserResult = await mermaidParserValidation(content);
+    if (!printResult("stdin", basicResult, parserResult)) {
+      allValid = false;
+    }
+  } else {
+    for (const arg of args) {
+      if (arg.startsWith("--")) continue;
+
+      const filepath = resolve(arg);
+      if (!existsSync(filepath)) {
+        console.error(`Error: File not found: ${filepath}`);
+        allValid = false;
+        continue;
+      }
+
+      const content = readFileSync(filepath, "utf-8");
+      const basicResult = basicValidation(content, filepath);
+      const parserResult = await mermaidParserValidation(content);
+      if (!printResult(basename(filepath), basicResult, parserResult)) {
+        allValid = false;
+      }
+    }
+  }
+
+  process.exit(allValid ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(2);
+});

--- a/.claude/skills/tlc-spec-driven/.skill-meta.json
+++ b/.claude/skills/tlc-spec-driven/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "69867b0e19be1fb556d2e697f0f18f1de0363d1aa2de9d36754d5b107156357c",
+  "downloadedAt": 1776159111004
+}

--- a/.claude/skills/tlc-spec-driven/README.md
+++ b/.claude/skills/tlc-spec-driven/README.md
@@ -1,0 +1,449 @@
+<p align="center">
+  <img src="https://img.shields.io/badge/Skill-TLC%20Spec--Driven-blue?style=for-the-badge" alt="skill badge" />
+  <img src="https://img.shields.io/badge/Stack-Agnostic-green?style=for-the-badge" alt="stack agnostic" />
+  <img src="https://img.shields.io/badge/Version-2.0.0-purple?style=for-the-badge" alt="version" />
+</p>
+
+<h1 align="center">🎯 TLC Spec-Driven</h1>
+
+<p align="center">
+  <strong>Plan and implement projects with precision. Granular tasks. Clear dependencies. Right tools. Zero ceremony.</strong>
+</p>
+
+<p align="center">
+  <em>From the <a href="https://github.com/tech-leads-club">Tech Lead's Club</a> community</em>
+</p>
+
+<p align="center">
+  <strong>Author:</strong> <a href="https://github.com/felipfr">Felipe Rodrigues</a> · 
+  <a href="https://linkedin.com/in/felipfr">LinkedIn</a>
+</p>
+
+## ✨ What Is This Skill?
+
+**TLC Spec-Driven** transforms how AI agents approach software projects. Instead of a rigid, bureaucratic pipeline, it uses **4 adaptive phases** that auto-size based on complexity — applying full rigor for complex features and skipping ceremony for simple ones:
+
+```
+┌──────────┐   ┌──────────┐   ┌─────────┐   ┌─────────┐
+│ SPECIFY  │ → │  DESIGN  │ → │  TASKS  │ → │ EXECUTE │
+└──────────┘   └──────────┘   └─────────┘   └─────────┘
+   required      optional*      optional*     required
+
+* Agent auto-skips when scope doesn't need it
+```
+
+**The complexity is in the system, not in your workflow.** You talk naturally — the skill decides how deep to go:
+
+| Scope                               | What happens                                                      |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| **Small** (≤3 files)                | Quick mode — describe → implement → verify → commit               |
+| **Medium** (clear feature)          | Specify → Execute (design and tasks inline)                       |
+| **Large** (multi-component)         | Full pipeline with formal design and task breakdown               |
+| **Complex** (ambiguity, new domain) | Full pipeline + gray area discussion + research + interactive UAT |
+
+## 🚀 Quick Start
+
+### Installation
+
+```bash
+npx @tech-leads-club/agent-skills install -s tlc-spec-driven
+```
+
+### First Commands
+
+| What You Want           | Say This                                      |
+| ----------------------- | --------------------------------------------- |
+| Start a new project     | `"Initialize project"` or `"Setup project"`   |
+| Work with existing code | `"Map codebase"` or `"Analyze existing code"` |
+| Plan a feature          | `"Specify feature [name]"`                    |
+| Quick bug fix           | `"Quick fix: [description]"`                  |
+| Resume previous work    | `"Resume work"` or `"Continue"`               |
+
+> 💬 **Natural Conversation, Not Commands**
+>
+> These are trigger phrases, not strict commands. The skill works through **natural conversation** — talk to your agent like you would to a colleague. Say things like _"I want to build an authentication system"_ or _"Fix the login button, it returns 401"_. The agent understands context and intent, not just keywords.
+
+## 📁 Project Structure
+
+The skill creates a `.specs/` directory to organize all project documentation:
+
+```
+.specs/
+├── project/
+│   ├── PROJECT.md      # Vision, goals, tech stack, constraints
+│   ├── ROADMAP.md      # Milestones, features, status tracking
+│   └── STATE.md        # Persistent memory: decisions, blockers, learnings, todos, deferred ideas
+│
+├── codebase/           # Brownfield analysis (existing projects only)
+│   ├── STACK.md        # Technology stack and dependencies
+│   ├── ARCHITECTURE.md # Patterns, data flow, code organization
+│   ├── CONVENTIONS.md  # Naming, style, coding patterns
+│   ├── STRUCTURE.md    # Directory layout and modules
+│   ├── TESTING.md      # Test frameworks and patterns
+│   ├── INTEGRATIONS.md # External services and APIs
+│   └── CONCERNS.md     # Tech debt, risks, fragile areas
+│
+├── features/           # Feature specifications
+│   └── [feature-name]/
+│       ├── spec.md     # Requirements with traceable IDs (FEAT-01, AUTH-02...)
+│       ├── context.md  # User decisions for gray areas (only when needed)
+│       ├── design.md   # Architecture and components (only for large/complex)
+│       └── tasks.md    # Atomic tasks with dependencies (only for large/complex)
+│
+└── quick/              # Ad-hoc tasks (quick mode)
+    └── NNN-slug/
+        ├── TASK.md     # Description + verification
+        └── SUMMARY.md  # What was done + commit
+```
+
+## 🔄 The Four Adaptive Phases
+
+### Specify (always)
+
+**Goal:** Capture WHAT to build with testable, traceable requirements.
+
+The agent acts as a thinking partner — not an interviewer. It asks clarifying questions, challenges vagueness, and captures requirements with traceable IDs:
+
+```markdown
+### P1: User Login ⭐ MVP
+
+**User Story:** As a user, I want to log in so that I can access my account.
+
+| Requirement ID | Acceptance Criteria                                                            |
+| -------------- | ------------------------------------------------------------------------------ |
+| AUTH-01        | WHEN user enters valid credentials THEN system SHALL authenticate and redirect |
+| AUTH-02        | WHEN user enters invalid credentials THEN system SHALL display error message   |
+| AUTH-03        | WHEN user is already logged in THEN system SHALL redirect to dashboard         |
+```
+
+**Discuss gray areas (auto-triggered):** When the spec has ambiguous, user-facing decisions (layout preferences, interaction patterns, error handling style), the agent automatically asks the user about them — creating a `context.md` that locks those decisions before design. This is NOT a separate phase — it only happens within Specify when ambiguity is detected.
+
+### Design (when needed)
+
+**Goal:** Define HOW to build it. Architecture, components, what to reuse.
+
+**Skipped when:** The change is straightforward — no architectural decisions, no new patterns. For simple features, design happens inline during Execute.
+
+**Includes research:** Before designing with unfamiliar tech, the agent follows the **Knowledge Verification Chain** (codebase → project docs → Context7 MCP → web search → flag uncertain). It **never assumes or fabricates** — if it can't find documentation, it says so.
+
+**Output:** `design.md` with architecture diagrams, component definitions, and integration points.
+
+### Tasks (when needed)
+
+**Goal:** Break into GRANULAR, ATOMIC tasks with clear dependencies.
+
+**Skipped when:** There are ≤3 obvious steps. In that case, tasks are listed inline at the start of Execute.
+
+**Safety valve:** If listing inline steps reveals >5 steps or complex dependencies, the agent STOPS and creates a formal `tasks.md` — acknowledging that the Tasks phase was wrongly skipped.
+
+| ❌ Vague Task | ✅ Atomic Tasks                   |
+| ------------- | --------------------------------- |
+| "Create form" | T1: Create email input component  |
+|               | T2: Add email validation function |
+|               | T3: Create submit button          |
+|               | T4: Add form state management     |
+
+Each task includes: What (deliverable), Where (file path), Depends on (prerequisites), Reuses (existing code), Requirement (traceable ID), Done when (verifiable criteria), Commit (message format).
+
+### Execute (always)
+
+**Goal:** Implement one task at a time. Verify. Commit. Repeat.
+
+Every task follows the same cycle:
+
+```
+Plan → Implement → Verify → Commit → Next
+```
+
+**Key principles:**
+
+- **Surgical changes** — Only touch required files
+- **No scope creep** — If it's not in the task, don't touch it. Capture ideas in STATE.md as Deferred Ideas
+- **Verify before commit** — Check all "Done when" criteria
+- **Atomic git commits** — One task = one commit, following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+
+```
+feat(auth): add email validation to login form
+
+refactor(api): extract token refresh logic into service
+
+fix(cart): prevent negative quantity on item decrement
+```
+
+**Feature-level validation** happens after all tasks complete — including acceptance criteria checks, code quality review, and optionally interactive UAT for complex user-facing features.
+
+## ⚡ Quick Mode
+
+For small tasks (bug fixes, config changes, tweaks ≤3 files) that don't need the full pipeline:
+
+```
+You: Quick fix: login button returns 401 because token refresh skips expired check
+
+Agent: Quick Task: Fix token refresh expired check
+       Files: src/services/auth.ts
+       Approach: Add expiry validation before refresh attempt
+       Verify: Login with expired token returns new session, not 401
+
+       [Implements...]
+
+       ✅ Done. Committed: fix(auth): add expiry check to token refresh
+```
+
+**Guardrails:** Max 3 files, max 1 hour, no design decisions, no new dependencies. If any of these are exceeded, the agent recommends the full pipeline.
+
+## 📋 Complete Command Reference
+
+These trigger patterns help the agent recognize your intent, but you don't need to use them verbatim. Speak naturally — the agent understands variations and context.
+
+### Project-Level
+
+| Trigger Pattern                              | Description                                           |
+| -------------------------------------------- | ----------------------------------------------------- |
+| `Initialize project`, `Setup project`        | Create PROJECT.md with vision, goals, and constraints |
+| `Create roadmap`, `Plan features`            | Create ROADMAP.md with milestones and features        |
+| `Map codebase`, `Analyze existing code`      | Create 7 brownfield docs for existing projects        |
+| `Document concerns`, `Find tech debt`        | Identify and document codebase risks                  |
+| `Record decision`, `Log blocker`, `Add todo` | Add entries to STATE.md                               |
+| `Pause work`, `End session`                  | Create handoff for session continuity                 |
+| `Resume work`, `Continue`                    | Load previous state and continue                      |
+
+### Feature-Level (auto-sized)
+
+| Trigger Pattern                           | Description                             |
+| ----------------------------------------- | --------------------------------------- |
+| `Specify feature`, `Define requirements`  | Create spec.md with requirement IDs     |
+| `Discuss feature`, `How should this work` | Capture user decisions for gray areas   |
+| `Design feature`, `Architecture`          | Create design.md with architecture      |
+| `Break into tasks`, `Create tasks`        | Create tasks.md with atomic breakdown   |
+| `Implement task`, `Build`, `Execute`      | Execute specific task with verification |
+| `Validate`, `Verify work`, `UAT`          | Feature-level validation and testing    |
+| `Quick fix`, `Quick task`, `Bug fix`      | Express lane for small changes          |
+
+## 🔁 Workflow Examples
+
+### Starting a New Project
+
+```
+You: Initialize project
+
+Agent: I'll help you set up your project. Let me ask a few questions:
+       1. What are you building?
+       2. Who is it for and what problem does it solve?
+       ...
+
+You: [Answer questions]
+
+Agent: ✅ Created .specs/project/PROJECT.md
+       Next: Would you like to create a roadmap? Say "Create roadmap"
+```
+
+### Working with an Existing Codebase
+
+```
+You: Map codebase
+
+Agent: I'll analyze your existing codebase and document:
+       - Technology stack, Architecture patterns, Coding conventions
+       - Project structure, Testing infrastructure, External integrations
+       - Concerns (tech debt, risks, fragile areas)
+
+       [Analyzes codebase...]
+
+       ✅ Created 7 brownfield docs in .specs/codebase/
+       Next: Initialize project to define goals and roadmap
+```
+
+### Implementing a Feature (auto-sized)
+
+```
+You: Specify feature user-authentication
+
+Agent: [Asks clarifying questions, creates spec.md with requirement IDs]
+       I notice some gray areas in the UX — how should failed login attempts behave?
+       [Discusses gray areas, creates context.md]
+
+You: Design the feature
+
+Agent: [Researches JWT best practices via Context7, creates design.md]
+
+You: Break into tasks
+
+Agent: [Creates tasks.md with 8 atomic tasks + parallel execution plan]
+
+You: Implement T1
+
+Agent: Implementing T1: Create auth service interface
+       Files: src/services/auth.interface.ts
+       Approach: Define interface based on design
+       Verify: Interface compiles, exports correctly
+
+       [Implements...]
+
+       ✅ Committed: feat(auth): create auth service interface
+       Next available: T2, T3 [P] (parallel)
+```
+
+### Quick Bug Fix
+
+```
+You: Quick fix: dark mode toggle doesn't persist after page refresh
+
+Agent: Quick Task: Persist dark mode preference
+       Files: src/hooks/useTheme.ts, src/utils/storage.ts
+       Approach: Save preference to localStorage on toggle
+       Verify: Toggle dark mode, refresh page, preference persists
+
+       [Implements...]
+
+       ✅ Committed: fix(theme): persist dark mode preference to localStorage
+```
+
+### Session Continuity
+
+```
+You: Pause work
+
+Agent: ✅ Created .specs/HANDOFF.md
+       - Feature: user-authentication
+       - Completed: T1, T2 (committed)
+       - In progress: T3 (70%)
+       - Next session: Continue T3, then T4
+
+--- Later, new session ---
+
+You: Resume work
+
+Agent: Resuming user-authentication at T3
+       - Completed: T1 (auth interface), T2 (token storage)
+       - In progress: T3 - auth service at src/services/auth.service.ts:45
+       - Next: Complete T3, then T4 (parallel with T5)
+
+       Continue with T3?
+```
+
+## 🧠 Context Management
+
+The skill is designed to work within context limits:
+
+| Load Strategy          | Documents                                   | Tokens |
+| ---------------------- | ------------------------------------------- | ------ |
+| **Base load** (always) | PROJECT.md, ROADMAP.md, STATE.md            | ~15k   |
+| **On-demand**          | Current spec, context, design, or tasks     | +5-10k |
+| **Never simultaneous** | Multiple feature specs or architecture docs | —      |
+
+**Target:** <40k tokens loaded (20% of context)
+**Reserve:** 160k+ tokens for work, reasoning, outputs
+
+When context exceeds 40k tokens, the skill displays a status indicator and suggests optimizations.
+
+## 🔗 Skill Integrations
+
+TLC Spec-Driven works even better when combined with complementary skills:
+
+| Skill              | Integration                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
+| **mermaid-studio** | Diagrams — architecture overviews, data flows, sequence diagrams                  |
+| **codenavi**       | Code exploration — brownfield mapping, pattern identification, dependency tracing |
+
+The skill automatically detects if these are installed and delegates specialized tasks to them. If not installed, it falls back gracefully and recommends them once per session.
+
+## 📚 Reference Files
+
+The skill includes detailed reference documentation loaded on-demand:
+
+| File                    | Purpose                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `project-init.md`       | Project initialization process and template                            |
+| `roadmap.md`            | Roadmap creation and milestone tracking                                |
+| `brownfield-mapping.md` | Comprehensive codebase analysis (7 docs)                               |
+| `concerns.md`           | Tech debt, risks, and fragile area documentation                       |
+| `specify.md`            | Requirements gathering with traceable IDs                              |
+| `discuss.md`            | Gray area discussion and context capture                               |
+| `design.md`             | Architecture, research, and component design                           |
+| `tasks.md`              | Granular task breakdown methodology                                    |
+| `implement.md`          | Execute: implementation + verification + atomic commits                |
+| `validate.md`           | Feature validation and interactive UAT                                 |
+| `quick-mode.md`         | Express lane for ad-hoc tasks                                          |
+| `session-handoff.md`    | Pause/resume work process                                              |
+| `state-management.md`   | Persistent memory: decisions, blockers, lessons, todos, deferred ideas |
+| `coding-principles.md`  | Behavioral guidelines for implementation                               |
+| `context-limits.md`     | Token budget and monitoring                                            |
+| `code-analysis.md`      | Available tools and fallbacks                                          |
+
+## ⚡ Tips for Best Results
+
+### Do's ✅
+
+- **Start with project initialization** — Even for existing codebases
+- **Be specific about scope** — Clear boundaries prevent creep
+- **Trust the auto-sizing** — The agent applies the right depth
+- **Use natural language** — No need to memorize commands
+- **Say "pause work" before ending** — Enables seamless resumption
+- **Challenge the agent** — If something looks wrong, say so
+
+### Don'ts ❌
+
+- **Don't force all phases** — Let the agent skip what's unnecessary
+- **Don't work on multiple features at once** — One feature per cycle
+- **Don't ignore verification** — Even quick tasks need a verify step
+- **Don't accept vague answers** — If the agent says something fuzzy, ask for specifics
+
+## 💡 Model Recommendation
+
+> **Best results with modern, reasoning-capable models:**
+>
+> - **Claude Opus 4.6 / Sonnet 4.5** — Excellent for all phases
+> - **Gemini 3 Pro / GPT 5.2** — Strong reasoning and large context window
+> - **Gemini 3 Flash / Claude Haiku 4.5** — Great general-purpose performance
+>
+> For cost optimization, the skill will suggest when lighter models are sufficient for simple tasks like validation or session handoff.
+
+## 🤖 Compatibility
+
+This skill works with **any AI coding agent** that supports skills or custom instructions.
+
+**Tested and verified on:**
+
+| Agent                | Status    |
+| -------------------- | --------- |
+| Antigravity (Gemini) | ✅ Tested |
+| Claude Code          | ✅ Tested |
+| GitHub Copilot       | ✅ Tested |
+| Cursor               | ✅ Tested |
+| Opencode             | ✅ Tested |
+
+> **Note:** If your agent supports loading custom instructions or skills, this skill should work. The agents above are simply where it has been actively tested.
+
+## ❓ FAQ
+
+**Q: Can I skip phases?**
+A: Yes! The skill auto-sizes. Design and Tasks are skipped for simple features. Quick mode skips the entire pipeline for small changes. You only get ceremony when scope demands it.
+
+**Q: What if my project already has code?**
+A: Use `"Map codebase"` first. This creates 7 documents analyzing your existing architecture, conventions, stack, and concerns before you start adding features.
+
+**Q: How does requirement traceability work?**
+A: Each requirement gets a unique ID (e.g., `AUTH-01`) in spec.md. Tasks reference these IDs, and validation checks which requirements are verified. You get a clear trail from spec → design → task → commit.
+
+**Q: What are atomic git commits?**
+A: Each task produces exactly one commit following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). This means clean git history, easy bisect for debugging, and simple rollbacks when needed.
+
+**Q: Can I use this for small tasks or quick fixes?**
+A: Yes! Say `"Quick fix: [description]"` for bug fixes, config changes, or small tweaks. You get quality guardrails (verify + commit) without the planning overhead.
+
+**Q: What happens if I close my session mid-task?**
+A: Say `"Pause work"` before ending your session. This creates a handoff document. Next session, say `"Resume work"` to continue exactly where you left off.
+
+**Q: Does this work with any tech stack?**
+A: Yes! The skill is completely stack-agnostic. It works with any language, framework, or architecture.
+
+**Q: What if the agent invents an API or pattern that doesn't exist?**
+A: The skill enforces a strict **Knowledge Verification Chain**: codebase → project docs → Context7 MCP → web search → flag as uncertain. It NEVER fabricates information. If the agent can't find documentation, it will say "I don't know" instead of guessing.
+
+## 📄 License
+
+CC-BY-4.0 © [Tech Lead's Club](https://github.com/tech-leads-club)
+
+<p align="center">
+  <sub>Built with ❤️ by the Tech Lead's Club community</sub>
+</p>

--- a/.claude/skills/tlc-spec-driven/SKILL.md
+++ b/.claude/skills/tlc-spec-driven/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: tlc-spec-driven
+description: Project and feature planning with 4 adaptive phases - Specify, Design, Tasks, Execute. Auto-sizes depth by complexity. Creates atomic tasks with verification criteria, atomic git commits, requirement traceability, and persistent memory across sessions. Stack-agnostic. Use when (1) Starting new projects (initialize vision, goals, roadmap), (2) Working with existing codebases (map stack, architecture, conventions), (3) Planning features (requirements, design, task breakdown), (4) Implementing with verification and atomic commits, (5) Quick ad-hoc tasks (bug fixes, config changes), (6) Tracking decisions/blockers/deferred ideas across sessions, (7) Pausing/resuming work. Triggers on "initialize project", "map codebase", "specify feature", "discuss feature", "design", "tasks", "implement", "validate", "verify work", "UAT", "quick fix", "quick task", "pause work", "resume work". Do NOT use for architecture decomposition analysis (use architecture skills) or technical design docs (use create-technical-design-doc).
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: 2.0.0
+---
+
+# Tech Lead's Club - Spec-Driven Development
+
+Plan and implement projects with precision. Granular tasks. Clear dependencies. Right tools. Zero ceremony.
+
+```
+┌──────────┐   ┌──────────┐   ┌─────────┐   ┌─────────┐
+│ SPECIFY  │ → │  DESIGN  │ → │  TASKS  │ → │ EXECUTE │
+└──────────┘   └──────────┘   └─────────┘   └─────────┘
+   required      optional*      optional*     required
+
+* Agent auto-skips when scope doesn't need it
+```
+
+## Auto-Sizing: The Core Principle
+
+**The complexity determines the depth, not a fixed pipeline.** Before starting any feature, assess its scope and apply only what's needed:
+
+| Scope       | What                     | Specify                                                 | Design                                          | Tasks                         | Execute                                               |
+| ----------- | ------------------------ | ------------------------------------------------------- | ----------------------------------------------- | ----------------------------- | ----------------------------------------------------- |
+| **Small**   | ≤3 files, one sentence   | **Quick mode** — skip pipeline entirely                 | -                                               | -                             | -                                                     |
+| **Medium**  | Clear feature, <10 tasks | Spec (brief)                                            | Skip — design inline                            | Skip — tasks implicit         | Implement + verify                                    |
+| **Large**   | Multi-component feature  | Full spec + requirement IDs                             | Architecture + components                       | Full breakdown + dependencies | Implement + verify per task                           |
+| **Complex** | Ambiguity, new domain    | Full spec + [discuss gray areas](references/discuss.md) | [Research](references/design.md) + architecture | Breakdown + parallel plan     | Implement + [interactive UAT](references/validate.md) |
+
+**Rules:**
+
+- **Specify and Execute are always required** — you always need to know WHAT and DO it
+- **Design is skipped** when the change is straightforward (no architectural decisions, no new patterns)
+- **Tasks is skipped** when there are ≤3 obvious steps (they become implicit in Execute)
+- **Discuss is triggered within Specify** only when the agent detects ambiguous gray areas that need user input
+- **Interactive UAT is triggered within Execute** only for user-facing features with complex behavior
+- **Quick mode** is the express lane — for bug fixes, config changes, and small tweaks
+
+**Safety valve:** Even when Tasks is skipped, Execute ALWAYS starts by listing atomic steps inline (see [implement.md](references/implement.md)). If that listing reveals >5 steps or complex dependencies, STOP and create a formal `tasks.md` — the Tasks phase was wrongly skipped.
+
+## Project Structure
+
+```
+.specs/
+├── project/
+│   ├── PROJECT.md      # Vision & goals
+│   ├── ROADMAP.md      # Features & milestones
+│   └── STATE.md        # Memory: decisions, blockers, lessons, todos, deferred ideas
+├── codebase/           # Brownfield analysis (existing projects)
+│   ├── STACK.md
+│   ├── ARCHITECTURE.md
+│   ├── CONVENTIONS.md
+│   ├── STRUCTURE.md
+│   ├── TESTING.md
+│   ├── INTEGRATIONS.md
+│   └── CONCERNS.md
+├── features/           # Feature specifications
+│   └── [feature]/
+│       ├── spec.md     # Requirements with traceable IDs
+│       ├── context.md  # User decisions for gray areas (only when discuss is triggered)
+│       ├── design.md   # Architecture & components (only for Large/Complex)
+│       └── tasks.md    # Atomic tasks with verification (only for Large/Complex)
+└── quick/              # Ad-hoc tasks (quick mode)
+    └── NNN-slug/
+        ├── TASK.md
+        └── SUMMARY.md
+```
+
+## Workflow
+
+**New project:**
+
+1. Initialize project → PROJECT.md + ROADMAP.md
+2. For each feature → Specify → (Design) → (Tasks) → Execute (depth auto-sized)
+
+**Existing codebase:**
+
+1. Map codebase → 7 brownfield docs
+2. Initialize project → PROJECT.md + ROADMAP.md
+3. For each feature → same adaptive workflow
+
+**Quick mode:** Describe → Implement → Verify → Commit (for ≤3 files, one-sentence scope)
+
+## Context Loading Strategy
+
+**Base load (~15k tokens):**
+
+- PROJECT.md (if exists)
+- ROADMAP.md (when planning/working on features)
+- STATE.md (persistent memory)
+
+**On-demand load:**
+
+- Codebase docs (when working in existing project)
+- CONCERNS.md (when planning features that touch flagged areas, estimating risk, or modifying fragile components)
+- TESTING.md (when creating tasks or executing — drives test type assignment and gate checks)
+- spec.md (when working on specific feature)
+- context.md (when designing or implementing from user decisions)
+- design.md (when implementing from design)
+- tasks.md (when executing tasks)
+
+**Never load simultaneously:**
+
+- Multiple feature specs
+- Multiple architecture docs
+- Archived documents
+
+**Target:** <40k tokens total context
+**Reserve:** 160k+ tokens for work, reasoning, outputs
+**Monitoring:** Display status when >40k (see [context-limits.md](references/context-limits.md))
+
+## Sub-Agent Delegation
+
+Use sub-agents (the Task tool or equivalent) to keep the main context window lean and enable
+parallel execution. The orchestrating agent plans and coordinates; sub-agents do the heavy lifting.
+
+**When to delegate to a sub-agent:**
+
+| Activity | Delegate? | Why |
+|---|---|---|
+| Research (design phase, brownfield mapping) | Yes | Research output is large; only the summary matters to the main context |
+| Implementing a task | Yes | File reads, edits, test output consume context; only the result matters |
+| Parallel `[P]` tasks | Yes (one per task) | The only way to actually run tasks in parallel |
+| Sequential tasks with no `[P]` | Yes | Keeps implementation artifacts out of the main context |
+| Planning, task creation, validation reports | No | These require the full accumulated context to be coherent |
+| Quick mode tasks | No | Too small to justify the overhead |
+
+**Context each sub-agent receives:**
+
+The orchestrating agent MUST provide each sub-agent with:
+- The specific task definition from tasks.md (What, Where, Depends on, Reuses, Done when, Tests, Gate)
+- Relevant coding principles and conventions (coding-principles.md, CONVENTIONS.md)
+- TESTING.md, if it exists (for gate check commands and test patterns)
+- Any spec/design context the task references
+
+The sub-agent does NOT receive: other tasks' definitions, accumulated chat history, validation reports
+from other tasks, or STATE.md (unless the task explicitly references a decision/blocker).
+
+**What sub-agents return:**
+
+Each sub-agent reports back:
+- Status: Complete | Blocked | Partial
+- Files changed: [list]
+- Gate check result: [pass/fail + test counts]
+- SPEC_DEVIATION markers (if any)
+- Issues encountered (if any)
+
+The orchestrating agent uses this to update tasks.md status, traceability, and decide next steps.
+
+## Commands
+
+**Project-level:**
+| Trigger Pattern | Reference |
+|----------------|-----------|
+| Initialize project, setup project | [project-init.md](references/project-init.md) |
+| Create roadmap, plan features | [roadmap.md](references/roadmap.md) |
+| Map codebase, analyze existing code | [brownfield-mapping.md](references/brownfield-mapping.md) |
+| Document concerns, find tech debt, what's risky | [concerns.md](references/concerns.md) |
+| Record decision, log blocker, add todo | [state-management.md](references/state-management.md) |
+| Pause work, end session | [session-handoff.md](references/session-handoff.md) |
+| Resume work, continue | [session-handoff.md](references/session-handoff.md) |
+
+**Feature-level (auto-sized):**
+| Trigger Pattern | Reference |
+|----------------|-----------|
+| Specify feature, define requirements | [specify.md](references/specify.md) |
+| Discuss feature, capture context, how should this work | [discuss.md](references/discuss.md) |
+| Design feature, architecture | [design.md](references/design.md) |
+| Break into tasks, create tasks | [tasks.md](references/tasks.md) |
+| Implement task, build, execute | [implement.md](references/implement.md) |
+| Validate, verify, test, UAT, walk me through it | [validate.md](references/validate.md) |
+| Quick fix, quick task, small change, bug fix | [quick-mode.md](references/quick-mode.md) |
+
+## Skill Integrations
+
+This skill coexists with other skills. Before specific tasks, check if complementary skills are installed and prefer them when available.
+
+### Diagrams → mermaid-studio
+
+Whenever the workflow requires creating or updating a diagram (architecture overviews, data flows, component diagrams, sequence diagrams, etc.), **always** check if the `mermaid-studio` skill is installed in the user's environment before proceeding. If it is installed, delegate all diagram creation and rendering to it. If it is not installed, proceed with inline mermaid code blocks as usual and recommend the user install `mermaid-studio` for richer diagram capabilities (rendering to SVG/PNG, validation, theming, etc.). Display this recommendation at most once per session.
+
+### Code Exploration → codenavi
+
+Whenever the workflow requires exploring or discovering things in an existing repository (brownfield mapping, code reuse analysis, pattern identification, dependency tracing, etc.), **always** check if the `codenavi` skill is installed in the user's environment before proceeding. If it is installed, delegate code exploration and navigation tasks to it. If it is not installed, fall back to the built-in code analysis tools (see [code-analysis.md](references/code-analysis.md)) and recommend the user install `codenavi` for more effective codebase exploration. Display this recommendation at most once per session.
+
+## Knowledge Verification Chain
+
+When researching, designing, or making any technical decision, follow this chain in strict order. Never skip steps.
+
+```
+Step 1: Codebase → check existing code, conventions, and patterns already in use
+Step 2: Project docs → README, docs/, inline comments, .specs/codebase/
+Step 3: Context7 MCP → resolve library ID, then query for current API/patterns
+Step 4: Web search → official docs, reputable sources, community patterns
+Step 5: Flag as uncertain → "I'm not certain about X — here's my reasoning, but verify"
+```
+
+**Rules:**
+
+- Never skip to Step 5 if Steps 1-4 are available
+- Step 5 is ALWAYS flagged as uncertain — never presented as fact
+- **NEVER assume or fabricate.** If you cannot find an answer, say "I don't know" or "I couldn't find documentation for this". Inventing APIs, patterns, or behaviors causes cascading failures across design → tasks → implementation. Uncertainty is always preferable to fabrication.
+
+## Output Behavior
+
+**Model guidance:** After completing lightweight tasks (validation, state updates, session handoff), naturally mention once that such tasks work well with faster/cheaper models. Track in STATE.md under `Preferences` to avoid repeating. For heavy tasks (brownfield mapping, complex design), briefly note the reasoning requirements before starting.
+
+Be conversational, not robotic. Don't interrupt workflow—add as a natural closing note. Skip if user seems experienced or has already acknowledged the tip.
+
+## Code Analysis
+
+Use available tools with graceful degradation. See [code-analysis.md](references/code-analysis.md).

--- a/.claude/skills/tlc-spec-driven/references/brownfield-mapping.md
+++ b/.claude/skills/tlc-spec-driven/references/brownfield-mapping.md
@@ -1,0 +1,455 @@
+# Brownfield Mapping
+
+**Trigger:** "Map codebase", "Analyze existing code", "Document current architecture"
+
+**Purpose:** Understand existing project structure before adding features.
+
+## Process
+
+Before starting, check if the `codenavi` skill is available for code exploration (see Skill Integrations in SKILL.md). If available, prefer it for all discovery and navigation tasks below.
+
+**High-level approach:**
+
+1. Explore directory structure systematically
+2. Identify technology stack from dependency manifests
+3. Extract patterns from representative code samples
+4. Document observed conventions and architectures
+5. Catalog external integrations
+6. Identify concerns: tech debt, known bugs, security risks, performance bottlenecks, fragile areas
+
+**Analysis depth:**
+
+- Sample 5-10 representative files per category
+- Focus on consistency and patterns, not exhaustive coverage
+- Extract actual examples, not assumptions
+
+## Output: 7 Files in .specs/codebase/
+
+---
+
+### 1. STACK.md
+
+**Purpose:** Document technology stack and dependencies.
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Extract from:**
+
+- Dependency manifest files
+- Build configuration
+- Runtime configuration
+
+**Document:**
+
+```markdown
+# Tech Stack
+
+**Analyzed:** [date]
+
+## Core
+
+- Framework: [detected name + version]
+- Language: [detected name + version]
+- Runtime: [detected name + version]
+- Package manager: [detected manager]
+
+## Frontend (if applicable)
+
+- UI Framework: [name + version]
+- Styling: [approach + tools]
+- State Management: [library/pattern]
+- Form Handling: [library if present]
+
+## Backend (if applicable)
+
+- API Style: [REST/GraphQL/gRPC + framework]
+- Database: [ORM/query builder + database system]
+- Authentication: [library/approach]
+
+## Testing
+
+- Unit: [framework]
+- Integration: [framework]
+- E2E: [framework if present]
+
+## External Services
+
+- [Category]: [Service name]
+- [Category]: [Service name]
+
+## Development Tools
+
+- [Tool category]: [Tool name]
+```
+
+**Instructions:**
+
+- Extract from actual dependency files
+- Include versions for major dependencies
+- Categorize by purpose
+- Note testing frameworks explicitly
+
+---
+
+### 2. ARCHITECTURE.md
+
+**Purpose:** Document architectural patterns and data flow.
+
+**Size limit:** 4,000 tokens (~2,400 words)
+
+**Extract from:**
+
+- Directory organization
+- Code structure analysis
+- Repeated patterns across files
+
+**Document:**
+
+```markdown
+# Architecture
+
+**Pattern:** [Identified pattern - monolith/microservices/modular/etc]
+
+## High-Level Structure
+
+[Create diagram/description based on actual organization]
+
+## Identified Patterns
+
+### [Pattern Name]
+
+**Location:** [where this pattern lives]
+**Purpose:** [what this achieves]
+**Implementation:** [how it's structured]
+**Example:** [reference to actual file/function]
+
+### [Pattern Name]
+
+[Same structure]
+
+## Data Flow
+
+### [Key Flow - e.g., Authentication/Payment/etc]
+
+[Map actual flow from code analysis]
+
+### [Key Flow]
+
+[Map actual flow]
+
+## Code Organization
+
+**Approach:** [feature-based/layer-based/domain-driven/etc]
+
+**Structure:**
+[Document actual directory organization]
+
+**Module boundaries:**
+[How code is divided into modules/packages]
+```
+
+**Instructions:**
+
+- Identify patterns from actual code, not assumptions
+- Document observed architectural decisions
+- Create flow diagrams for critical paths
+- Reference concrete examples from codebase
+
+---
+
+### 3. CONVENTIONS.md
+
+**Purpose:** Document code style and naming conventions.
+
+**Size limit:** 3,000 tokens (~1,800 words)
+
+**Extract from:**
+
+- Analyzing 5-10 representative files
+- Identifying consistent patterns
+- Observing actual conventions in use
+
+**Document:**
+
+```markdown
+# Code Conventions
+
+## Naming Conventions
+
+**Files:**
+[Observed pattern - document actual approach]
+Examples: [actual filenames from codebase]
+
+**Functions/Methods:**
+[Observed pattern]
+Examples: [actual function names]
+
+**Variables:**
+[Observed pattern]
+Examples: [actual variable names]
+
+**Constants:**
+[Observed pattern]
+Examples: [actual constant names]
+
+## Code Organization
+
+**Import/Dependency Declaration:**
+[Observed ordering pattern]
+[Example from actual file]
+
+**File Structure:**
+[Observed organization within files]
+[Example from actual file]
+
+## Type Safety/Documentation
+
+**Approach:** [Type system/documentation approach used]
+[Example from actual code]
+
+## Error Handling
+
+**Pattern:** [Observed error handling approach]
+[Example from actual code]
+
+## Comments/Documentation
+
+**Style:** [When/how comments are used]
+[Example from actual code]
+```
+
+**Instructions:**
+
+- Extract patterns from actual code samples
+- Document observed conventions, not ideal conventions
+- Include concrete examples from codebase
+- Note exceptions or variations where found
+
+---
+
+### 4. STRUCTURE.md
+
+**Purpose:** Document directory layout and file organization.
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Document:**
+
+```markdown
+# Project Structure
+
+**Root:** [project root path]
+
+## Directory Tree
+
+[Visual tree representation - max 3 levels deep]
+
+## Module Organization
+
+### [Module/Area Name]
+
+**Purpose:** [what this area handles]
+**Location:** [where files live]
+**Key files:** [important files in this area]
+
+### [Module/Area Name]
+
+[Same structure]
+
+## Where Things Live
+
+**[Capability/Feature]:**
+
+- UI/Interface: [location]
+- Business Logic: [location]
+- Data Access: [location]
+- Configuration: [location]
+
+**[Capability/Feature]:**
+[Same structure]
+
+## Special Directories
+
+**[Directory name]:**
+**Purpose:** [what belongs here]
+**Examples:** [key files in this directory]
+```
+
+**Instructions:**
+
+- Create tree view of actual directory structure
+- Limit depth to maintain readability
+- Document purpose of key directories
+- Map capabilities to physical locations
+
+---
+
+### 5. TESTING.md
+
+**Purpose:** Document testing infrastructure and patterns.
+
+**Size limit:** 4,000 tokens (~2,400 words)
+
+**Document:**
+
+```markdown
+# Testing Infrastructure
+
+## Test Frameworks
+
+**Unit/Integration:** [framework name + version]
+**E2E:** [framework name + version]
+**Coverage:** [tool if used]
+
+## Test Organization
+
+**Location:** [where tests live]
+**Naming:** [test file naming pattern]
+**Structure:** [how tests are organized]
+
+## Testing Patterns
+
+### Unit Tests
+
+**Approach:** [observed pattern]
+**Location:** [where unit tests live]
+[Description of actual pattern used]
+
+### Integration Tests
+
+**Approach:** [observed pattern]
+**Location:** [where integration tests live]
+[Description of actual pattern used]
+
+### E2E Tests
+
+**Approach:** [observed pattern if present]
+**Location:** [where E2E tests live]
+[Description of actual pattern used]
+
+## Test Execution
+
+**Commands:** [how to run tests]
+**Configuration:** [test configuration approach]
+
+## Coverage Targets
+
+**Current:** [if measurable]
+**Goals:** [if documented]
+**Enforcement:** [if automated]
+
+## Test Coverage Matrix
+
+Analyze the codebase to determine which code layers require which test types.
+For each layer, document the required test type, file location pattern, and run command.
+
+| Code Layer | Required Test Type          | Location Pattern       | Run Command |
+| ---------- | --------------------------- | ---------------------- | ----------- |
+| [layer]    | [unit/integration/e2e/none] | [glob or path pattern] | [command]   |
+
+## Parallelism Assessment
+
+| Test Type | Parallel-Safe? | Isolation Model | Evidence                      |
+| --------- | -------------- | --------------- | ----------------------------- |
+| [type]    | [Yes/No]       | [description]   | [file/pattern that proves it] |
+
+## Gate Check Commands
+
+| Gate Level | When to Use                            | Command                     |
+| ---------- | -------------------------------------- | --------------------------- |
+| Quick      | After tasks with unit tests only       | [unit test command]         |
+| Full       | After tasks with e2e/integration tests | [unit + e2e commands]       |
+| Build      | After phase completion                 | [build + lint + unit + e2e] |
+```
+
+**Instructions:**
+
+- Identify test frameworks from dependencies and code
+- Document actual testing patterns observed
+- Note test organization approach
+- Include execution instructions
+- **Test Coverage Matrix:** Sample 5-10 existing test files to identify which layers are tested and how. Look at test file locations relative to source to determine patterns. Extract run commands from `package.json`, `project.json`, `Makefile`, CI config. Mark layers with no existing tests as "none" with a note in CONCERNS.md.
+- **Parallelism Assessment:** NOT parallel-safe signals: shared DB connection (same URL from config), table-level cleanup in `beforeEach`/`afterAll` (`.del()`, `DELETE FROM`, `TRUNCATE`), shared mock state reset on globals. Parallel-safe signals: per-test DB creation (Testcontainers, dynamic schema, SQLite in-memory), data namespacing (all data keyed by unique test ID), no shared mutable state between test files, all deps mocked (`jest.fn()`, `vi.fn()`).
+- **Gate Check Commands:** Extract from actual project commands — do not invent commands.
+
+---
+
+### 6. INTEGRATIONS.md
+
+**Purpose:** Document external service integrations.
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+**Document:**
+
+```markdown
+# External Integrations
+
+## [Service Category]
+
+**Service:** [service name]
+**Purpose:** [what this integration provides]
+**Implementation:** [where integration lives in code]
+**Configuration:** [how service is configured]
+**Authentication:** [auth approach if applicable]
+
+## [Service Category]
+
+[Same structure]
+
+## API Integrations
+
+### [API Name]
+
+**Purpose:** [what this API provides]
+**Location:** [where API client/code lives]
+**Authentication:** [auth method]
+**Key endpoints:** [major endpoints used]
+
+## Webhooks
+
+### [Webhook Source]
+
+**Purpose:** [what events are handled]
+**Location:** [webhook handler location]
+**Events:** [event types processed]
+
+## Background Jobs
+
+**Queue system:** [system if used]
+**Location:** [where job definitions live]
+**Jobs:** [key background jobs]
+```
+
+**Instructions:**
+
+- Identify integrations from code and configuration
+- Document authentication approaches
+- Note webhook handlers if present
+- Include background job infrastructure
+
+---
+
+### 7. CONCERNS.md
+
+**Purpose:** Surface actionable warnings about the codebase — tech debt, known bugs, security gaps, performance bottlenecks, fragile areas, scaling limits, risky dependencies, missing features, and test coverage gaps.
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+See [concerns.md](concerns.md) for the full template, guidelines, and examples.
+
+**Instructions:**
+
+- Document only concerns backed by evidence (file paths, measurements, reproduction steps)
+- Include fix approaches, not just problems
+- Omit sections with no findings
+- Prioritize by risk/impact
+- Use professional, solution-oriented tone
+
+---
+
+## Total Context Budget
+
+**Combined:** ~19,000 tokens (10% of context window)
+**Acceptable for:** Brownfield projects requiring codebase understanding
+**Loading strategy:** Load relevant docs on-demand based on task

--- a/.claude/skills/tlc-spec-driven/references/code-analysis.md
+++ b/.claude/skills/tlc-spec-driven/references/code-analysis.md
@@ -1,0 +1,98 @@
+# Code Analysis Tools
+
+Use graceful degradation for code search and structural analysis.
+
+## Tool Priority
+
+1. **ast-grep** (`sg`) - Structural pattern-based search
+2. **ripgrep** (`rg`) - Fast context-aware text search
+3. **grep** - Standard text search (always available)
+
+## Detection
+
+Check tool availability before use:
+
+```bash
+# Check for ast-grep
+if command -v sg >/dev/null 2>&1; then
+  # Use ast-grep for structural search
+elif command -v rg >/dev/null 2>&1; then
+  # Fall back to ripgrep
+else
+  # Use standard grep as final fallback
+fi
+```
+
+## Usage Examples
+
+**Finding function definitions:**
+
+```bash
+# ast-grep (best - structural)
+sg -p 'function $NAME($$$) { $$$ }'
+
+# ripgrep (fallback - fast text)
+rg '^function\s+\w+\(' --type-add 'source:*.[extension]' -t source
+
+# grep (last resort - basic)
+grep -r '^function ' --include="*.[extension]"
+```
+
+**Finding imports/requires:**
+
+```bash
+# ast-grep
+sg -p 'import { $$$ } from "$MODULE"'
+
+# ripgrep
+rg '^import .* from' --type-add 'source:*.[extension]' -t source
+
+# grep
+grep -r '^import ' --include="*.[extension]"
+```
+
+**Finding class/component definitions:**
+
+```bash
+# ast-grep
+sg -p 'class $NAME { $$$ }'
+
+# ripgrep
+rg '^(class|export class)\s+\w+' --type-add 'source:*.[extension]' -t source
+
+# grep
+grep -r '^class ' --include="*.[extension]"
+```
+
+## Search Scope
+
+**Best practices:**
+
+- Limit to source file extensions relevant to project
+- Exclude directories: `node_modules`, `vendor`, `dist`, `build`, `.git`
+- Focus on source directories: `src`, `lib`, `app`
+- Use file type filters when available
+
+**Performance tips:**
+
+- Use specific patterns over broad searches
+- Limit directory depth with `--max-depth` (ripgrep/grep)
+- Cache results for repeated queries
+
+## Fallback Notice
+
+If ast-grep unavailable, display once per session:
+
+```
+⚠️ ast-grep not detected. Install for more precise structural code analysis.
+   https://ast-grep.github.io/guide/quick-start.html
+```
+
+## When to Use
+
+- Finding usage patterns across codebase
+- Identifying code structure and organization
+- Locating function/class/component definitions
+- Analyzing import/dependency patterns
+- Refactoring impact analysis
+- Code navigation in unfamiliar codebases

--- a/.claude/skills/tlc-spec-driven/references/coding-principles.md
+++ b/.claude/skills/tlc-spec-driven/references/coding-principles.md
@@ -1,0 +1,56 @@
+# Coding Principles
+
+Behavioral bias, not checklist. Read before every implementation.
+
+---
+
+## Before Coding
+
+- State assumptions explicitly. If uncertain, ask.
+- Multiple interpretations exist? Present all—don't pick silently.
+- Simpler approach exists? Say so. Push back when warranted.
+- Something unclear? Stop. Name what's confusing. Ask.
+- User's approach seems wrong? Disagree honestly. Don't be sycophantic.
+
+---
+
+## During Implementation
+
+### Simplicity
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" not requested
+- No error handling for impossible scenarios
+- 200 lines that could be 50? Rewrite it.
+
+### Surgical Changes
+
+- Don't "improve" adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Match existing style, even if you'd do differently
+- Unrelated dead code noticed? Mention it—don't delete it
+- Remove ONLY imports/variables/functions YOUR changes orphaned
+- Don't remove pre-existing dead code unless asked
+
+### Test Integrity
+
+- NEVER weaken an existing test assertion to make it pass
+- NEVER delete a test to reduce failure count
+- NEVER use the test framework's skip/disable/pending mechanism to bypass a failing test
+- NEVER modify tests written in the RED phase during GREEN phase
+- If a test is genuinely wrong, STOP and confirm with the user before changing it
+- Tests are the spec — implementation conforms to tests, not the other way around
+
+### Goal-Driven
+
+- Transform vague tasks into verifiable goals
+- Multi-step work? State brief plan with verify checkpoints
+- Every changed line must trace directly to user's request
+
+---
+
+## After Each Change
+
+Ask: "Would senior engineer call this overcomplicated?"
+If yes → simplify before proceeding.

--- a/.claude/skills/tlc-spec-driven/references/concerns.md
+++ b/.claude/skills/tlc-spec-driven/references/concerns.md
@@ -1,0 +1,193 @@
+# Phase: Codebase Concerns
+
+**Trigger:** Part of brownfield mapping, or explicitly "document concerns", "find tech debt", "what's risky in this codebase"
+
+**Purpose:** Surface actionable warnings about the codebase. Focused on "what to watch out for when making changes." This is living documentation, not a complaint list.
+
+## When to Generate
+
+CONCERNS.md is generated as part of the brownfield mapping flow (alongside STACK.md, ARCHITECTURE.md, etc.). It can also be created or updated independently when:
+
+- Exploring a new area of the codebase reveals risks
+- A bug investigation uncovers systemic issues
+- A feature implementation hits unexpected fragility
+- A dependency audit reveals risks
+
+## Process
+
+### 1. Gather Evidence
+
+During codebase exploration, look for concrete signals — not opinions. Evidence sources:
+
+- Code patterns that indicate shortcuts (TODO/FIXME/HACK comments, duplicated logic, missing error handling)
+- Test coverage gaps (untested critical paths, missing edge cases)
+- Dependency manifests (outdated packages, deprecated libraries, security advisories)
+- Performance indicators (N+1 queries, missing indexes, synchronous blocking calls)
+- Security patterns (client-side-only auth checks, unvalidated inputs, exposed secrets)
+
+### 2. Classify and Document
+
+Each concern must have: **what** the problem is, **where** it lives (file paths), **why** it matters (impact), and **how** to fix it (approach).
+
+### 3. Prioritize by Risk
+
+Focus on concerns that could cause real damage — data loss, security breaches, user-facing failures, scaling walls. Minor style issues and normal TODOs do not belong here.
+
+---
+
+## Template: `.specs/codebase/CONCERNS.md`
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+```markdown
+# Codebase Concerns
+
+**Analysis Date:** [YYYY-MM-DD]
+
+## Tech Debt
+
+**[Area/Component]:**
+
+- Issue: [What's the shortcut/workaround]
+- Files: [Specific file paths with backticks]
+- Why: [Why it was done this way]
+- Impact: [What breaks or degrades because of it]
+- Fix approach: [How to properly address it]
+
+## Known Bugs
+
+**[Bug description]:**
+
+- Symptoms: [What happens]
+- Trigger: [How to reproduce]
+- Files: [Where the bug lives]
+- Workaround: [Temporary mitigation if any]
+- Root cause: [If known]
+- Blocked by: [If waiting on something]
+
+## Security Considerations
+
+**[Area requiring security care]:**
+
+- Risk: [What could go wrong]
+- Files: [Where the risk lives]
+- Current mitigation: [What's in place now]
+- Recommendations: [What should be added]
+
+## Performance Bottlenecks
+
+**[Slow operation/endpoint]:**
+
+- Problem: [What's slow]
+- Files: [Where the bottleneck lives]
+- Measurement: [Actual numbers: "500ms p95", "2s load time"]
+- Cause: [Why it's slow]
+- Improvement path: [How to speed it up]
+
+## Fragile Areas
+
+**[Component/Module]:**
+
+- Files: [Where the fragility lives]
+- Why fragile: [What makes it break easily]
+- Common failures: [What typically goes wrong]
+- Safe modification: [How to change it without breaking]
+- Test coverage: [Is it tested? Gaps?]
+
+## Scaling Limits
+
+**[Resource/System]:**
+
+- Current capacity: [Numbers: "100 req/sec", "10k users"]
+- Limit: [Where it breaks]
+- Symptoms at limit: [What happens]
+- Scaling path: [How to increase capacity]
+
+## Dependencies at Risk
+
+**[Package/Service]:**
+
+- Risk: [e.g., "deprecated", "unmaintained", "breaking changes coming"]
+- Impact: [What breaks if it fails]
+- Migration plan: [Alternative or upgrade path]
+
+## Missing Critical Features
+
+**[Feature gap]:**
+
+- Problem: [What's missing]
+- Current workaround: [How users cope]
+- Blocks: [What can't be done without it]
+- Implementation complexity: [Rough effort estimate]
+
+## Test Coverage Gaps
+
+**[Untested area]:**
+
+- What's not tested: [Specific functionality]
+- Risk: [What could break unnoticed]
+- Priority: [High/Medium/Low]
+- Difficulty to test: [Why it's not tested yet]
+
+---
+
+_Concerns audit: [date]_
+_Update as issues are fixed or new ones discovered_
+```
+
+**Include only sections that have findings.** Empty sections should be omitted entirely.
+
+---
+
+## What Belongs vs. What Doesn't
+
+**Include:**
+
+- Tech debt with clear impact and fix approach
+- Known bugs with reproduction steps
+- Security gaps and mitigation recommendations
+- Performance bottlenecks with measurements
+- Fragile code that breaks easily
+- Scaling limits with numbers
+- Dependencies that need attention
+- Missing features that block workflows
+- Test coverage gaps
+
+**Exclude:**
+
+- Opinions without evidence ("code is messy")
+- Complaints without solutions ("auth sucks")
+- Future feature ideas (that's for product planning)
+- Normal TODOs (those live in code comments)
+- Architectural decisions that are working fine
+- Minor code style issues
+
+---
+
+## Writing Guidelines
+
+- **Always include file paths** — Concerns without locations are not actionable. Use backticks: `src/file.ts`
+- Be specific with measurements ("500ms p95" not "slow")
+- Include reproduction steps for bugs
+- Suggest fix approaches, not just problems
+- Focus on actionable items
+- Prioritize by risk/impact
+
+**Tone:** Professional, not emotional. Solution-oriented. Risk-focused. Factual.
+
+- ✅ "N+1 query pattern in `app/api/courses/route.ts` — 1.2s p95 with 50+ courses"
+- ❌ "Terrible queries, everything is slow"
+- ✅ "Fix: add index on `user_id` in `subscriptions` table"
+- ❌ "Needs fixing"
+
+---
+
+## How CONCERNS.md Gets Used
+
+- **Feature planning:** Check CONCERNS.md before designing features that touch flagged areas
+- **Risk estimation:** Use fragile areas and scaling limits to estimate change risk
+- **Onboarding new sessions:** Load CONCERNS.md to give context about what to watch out for
+- **Refactoring prioritization:** Use tech debt and test coverage gaps to plan improvement sprints
+- **Implementation phase:** Consult before modifying any flagged component
+
+This is living documentation. Update as issues are fixed or new ones discovered during any workflow phase.

--- a/.claude/skills/tlc-spec-driven/references/context-limits.md
+++ b/.claude/skills/tlc-spec-driven/references/context-limits.md
@@ -1,0 +1,40 @@
+# Context Limits
+
+## File Size Limits
+
+| File            | Max Tokens | ~Words | Warning At  |
+| --------------- | ---------- | ------ | ----------- |
+| PROJECT.md      | 2,000      | 1,200  | 1,600 (80%) |
+| ROADMAP.md      | 3,000      | 1,800  | 2,400       |
+| STATE.md        | 10,000     | 6,000  | 7,000 (70%) |
+| spec.md         | 5,000      | 3,000  | 4,000       |
+| design.md       | 8,000      | 4,800  | 6,400       |
+| tasks.md        | 10,000     | 6,000  | 8,000       |
+| STACK.md        | 2,000      | 1,200  | 1,600       |
+| ARCHITECTURE.md | 4,000      | 2,400  | 3,200       |
+| CONVENTIONS.md  | 3,000      | 1,800  | 2,400       |
+| STRUCTURE.md    | 2,000      | 1,200  | 1,600       |
+| TESTING.md      | 4,000      | 2,400  | 3,200       |
+| INTEGRATIONS.md | 5,000      | 3,000  | 4,000       |
+
+## Context Zones
+
+🟢 **Healthy** (<40k total): Silent
+🟡 **Moderate** (40-60k): Discrete footer note
+🔴 **Critical** (>60k): Active warning, suggest optimization
+
+## Monitoring
+
+Display context status in footer when >40k:
+
+```
+📊 Context: 52k tokens (moderate)
+  - STATE.md: 8k (yellow zone)
+  - tasks.md: 11k (ok)
+  - Total: 52k / 200k (26%)
+```
+
+## Principles
+
+**Target:** <40k tokens loaded (20% of window)
+**Reserve:** 160k+ tokens for work, reasoning, outputs

--- a/.claude/skills/tlc-spec-driven/references/design.md
+++ b/.claude/skills/tlc-spec-driven/references/design.md
@@ -1,0 +1,166 @@
+# Design
+
+**Goal**: Define HOW to build it. Architecture, components, what to reuse.
+
+**Skip this phase when:** The change is straightforward — no architectural decisions, no new patterns, no component interactions to plan. For simple features, design happens inline during Execute.
+
+## Process
+
+### 1. Load Context
+
+Read `.specs/features/[feature]/spec.md` before designing. If `.specs/features/[feature]/context.md` exists, load it too — it contains implementation decisions that constrain the design (layout choices, behavior preferences, interaction patterns). Decisions marked as "Agent's Discretion" are yours to decide.
+
+### 1.5. Research (Optional but Recommended)
+
+If the feature involves unfamiliar technology, patterns, or integrations, research before designing. Document findings briefly in the design doc or as inline notes. This prevents incorrect assumptions from propagating into tasks.
+
+Follow the **Knowledge Verification Chain** (see SKILL.md) in strict order:
+
+```
+Codebase → Project docs → Context7 MCP → Web search → Flag as uncertain
+```
+
+**CRITICAL: NEVER assume or fabricate information.** If you cannot find an answer through the chain, explicitly say "I don't know" or "I couldn't find documentation for this". Inventing an API, a pattern, or a behavior that doesn't exist is far worse than admitting uncertainty. Wrong assumptions propagate through design → tasks → implementation and cause cascading failures.
+
+Good triggers for research: new libraries, unfamiliar APIs, performance-sensitive features, security-sensitive features, patterns you haven't used in this codebase before.
+
+### 2. Define Architecture
+
+Overview of how components interact. Use mermaid diagrams when helpful. Before creating any diagrams, check if the `mermaid-studio` skill is available (see Skill Integrations in SKILL.md).
+
+### 3. Identify Code Reuse
+
+**CRITICAL**: What existing code can we leverage? This saves tokens and reduces errors.
+
+If `.specs/codebase/CONCERNS.md` exists, check it before designing. Any component flagged as fragile, carrying tech debt, or having test coverage gaps requires extra care in the design — document how the design mitigates those concerns.
+
+### 4. Define Components and Interfaces
+
+Each component: Purpose, Location, Interfaces, Dependencies, What it reuses.
+
+### 5. Define Data Models
+
+If the feature involves data, define models before implementation.
+
+---
+
+## Template: `.specs/[feature]/design.md`
+
+````markdown
+# [Feature] Design
+
+**Spec**: `.specs/[feature]/spec.md`
+**Status**: Draft | Approved
+
+---
+
+## Architecture Overview
+
+[Brief description of the architecture approach]
+
+```mermaid
+graph TD
+    A[User Action] --> B[Component A]
+    B --> C[Service Layer]
+    C --> D[Data Store]
+    B --> E[Component B]
+```
+````
+
+---
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+| Component            | Location            | How to Use                |
+| -------------------- | ------------------- | ------------------------- |
+| [Existing Component] | `src/path/to/file`  | [Extend/Import/Reference] |
+| [Existing Utility]   | `src/utils/file`    | [How it helps]            |
+| [Existing Pattern]   | `src/patterns/file` | [Apply same pattern]      |
+
+### Integration Points
+
+| System         | Integration Method                      |
+| -------------- | --------------------------------------- |
+| [Existing API] | [How new feature connects]              |
+| [Database]     | [How data connects to existing schemas] |
+
+---
+
+## Components
+
+### [Component Name]
+
+- **Purpose**: [What this component does - one sentence]
+- **Location**: `src/path/to/component/`
+- **Interfaces**:
+  - `methodName(param: Type): ReturnType` - [description]
+  - `methodName(param: Type): ReturnType` - [description]
+- **Dependencies**: [What it needs to function]
+- **Reuses**: [Existing code this builds upon]
+
+### [Component Name]
+
+- **Purpose**: [What this component does]
+- **Location**: `src/path/to/component/`
+- **Interfaces**:
+  - `methodName(param: Type): ReturnType`
+- **Dependencies**: [Dependencies]
+- **Reuses**: [Existing code]
+
+---
+
+## Data Models (if applicable)
+
+### [Model Name]
+
+```typescript
+interface ModelName {
+  id: string
+  field1: string
+  field2: number
+  createdAt: Date
+}
+```
+
+**Relationships**: [How this relates to other models]
+
+### [Model Name]
+
+```typescript
+interface AnotherModel {
+  id: string
+  // ...
+}
+```
+
+---
+
+## Error Handling Strategy
+
+| Error Scenario | Handling      | User Impact      |
+| -------------- | ------------- | ---------------- |
+| [Scenario 1]   | [How handled] | [What user sees] |
+| [Scenario 2]   | [How handled] | [What user sees] |
+
+---
+
+## Tech Decisions (only non-obvious ones)
+
+| Decision          | Choice          | Rationale     |
+| ----------------- | --------------- | ------------- |
+| [What we decided] | [What we chose] | [Why - brief] |
+
+---
+
+## Tips
+
+- **Load context first** — If context.md exists, decisions there are locked
+- **Research when uncertain** — 5 minutes of research prevents hours of rework
+- **Reuse is king** — Every component should reference existing patterns
+- **Interfaces first** — Define contracts before implementation
+- **Keep it visual** — Diagrams save 1000 words (check mermaid-studio skill in Skill Integrations)
+- **Small components** — If component does 3+ things, split it
+- **Check CONCERNS.md** — If it exists, flag fragile areas the design must address
+- **Confirm before Tasks** — User approves design before breaking into tasks

--- a/.claude/skills/tlc-spec-driven/references/discuss.md
+++ b/.claude/skills/tlc-spec-driven/references/discuss.md
@@ -1,0 +1,129 @@
+# Specify: Discuss Gray Areas
+
+**Goal:** Capture HOW the user envisions the feature when the spec has ambiguous areas. This is NOT a separate phase — it's triggered within Specify when the agent detects gray areas that need user input.
+
+**Trigger:** Automatically when gray areas are detected during spec creation, or explicitly via "discuss feature", "how should this work?", "capture context"
+
+**When to trigger (auto-detect):** The spec contains user-facing behavior that could go multiple ways AND the user hasn't expressed a preference. If the spec is clear and unambiguous, skip this entirely.
+
+**When NOT to trigger:** Infrastructure work, CRUD operations, well-defined API contracts, anything where the "how" is obvious from the "what".
+
+## Why This Phase Exists
+
+Specifications capture WHAT to build. Design captures the architecture. But neither captures the user's vision for ambiguous areas — layout preferences, interaction patterns, error handling style, content tone. Without this, the agent guesses. With this, the agent builds what the user actually imagined.
+
+The output — `context.md` — feeds directly into Design and Tasks:
+
+- **Design reads it** to know what decisions are locked vs. flexible
+- **Tasks reads it** to include specific behaviors in task definitions
+
+## Process
+
+### 1. Analyze the Feature
+
+Read `.specs/features/[feature]/spec.md` and identify the domain:
+
+| Domain                         | Gray areas to explore                                         |
+| ------------------------------ | ------------------------------------------------------------- |
+| Something users **SEE**        | Layout, density, interactions, empty states, visual hierarchy |
+| Something users **CALL** (API) | Response format, errors, auth, versioning, rate limiting      |
+| Something users **RUN** (CLI)  | Output format, flags, modes, error handling, verbosity        |
+| Something users **READ**       | Structure, tone, depth, flow, navigation                      |
+| Something being **ORGANIZED**  | Grouping criteria, naming, duplicates, exceptions             |
+
+Generate 3-4 **feature-specific** gray areas. Not generic categories, but concrete decisions for THIS feature.
+
+### 2. Present Gray Areas
+
+Present the feature boundary (from spec.md) and the gray areas to the user. Let them choose which to discuss. Do NOT include a "skip all" option — the user invoked this phase to discuss.
+
+### 3. Deep-Dive Each Area
+
+For each selected area:
+
+1. Ask 3-4 concrete questions with specific options (not vague categories)
+2. After the questions, check: "More about [area], or move on?"
+3. If more → ask 3-4 more, check again
+4. After all areas → "Ready to create context?"
+
+**Question design:**
+
+- Options should be concrete ("Card layout" not "Option A")
+- Each answer should inform the next question
+- Include "You decide" as an option when reasonable — captures agent discretion
+
+### 4. Scope Guardrail (CRITICAL)
+
+The feature boundary from spec.md is **fixed**. Discussion clarifies HOW to implement, never WHETHER to add new capabilities.
+
+**Allowed:** "How should posts be displayed?" (clarifying ambiguity)
+**Not allowed:** "Should we also add comments?" (new capability)
+
+When user suggests scope creep: "That sounds like a separate feature. I'll note it in Deferred Ideas. Back to [current area]."
+
+### 5. Write context.md
+
+---
+
+## Template: `.specs/features/[feature]/context.md`
+
+```markdown
+# [Feature] Context
+
+**Gathered:** [date]
+**Spec:** `.specs/features/[feature]/spec.md`
+**Status:** Ready for design
+
+---
+
+## Feature Boundary
+
+[Clear statement of what this feature delivers — the scope anchor from spec.md]
+
+---
+
+## Implementation Decisions
+
+### [Area 1 that was discussed]
+
+- [Specific decision made]
+- [Another decision if applicable]
+
+### [Area 2 that was discussed]
+
+- [Specific decision made]
+
+### [Area 3 that was discussed]
+
+- [Specific decision made]
+
+### Agent's Discretion
+
+[Areas where user explicitly said "you decide" — agent has flexibility here during design/implementation]
+
+---
+
+## Specific References
+
+[Any "I want it like X" moments, product references, specific behaviors, interaction patterns mentioned during discussion]
+
+[If none: "No specific requirements — open to standard approaches"]
+
+---
+
+## Deferred Ideas
+
+[Ideas that came up during discussion but belong in other features/phases. Captured here so they're not lost, but explicitly out of scope]
+
+[If none: "None — discussion stayed within feature scope"]
+```
+
+---
+
+## Tips
+
+- **Decisions, not vision** — "Card-based layout with subtle shadows" is a decision. "Should feel modern" is not.
+- **Scope is sacred** — Deferred Ideas captures scope creep without losing ideas
+- **User = visionary, Agent = builder** — Ask about how they imagine it, not about technical implementation
+- **Don't ask about:** Technical architecture, performance, implementation details — that's Design's job
+- **Confirm before Design** — User approves context.md before moving to design phase

--- a/.claude/skills/tlc-spec-driven/references/implement.md
+++ b/.claude/skills/tlc-spec-driven/references/implement.md
@@ -1,0 +1,284 @@
+# Execute
+
+**Goal**: Implement ONE task at a time. Surgical changes. Verify. Commit. Repeat.
+
+This is where code gets written. Every task follows the same cycle: plan → implement → verify → commit. Verification is built into every task, not a separate phase.
+
+---
+
+## MANDATORY: Before Starting Any Implementation
+
+**Read [coding-principles.md](coding-principles.md) and state:**
+
+1. **Assumptions** - What am I assuming? Any uncertainty?
+2. **Files to touch** - List ONLY files this task requires
+3. **Success criteria** - How will I verify this works?
+
+⚠️ **Do not proceed without stating these explicitly.**
+
+---
+
+## Process
+
+**Sub-agent context:** When this task is executed by a sub-agent, the sub-agent receives
+the task definition, coding principles, TESTING.md, and relevant spec/design context.
+All steps below apply identically whether running in the main context or a sub-agent.
+The only difference: sub-agents report results back to the orchestrator rather than
+continuing to the next task.
+
+### 0. List Atomic Steps (MANDATORY when Tasks phase was skipped)
+
+If there is no `tasks.md` for this feature, you MUST list atomic steps before writing any code. This is non-negotiable — it prevents the agent from losing focus and doing too many things at once.
+
+```
+## Execution Plan
+
+1. [Step] → files: [list] → verify: [how] → commit: [message]
+2. [Step] → files: [list] → verify: [how] → commit: [message]
+3. [Step] → files: [list] → verify: [how] → commit: [message]
+```
+
+**Each step must be:**
+
+- ONE deliverable (one component, one function, one endpoint, one file change)
+- Independently verifiable (can prove it works before moving on)
+- Independently committable (gets its own atomic git commit)
+
+If listing steps reveals >5 steps or complex dependencies, STOP and create a formal `tasks.md` instead. The Tasks phase was wrongly skipped.
+
+### 1. Pick Task
+
+From tasks.md (if exists) or from the execution plan above. User specifies ("implement T3") or suggest next available.
+
+### 2. Verify Dependencies
+
+If tasks.md exists, check dependencies. If using inline plan, follow the order listed.
+
+❌ If blocked: "T3 depends on T2 which isn't done. Should I do T2 first?"
+
+### 3. State Implementation Plan
+
+Before writing code:
+
+```
+Files: [list]
+Approach: [brief description]
+Success: [how to verify]
+```
+
+### 4. Write Tests First (RED)
+
+If the task includes tests (per the Tests field in tasks.md or TESTING.md coverage matrix):
+
+1. Write the test file(s) BEFORE writing any implementation
+2. Tests must encode the expected behavior from the task's "Done when" criteria
+3. Run the test command — confirm tests FAIL (RED state)
+4. If tests pass before implementation exists, the tests are too weak — rewrite them
+
+**Constraints:**
+
+- Tests define correct behavior independently of implementation
+- Each acceptance criterion from "Done when" maps to at least one test assertion
+- Edge cases from spec.md that apply to this task get test cases too
+
+If the task does NOT include tests (e.g., entity-only, config-only), skip to Step 4b.
+
+### 4b. Implement (GREEN)
+
+Write the minimum implementation needed to satisfy the task's success criteria: pass all relevant tests (when present) and meet the defined verification/gate checks when there are no direct tests.
+
+**HARD CONSTRAINTS:**
+
+- Do NOT modify tests written in Step 4. The tests are the spec — implementation conforms to them.
+- Do NOT weaken assertions (making them less specific to pass more easily)
+- Do NOT delete or skip test cases
+- Do NOT use the test framework's skip/disable/pending mechanism to bypass failing tests
+- Minimum code to pass — save structural improvements for a refactor task
+
+If a test is genuinely wrong (tests the wrong behavior per spec), STOP and ask the user
+before modifying it. Never silently change a test.
+
+Follow [coding-principles.md](coding-principles.md):
+
+- Simplest code that works
+- Touch ONLY listed files
+- No scope creep
+
+### 5. Gate Check (VERIFY)
+
+Run the gate check command from the task definition. This is MANDATORY — not "if applicable."
+
+1. Look up the command for the task's Gate level (quick/full/build) in TESTING.md's Gate Check Commands section, then run it
+2. Non-zero exit code = STOP. Fix the failure. Re-run. Do not proceed until green.
+3. Confirm the test count matches expectations (no tests were silently deleted or skipped)
+
+**Tiered gates (from TESTING.md Gate Check Commands):**
+
+| Task includes                    | Gate level | What runs                |
+| -------------------------------- | ---------- | ------------------------ |
+| Unit tests only                  | Quick      | Unit test command        |
+| E2E or integration tests         | Full       | Unit + E2E commands      |
+| Last task in a phase             | Build      | Build + lint + all tests |
+| No tests (config, entities, etc) | Build      | Build + lint only        |
+
+The gate check is deterministic. The test runner decides if the code is correct,
+not the agent's self-assessment.
+
+### 6. Post-Gate Review
+
+After the gate check passes:
+
+1. Verify test count: Are there at least as many test cases as before? (prevents silent deletion)
+2. Verify no SPEC_DEVIATION: If implementation diverged from spec/design, add a marker:
+
+```
+// SPEC_DEVIATION: [what diverged]
+// Reason: [why the deviation was necessary]
+```
+
+3. Quick complexity check: "Would senior engineer flag this as overcomplicated?"
+   - Yes → Simplify, re-run gate
+   - No → Proceed to commit
+
+### 7. Atomic Git Commit
+
+Each task gets its own commit immediately after verification. Never batch multiple tasks into one commit.
+
+**Format ([Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)):**
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+| Type       | When to use                                             |
+| ---------- | ------------------------------------------------------- |
+| `feat`     | New feature or capability                               |
+| `fix`      | Bug fix                                                 |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `docs`     | Documentation only                                      |
+| `test`     | Adding or correcting tests                              |
+| `style`    | Formatting, missing semicolons, etc. (no code change)   |
+| `perf`     | Performance improvement                                 |
+| `build`    | Build system or external dependencies                   |
+| `ci`       | CI configuration files and scripts                      |
+| `chore`    | Maintenance tasks that don't modify src or test files   |
+
+**Scope:** Feature name or module area, lowercase, e.g., `auth`, `cart`, `api`
+
+**Description rules:**
+
+- Imperative mood ("add", not "added" or "adds")
+- Lowercase first letter
+- No period at the end
+- Complete the sentence: "If applied, this commit will _[your description]_"
+
+**Breaking changes:** Append `!` after type/scope AND add `BREAKING CHANGE:` footer:
+
+```
+feat(api)!: change authentication endpoint response format
+
+BREAKING CHANGE: login endpoint now returns JWT in body instead of cookie
+```
+
+**Examples:**
+
+```
+feat(auth): add email validation to login form
+```
+
+```
+fix(cart): prevent negative quantity on item decrement
+```
+
+```
+refactor(api): extract token refresh logic into service
+
+Move token refresh from inline handler to dedicated AuthTokenService
+for reuse across multiple endpoints.
+```
+
+**Rules:**
+
+- One task = one commit
+- Description references what was DONE, not what was planned
+- Include only files listed in the task — never sneak in "while I'm here" changes
+- If tests are part of the task, include them in the same commit
+
+### 8. Scope Guardrail
+
+During implementation, you will notice things that could be improved, refactored, or added. **Do not act on them.** Instead:
+
+- If it's a bug: note it in STATE.md as a blocker or use quick mode
+- If it's an improvement: note it in STATE.md under "Deferred Ideas" or "Lessons Learned"
+- If it's related to the current task: only include it if it's in the "Done when" criteria
+
+**The heuristic:** "Is this in my task definition?" If no, don't touch it.
+
+### 9. Update Task Status
+
+Mark task complete in tasks.md. Update requirement traceability in spec.md if requirement IDs are used.
+
+---
+
+## Execution Template
+
+```markdown
+## Implementing T[X]: [Task Title]
+
+**Reading**: task definition from tasks.md
+**Dependencies**: [All done? ✅ | Blocked by: TY]
+**Tests**: [unit/e2e/integration/none]
+**Gate**: [quick/full/build]
+
+### Pre-Implementation (MANDATORY)
+
+- **Assumptions**: [state explicitly]
+- **Files to touch**: [list ONLY these]
+- **Success criteria**: [how to verify]
+
+### RED: Write Tests
+
+- Test file(s): [paths]
+- Test count: [N test cases]
+- Confirmed failing: [Yes — all N tests fail as expected]
+
+### GREEN: Implement
+
+[Write minimum code to pass tests]
+
+- Tests modified: None
+- Tests skipped/deleted: None
+
+### VERIFY: Gate Check
+
+- Command: [gate check command]
+- Result: [X passed, 0 failed]
+- Test count: [N — matches RED phase count]
+
+### Post-Gate
+
+- [x] No SPEC_DEVIATION (or markers added)
+- [x] No unnecessary changes made
+- [x] Matches existing patterns
+
+**Status**: ✅ Complete | ❌ Blocked | ⚠️ Partial
+```
+
+---
+
+## Tips
+
+- **One task at a time** — Focus prevents errors
+- **Tools matter** — Wrong MCP = wrong approach
+- **Reuses save tokens** — Copy patterns, don't reinvent
+- **Check before commit** — Verify all criteria, then commit
+- **Stay surgical** — Touch only what's necessary
+- **Commit per task** — Clean git history enables bisect and rollback
+- **Never "while I'm here"** — Scope creep during implementation is the #1 quality killer
+- **Learn from mistakes** — If something goes wrong, add a Lesson Learned to STATE.md

--- a/.claude/skills/tlc-spec-driven/references/project-init.md
+++ b/.claude/skills/tlc-spec-driven/references/project-init.md
@@ -1,0 +1,71 @@
+# Project Initialization
+
+**Trigger:** "Initialize project", "Setup project", "Start new project"
+
+## Process
+
+Extract project vision via iterative Q&A (max 3-5 questions per message):
+
+**Essential questions:**
+
+1. What are you building?
+2. Who is it for and what problem does it solve?
+3. What tech stack are you using? (if known)
+4. What's in scope for v1? What's explicitly excluded?
+5. Critical constraints? (timeline, technical, resources)
+
+**Stop when:** Clear understanding of vision, goals, and boundaries.
+
+## Output: .specs/project/PROJECT.md
+
+**Structure:**
+
+```markdown
+# [Project Name]
+
+**Vision:** [1-2 sentence description]
+**For:** [target users]
+**Solves:** [core problem being addressed]
+
+## Goals
+
+- [Primary goal with measurable success metric]
+- [Secondary goal with measurable success metric]
+
+## Tech Stack
+
+**Core:**
+
+- Framework: [name + version]
+- Language: [name + version]
+- Database: [name]
+
+**Key dependencies:** [3-5 critical libraries/frameworks]
+
+## Scope
+
+**v1 includes:**
+
+- [Core capability 1]
+- [Core capability 2]
+- [Core capability 3]
+
+**Explicitly out of scope:**
+
+- [What is NOT being built]
+- [What is NOT being built]
+
+## Constraints
+
+- Timeline: [if applicable]
+- Technical: [if applicable]
+- Resources: [if applicable]
+```
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Validation:**
+
+- Vision clear in 1-2 sentences?
+- Goals have measurable outcomes?
+- Scope boundaries explicit?

--- a/.claude/skills/tlc-spec-driven/references/quick-mode.md
+++ b/.claude/skills/tlc-spec-driven/references/quick-mode.md
@@ -1,0 +1,132 @@
+# Quick Mode
+
+**Goal:** Execute small, ad-hoc tasks with the same quality principles but without full pipeline ceremony.
+
+**Trigger:** "Quick fix", "Quick task", "Small change", "Bug fix", "Just do X"
+
+## When to Use
+
+| Use quick mode             | Use full pipeline                   |
+| -------------------------- | ----------------------------------- |
+| Bug fixes with known cause | New features with multiple stories  |
+| Config changes             | Architectural changes               |
+| Small UI tweaks            | Features requiring design decisions |
+| Adding a field/column      | Multi-component features            |
+| One-off scripts            | Anything with unclear scope         |
+| Dependency updates         | Features requiring user stories     |
+
+**Rule of thumb:** If you can describe it in one sentence AND it touches ≤3 files, it's a quick task.
+
+## Process
+
+### 1. Describe the Task
+
+User provides a clear, one-sentence description. If vague, ask for specifics:
+
+- ❌ "Fix the login" → Ask: "What's broken? What should happen instead?"
+- ✅ "Fix: login button returns 401 because token refresh skips expired check"
+
+### 2. Pre-Implementation Check
+
+Before writing code, state:
+
+```
+Quick Task: [description]
+Files: [list ONLY files to touch]
+Approach: [one sentence]
+Verify: [how to prove it works]
+```
+
+Get user approval before proceeding. If the pre-implementation check reveals the task is bigger than expected (>3 files, unclear dependencies, design decisions needed), recommend the full pipeline instead.
+
+### 3. Implement
+
+Follow [coding-principles.md](coding-principles.md):
+
+- Simplest code that works
+- Touch ONLY listed files
+- No scope creep — fix the thing, nothing else
+
+### 4. Verify
+
+Run verification from step 2. Mark done only after verification passes.
+
+### 5. Commit
+
+Atomic commit following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>(<scope>): <description>
+```
+
+Use imperative mood, lowercase, no period. See [implement.md](implement.md) for full types table.
+
+Examples:
+
+- `fix(auth): prevent 401 on token refresh`
+- `feat(settings): add dark mode toggle`
+- `chore(deps): update eslint to v9`
+
+### 6. Track
+
+Update `.specs/project/STATE.md` with quick task record (see state-management.md Quick Tasks section).
+
+---
+
+## Structure
+
+Quick tasks live separately from planned features:
+
+```
+.specs/
+└── quick/
+    └── NNN-slug/
+        ├── TASK.md       # Description + verification
+        └── SUMMARY.md    # What was done + commit
+```
+
+**TASK.md template:**
+
+```markdown
+# Quick Task NNN: [Title]
+
+**Date:** [date]
+**Status:** Done | In Progress | Blocked
+
+## Description
+
+[One sentence: what and why]
+
+## Files Changed
+
+- `src/path/to/file.ts` — [what changed]
+- `src/path/to/other.ts` — [what changed]
+
+## Verification
+
+- [ ] [How to verify it works]
+- [ ] [Expected behavior after fix]
+
+## Commit
+
+`[hash]` — [commit message]
+```
+
+---
+
+## Guardrails
+
+- **Max 3 files** — If more, use full pipeline
+- **Max 1 hour** — If longer, scope is wrong
+- **No design decisions** — If you're choosing between approaches, use full pipeline
+- **No new dependencies** — Adding packages needs full pipeline review
+- **Track everything** — Even quick tasks get commits and STATE.md entries
+
+---
+
+## Tips
+
+- **Quick ≠ sloppy** — Same coding principles apply, just less ceremony
+- **When in doubt, go full** — Better to over-plan than to ship broken code
+- **Quick tasks compound** — If you're doing 5+ quick tasks for the same area, it's a feature that needs planning
+- **Verify before marking done** — The whole point is quality, even for small tasks

--- a/.claude/skills/tlc-spec-driven/references/roadmap.md
+++ b/.claude/skills/tlc-spec-driven/references/roadmap.md
@@ -1,0 +1,80 @@
+# Roadmap Creation
+
+**Trigger:** "Create roadmap", "Plan features", "Map project phases"
+
+## Process
+
+Based on PROJECT.md, decompose vision into:
+
+- Milestones (shippable increments)
+- Features (user-facing capabilities)
+- Status tracking (planned/in-progress/complete)
+
+## Output: .specs/project/ROADMAP.md
+
+**Structure:**
+
+```markdown
+# Roadmap
+
+**Current Milestone:** [milestone name]
+**Status:** Planning | In Progress | Complete
+
+---
+
+## [Milestone 1 Name]
+
+**Goal:** [What makes this milestone shippable]
+**Target:** [Date or completion criteria]
+
+### Features
+
+**[Feature Name]** - STATUS
+
+- [Capability 1]
+- [Capability 2]
+- [Capability 3]
+
+**[Feature Name]** - STATUS
+
+- [Capability 1]
+- [Capability 2]
+
+---
+
+## [Milestone 2 Name]
+
+**Goal:** [What this milestone adds]
+
+### Features
+
+**[Feature Name]** - PLANNED
+**[Feature Name]** - PLANNED
+
+---
+
+## Future Considerations
+
+- [Potential future capability]
+- [Potential future capability]
+```
+
+**Status values:**
+
+- PLANNED: Not started
+- IN PROGRESS: Currently implementing
+- COMPLETE: Shipped and verified
+
+**Size limit:** 3,000 tokens (~1,800 words)
+
+**Update strategy:**
+
+- Mark features PLANNED → IN PROGRESS when starting
+- Mark IN PROGRESS → COMPLETE when verified
+- Add new milestones as project evolves
+
+**Validation:**
+
+- Each milestone has clear shippable outcome?
+- Features are user-facing capabilities?
+- Status reflects current reality?

--- a/.claude/skills/tlc-spec-driven/references/session-handoff.md
+++ b/.claude/skills/tlc-spec-driven/references/session-handoff.md
@@ -1,0 +1,71 @@
+# Session Handoff
+
+## Pause Work
+
+**Trigger:** "Pause work", "End session", "Create handoff"
+
+**Purpose:** Checkpoint current state for resumption.
+
+**Output:** `.specs/HANDOFF.md` (overwrites previous)
+
+**Size target:** ~500 tokens
+
+**Structure:**
+
+```markdown
+# Handoff
+
+**Date:** [ISO timestamp]
+**Feature:** [feature name]
+**Task:** [task identifier] - [brief status]
+
+## Completed ✓
+
+- [Completed work item]
+- [Completed work item]
+
+## In Progress
+
+- [Current work] ([percentage or status])
+- Specific location: [file:line if applicable]
+
+## Pending
+
+- [Next immediate step]
+- [Following step]
+
+## Blockers
+
+- [Blocker description] - [impact]
+
+## Context
+
+- Branch: [git branch if applicable]
+- Uncommitted: [files with changes]
+- Related decisions: [STATE.md references if applicable]
+```
+
+**Instructions:**
+
+- Focus on actionable information for resumption
+- Include specific file/line references where relevant
+- Note uncommitted changes explicitly
+- Reference related STATE.md entries if applicable
+
+## Resume Work
+
+**Trigger:** "Resume work", "Continue", "Load handoff"
+
+**Process:**
+
+1. Load HANDOFF.md
+2. Load STATE.md for context
+3. Summarize current position
+4. Propose next action
+
+**Response pattern:**
+
+- "Resuming [feature] at [task]"
+- "Completed: [summary]"
+- "Next: [immediate action]"
+- "Continue with [specific step]?"

--- a/.claude/skills/tlc-spec-driven/references/specify.md
+++ b/.claude/skills/tlc-spec-driven/references/specify.md
@@ -1,0 +1,155 @@
+# Specify
+
+**Goal**: Capture WHAT to build with testable, traceable requirements.
+
+If the feature has ambiguous gray areas (multiple valid approaches for user-facing behavior), the agent will automatically trigger the [discuss gray areas](discuss.md) process within this phase. For clear, well-defined features, it goes straight to the next phase.
+
+## Process
+
+### 1. Clarify Requirements
+
+You are a thinking partner, not an interviewer. Start open — let the user dump their mental model. Follow the energy: whatever they emphasize, dig into that.
+
+Ask conversationally (not as a checklist):
+
+- "What problem are you solving?"
+- "Who is the user and what's their pain?"
+- "What does success look like?"
+
+If needed:
+
+- "What are the constraints (time, tech, resources)?"
+- "What is explicitly out of scope?"
+
+**Challenge vagueness.** Never accept fuzzy answers. "Good" means what? "Users" means who? "Simple" means how? Make the abstract concrete: "Walk me through using this." "What does that actually look like?"
+
+**Know when to stop.** When you understand what they're building, why, who it's for, and what done looks like — offer to proceed.
+
+### 2. Capture User Stories with Priorities
+
+**P1 = MVP** (must ship), **P2** (should have), **P3** (nice to have)
+
+Each story MUST be **independently testable** - you can implement and demo just that story.
+
+### 3. Write Acceptance Criteria
+
+Use **WHEN/THEN/SHALL** format - it's precise and testable:
+
+- WHEN [event/action] THEN [system] SHALL [response/behavior]
+
+---
+
+## Template: `.specs/[feature]/spec.md`
+
+```markdown
+# [Feature Name] Specification
+
+## Problem Statement
+
+[Describe the problem in 2-3 sentences. What pain point are we solving? Why now?]
+
+## Goals
+
+- [ ] [Primary goal with measurable outcome]
+- [ ] [Secondary goal with measurable outcome]
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature     | Reason         |
+| ----------- | -------------- |
+| [Feature X] | [Why excluded] |
+| [Feature Y] | [Why excluded] |
+
+---
+
+## User Stories
+
+### P1: [Story Title] ⭐ MVP
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P1**: [Why this is critical for MVP]
+
+**Acceptance Criteria**:
+
+1. WHEN [user action/event] THEN system SHALL [expected behavior]
+2. WHEN [user action/event] THEN system SHALL [expected behavior]
+3. WHEN [edge case] THEN system SHALL [graceful handling]
+
+**Independent Test**: [How to verify this story works alone - e.g., "Can demo by doing X and seeing Y"]
+
+---
+
+### P2: [Story Title]
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P2**: [Why this isn't MVP but important]
+
+**Acceptance Criteria**:
+
+1. WHEN [event] THEN system SHALL [behavior]
+2. WHEN [event] THEN system SHALL [behavior]
+
+**Independent Test**: [How to verify]
+
+---
+
+### P3: [Story Title]
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P3**: [Why this is nice-to-have]
+
+**Acceptance Criteria**:
+
+1. WHEN [event] THEN system SHALL [behavior]
+
+---
+
+## Edge Cases
+
+- WHEN [boundary condition] THEN system SHALL [behavior]
+- WHEN [error scenario] THEN system SHALL [graceful handling]
+- WHEN [unexpected input] THEN system SHALL [validation response]
+
+---
+
+## Requirement Traceability
+
+Each requirement gets a unique ID for tracking across design, tasks, and validation.
+
+| Requirement ID | Story       | Phase  | Status  |
+| -------------- | ----------- | ------ | ------- |
+| [FEAT]-01      | P1: [Story] | Design | Pending |
+| [FEAT]-02      | P1: [Story] | Design | Pending |
+| [FEAT]-03      | P2: [Story] | -      | Pending |
+
+**ID format:** `[CATEGORY]-[NUMBER]` (e.g., `AUTH-01`, `CART-03`, `NOTIF-02`)
+
+**Status values:** Pending → In Design → In Tasks → Implementing → Verified
+
+**Coverage:** X total, Y mapped to tasks, Z unmapped ⚠️
+
+---
+
+## Success Criteria
+
+How we know the feature is successful:
+
+- [ ] [Measurable outcome - e.g., "User can complete X in < 2 minutes"]
+- [ ] [Measurable outcome - e.g., "Zero errors in Y scenario"]
+```
+
+---
+
+## Tips
+
+- **P1 = Vertical Slice** — A complete, demo-able feature, not just backend or frontend
+- **WHEN/THEN is code** — If you can't write it as a test, rewrite it
+- **Requirement IDs are mandatory** — Every story maps to trackable IDs
+- **Edge cases matter** — What breaks? What's empty? What's huge?
+- **Out of Scope prevents creep** — If it's not here, it doesn't get built
+- **Confirm before Discuss** — User must approve spec before moving to discuss phase

--- a/.claude/skills/tlc-spec-driven/references/state-management.md
+++ b/.claude/skills/tlc-spec-driven/references/state-management.md
@@ -1,0 +1,130 @@
+# State Management
+
+**Purpose:** Persistent memory across sessions - decisions, blockers, learnings.
+
+## Structure
+
+**Output:** `.specs/project/STATE.md`
+
+```markdown
+# State
+
+**Last Updated:** [ISO timestamp]
+**Current Work:** [Feature name] - [Task identifier]
+
+---
+
+## Recent Decisions (Last 60 days)
+
+### AD-[NNN]: [Decision title] ([date])
+
+**Decision:** [What was decided]
+**Reason:** [Why this choice]
+**Trade-off:** [What was sacrificed]
+**Impact:** [How this affects implementation]
+
+### AD-[NNN]: [Decision title] ([date])
+
+[Same structure]
+
+---
+
+## Active Blockers
+
+### B-[NNN]: [Blocker description]
+
+**Discovered:** [Date]
+**Impact:** [Severity and scope]
+**Workaround:** [Temporary solution if available]
+**Resolution:** [Path to permanent fix]
+
+---
+
+## Lessons Learned
+
+### L-[NNN]: [Learning description]
+
+**Context:** [Situation that occurred]
+**Problem:** [What went wrong]
+**Solution:** [How it was resolved]
+**Prevents:** [What this knowledge prevents in future]
+
+---
+
+## Quick Tasks Completed
+
+| #   | Description              | Date   | Commit | Status  |
+| --- | ------------------------ | ------ | ------ | ------- |
+| 001 | [Quick task description] | [date] | [hash] | ✅ Done |
+
+---
+
+## Deferred Ideas
+
+Ideas captured during work that belong in future features or phases. Prevents scope creep while preserving good ideas.
+
+- [ ] [Idea description] — Captured during: [feature/phase]
+- [ ] [Idea description] — Captured during: [feature/phase]
+
+---
+
+## Todos
+
+Capture in-progress thoughts and action items that don't fit in active tasks.
+
+- [ ] [TODO: action item]
+- [ ] [TODO: action item]
+```
+
+## When to Update
+
+| Event                            | Action                                 |
+| -------------------------------- | -------------------------------------- |
+| Significant architectural choice | Add AD-[NNN]                           |
+| Implementation blocked           | Add B-[NNN]                            |
+| Important discovery/learning     | Add L-[NNN]                            |
+| Quick task completed             | Add row to Quick Tasks table           |
+| Scope creep captured             | Add to Deferred Ideas                  |
+| In-progress thought              | Add to Todos                           |
+| Session end                      | Update "Last Updated" + "Current Work" |
+
+## Size Management (Hybrid Strategy)
+
+**Zones:**
+
+- 🟢 <7k tokens: No action
+- 🟡 7-10k tokens: Footer note "STATE.md at [X]k. Cleanup recommended."
+- 🔴 >10k tokens: Active prompt "STATE.md critical ([X]k). Cleanup now?"
+
+**Cleanup process:**
+
+- Move decisions >60 days to STATE-ARCHIVE.md
+- Keep only active blockers
+- Preserve recent learnings (<60 days)
+
+**Validation:**
+
+- Decisions have clear rationale?
+- Blockers include resolution path?
+- Learnings are actionable?
+
+---
+
+## Preferences
+
+Track user-facing behavioral state in STATE.md:
+
+```markdown
+## Preferences
+
+**Model Guidance Shown:** [ISO date or "never"]
+```
+
+**Update when:**
+
+| Event                       | Action                   |
+| --------------------------- | ------------------------ |
+| First model tip given       | Set date                 |
+| User acknowledges/dismisses | Keep date (don't repeat) |
+
+This prevents repetitive suggestions while maintaining natural, helpful behavior.

--- a/.claude/skills/tlc-spec-driven/references/tasks.md
+++ b/.claude/skills/tlc-spec-driven/references/tasks.md
@@ -1,0 +1,419 @@
+# Tasks
+
+**Goal**: Break into GRANULAR, ATOMIC tasks. Clear dependencies. Right tools. Parallel execution plan.
+
+**Skip this phase when:** There are ≤3 obvious steps. In that case, tasks are implicit — go straight to Execute and list them inline in your implementation plan.
+
+## Why Granular Tasks?
+
+| Vague Task (BAD) | Granular Tasks (GOOD)             |
+| ---------------- | --------------------------------- |
+| "Create form"    | T1: Create email input component  |
+|                  | T2: Add email validation function |
+|                  | T3: Create submit button          |
+|                  | T4: Add form state management     |
+|                  | T5: Connect form to API           |
+| "Implement auth" | T1: Create login form             |
+|                  | T2: Create register form          |
+|                  | T3: Add token storage utility     |
+|                  | T4: Create auth API service       |
+|                  | T5: Add route protection          |
+
+**Benefits of granular:**
+
+- **Agents don't err** - Single focus, no ambiguity
+- **Easy to test** - Each task = one verifiable outcome
+- **Parallelizable** - Independent tasks run simultaneously
+- **Errors isolated** - One failure doesn't block everything
+
+**Rule**: One task = ONE of these:
+
+- One component
+- One function
+- One API endpoint
+- One file change
+
+---
+
+## Process
+
+### 1. Review Design
+
+Read `.specs/[feature]/design.md` before creating tasks.
+
+### 1.5. Load Test Coverage Matrix
+
+Read `.specs/codebase/TESTING.md` (if it exists) before creating tasks. The Test Coverage Matrix
+and Parallelism Assessment drive two critical decisions:
+
+**Co-located tests:** Every task that creates or modifies a code layer with a required test type
+MUST include writing/updating those tests in the same task. Tests are NOT separate tasks.
+
+| Task creates...                           | Done When must include...                   |
+| ----------------------------------------- | ------------------------------------------- |
+| Code layer with "unit" requirement        | Unit test written + quick gate passes       |
+| Code layer with "e2e" requirement         | E2E test written + full gate passes         |
+| Code layer with "integration" requirement | Integration test written + full gate passes |
+| Code layer with "none" requirement        | Gate check at appropriate level             |
+
+**Parallelism flags:** Cross-reference the Parallelism Assessment when marking tasks `[P]`:
+
+- If a task's required test type is marked "Parallel-Safe: No" → strip `[P]` flag
+- If a task's required test type is marked "Parallel-Safe: Yes" → `[P]` is allowed
+- If a task has no tests → `[P]` depends only on code dependencies
+
+If TESTING.md does not exist (greenfield project), ask the user what test types and commands
+the project will use before creating tasks.
+
+### 2. Break Into Atomic Tasks
+
+**Task = ONE deliverable**. Examples:
+
+- ✅ "Create UserService interface" (one file, one concept)
+- ❌ "Implement user management" (too vague, multiple files)
+
+### 3. Define Dependencies
+
+What MUST be done before this task can start?
+
+### 4. Create Execution Plan
+
+Group tasks into phases. Identify what can run in parallel.
+
+### 5. Validate Before Presenting (MANDATORY)
+
+Before showing tasks to the user, run ALL three pre-approval checks. These are NOT optional — they are gates. If any check fails, restructure the tasks and re-run until all pass.
+
+**Check 1: Task Granularity** — verify each task is atomic (see Granularity Check section).
+
+**Check 2: Diagram-Definition Cross-Check** — verify the execution diagram matches every task's `Depends on` field (see Diagram-Definition Cross-Check section). Build the cross-check table and include it in the output.
+
+**Check 3: Test Co-location Validation** — verify every task's `Tests` field matches the TESTING.md coverage matrix (see Test Co-location Validation section). Build the validation table and include it in the output.
+
+**Output both tables with the tasks** so the user can see the validation results. Any ❌ means you MUST restructure before presenting — do not show failing tasks to the user and ask them to approve.
+
+### 6. ASK About MCPs and Skills
+
+**CRITICAL**: Before execution, ask the user:
+
+> "For each task, which tools should I use?"
+>
+> **Available MCPs**: [list from project or user]
+> **Available Skills**: [list from project or user]
+
+---
+
+## Template: `.specs/[feature]/tasks.md`
+
+```markdown
+# [Feature] Tasks
+
+**Design**: `.specs/[feature]/design.md`
+**Status**: Draft | Approved | In Progress | Done
+
+---
+
+## Execution Plan
+
+### Phase 1: Foundation (Sequential)
+
+Tasks that must be done first, in order.
+```
+
+T1 → T2 → T3
+
+```
+
+### Phase 2: Core Implementation (Parallel OK)
+After foundation, these can run in parallel.
+
+```
+
+     ┌→ T4 ─┐
+
+T3 ──┼→ T5 ─┼──→ T8
+└→ T6 ─┘
+T7 ──────→
+
+```
+
+### Phase 3: Integration (Sequential)
+Bringing it all together.
+
+```
+
+T8 → T9
+
+---
+
+## Task Breakdown
+
+### T1: [Create X Interface]
+
+**What**: [One sentence: exact deliverable]
+**Where**: `src/path/to/file.ts`
+**Depends on**: None
+**Reuses**: `src/existing/BaseInterface.ts`
+**Requirement**: [FEAT]-01
+
+**Tools**:
+
+- MCP: `filesystem` (or NONE)
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Interface defined with all methods from design
+- [ ] Types exported correctly
+- [ ] No TypeScript errors
+
+**Tests**: [unit/e2e/integration/none — from coverage matrix]
+**Gate**: [quick/full/build — from gate check commands]
+
+---
+
+### T2: [Implement Y Service] [P]
+
+**What**: [Exact deliverable]
+**Where**: `src/services/YService.ts`
+**Depends on**: T1
+**Reuses**: `src/services/BaseService.ts` patterns
+
+**Tools**:
+
+- MCP: `filesystem`, `context7`
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Implements interface from T1
+- [ ] Handles error cases from design
+- [ ] Gate check passes: `[quick gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: unit
+**Gate**: quick
+
+---
+
+### T3: [Create Z Component] [P]
+
+**What**: [Exact deliverable]
+**Where**: `src/components/ZComponent.tsx`
+**Depends on**: T1
+**Reuses**: `src/components/BaseComponent.tsx`
+
+**Tools**:
+
+- MCP: `filesystem`
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Component renders correctly
+- [ ] Handles props from interface
+- [ ] Follows existing component patterns
+- [ ] Gate check passes: `[quick gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: unit
+**Gate**: quick
+
+---
+
+### T4: [Add A Feature to Y]
+
+**What**: [Exact deliverable]
+**Where**: `src/services/YService.ts` (modify)
+**Depends on**: T2, T3
+**Reuses**: Existing service patterns
+
+**Tools**:
+
+- MCP: `filesystem`, `github`
+- Skill: `api-design`
+
+**Done when**:
+
+- [ ] Feature works per acceptance criteria
+- [ ] Gate check passes: `[full gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: integration
+**Gate**: full
+
+**Commit**: `feat([scope]): [description]`
+
+---
+
+## Parallel Execution Map
+
+Visual representation of what can run simultaneously:
+
+```
+
+Phase 1 (Sequential):
+  T1 ──→ T2 ──→ T3
+
+Phase 2 (Parallel):
+  T3 complete, then:
+    ├── T4 [P]
+    ├── T5 [P]  } Can run simultaneously
+    └── T6 [P]
+
+Phase 3 (Sequential):
+  T4, T5, T6 complete, then:
+    T7 ──→ T8
+
+```
+
+**Parallelism constraint:** A task marked `[P]` must have ALL of these:
+
+- No unfinished dependencies
+- Required test type is parallel-safe (per TESTING.md Parallelism Assessment)
+- No shared mutable state with other `[P]` tasks in the same phase
+
+If a task's tests are NOT parallel-safe, it MUST run sequentially even if its
+implementation code has no dependencies. The test execution is the bottleneck.
+
+**How parallel execution works:**
+
+Tasks marked `[P]` are executed via sub-agents — one sub-agent per task, launched concurrently.
+Each sub-agent receives only its task definition and relevant project context (see Sub-Agent
+Delegation in SKILL.md). The orchestrating agent waits for all sub-agents in a phase to complete
+before advancing to the next phase.
+
+Sequential tasks (no `[P]`) are also delegated to sub-agents, but one at a time. This keeps
+implementation artifacts (file reads, test output, gate check logs) out of the main context.
+
+**The orchestrating agent's role during Execute:**
+1. Pick the next task(s) to execute
+2. Provide each sub-agent with its task definition + context
+3. Monitor sub-agent completion
+4. Update tasks.md with results
+5. Decide whether to proceed, fix, or escalate
+
+---
+
+## Task Granularity Check
+
+Before approving tasks, verify they are granular enough:
+
+| Task                            | Scope         | Status       |
+| ------------------------------- | ------------- | ------------ |
+| T1: Create email input          | 1 component   | ✅ Granular  |
+| T2: Add validation function     | 1 function    | ✅ Granular  |
+| T3: Create form with all fields | 5+ components | ❌ Split it! |
+| T4: Connect to API              | 1 function    | ✅ Granular  |
+
+**Granularity check**:
+
+- ✅ 1 component / 1 function / 1 endpoint = Good
+- ⚠️ 2-3 related things in same file = OK if cohesive
+- ❌ Multiple components or files = MUST split
+
+---
+
+## Diagram-Definition Cross-Check
+
+Before approving tasks, verify the execution diagram is consistent with the task definitions. These are independent artifacts that can drift — the diagram is drawn for visual clarity while task bodies are written for precision. Both must agree.
+
+For each task, check:
+
+| Task | Depends On (task body) | Diagram Shows | Status |
+| ---- | ---------------------- | ------------- | ------ |
+| T[N] | [deps from body] | [deps from diagram arrows] | ✅ Match or ❌ Mismatch |
+
+**Rules:**
+
+- Every `Depends on` in a task body must have a corresponding arrow in the diagram.
+- Every arrow in the diagram must correspond to a `Depends on` in the target task's body.
+- Tasks shown as parallel (`[P]`) in the diagram must not depend on each other.
+- If a task depends on another task in the same parallel phase, they are NOT parallel — fix the diagram or remove the `[P]` flag.
+
+---
+
+## Test Co-location Validation
+
+Before approving tasks, verify EVERY task's `Tests` field is consistent with the TESTING.md Test Coverage Matrix. This is a hard gate — tasks that fail this check MUST be fixed.
+
+For each task, check: does the task create or modify a code layer that has a required test type in the coverage matrix? If yes, the task's `Tests` field MUST match.
+
+| Task | Code Layer Created/Modified | Matrix Requires | Task Says | Status |
+| ---- | --------------------------- | --------------- | --------- | ------ |
+| T[N]: [name] | [layer from coverage matrix] | [test type] | [task's Tests field] | ✅ OK or ❌ VIOLATION |
+
+**Rules:**
+
+- "Tested in another task" is NOT a valid justification for `Tests: none`. That is test deferral — the exact anti-pattern this validation prevents.
+- `Tests: none` is only valid when the coverage matrix says "none" for that code layer.
+- If a task creates MULTIPLE code layers (e.g., service + controller), use the HIGHEST test type required by any of them.
+- Any ❌ VIOLATION → restructure the task to include its required tests before proceeding.
+
+**Resolving compilation dependencies:**
+
+When a task creates code that can't be tested until a later task completes (e.g., a controller that needs module wiring before its e2e tests can run), do NOT defer the tests to a separate task. Instead, restructure:
+
+1. **Merge forward:** Move the untestable task's tests into the earliest task where they become runnable (e.g., the wiring task includes wiring + e2e tests for the controller it enables).
+2. **Merge backward:** Absorb the blocking dependency into the current task so it becomes self-testable (e.g., controller task includes its own module registration).
+
+Pick whichever option keeps tasks atomic and cohesive. The goal: no task produces unverified code. If code can't be tested in the task that creates it, the task boundaries are wrong.
+
+---
+
+## Tips
+
+- **[P] = Parallel OK** — Mark tasks that can run simultaneously
+- **Reuses = Token saver** — Always reference existing code
+- **Tools per task** — MCPs and Skills prevent wrong approaches
+- **Dependencies are gates** — Clear what blocks what
+- **Done when = Testable** — If you can't verify it, rewrite it
+- **Requirement ID = Traceable** — Every task traces back to a spec requirement
+- **One commit per task** — Plan the commit message format in advance
+
+---
+
+## Task Verification Standards
+
+Every task MUST include:
+
+**Done when checklist:**
+
+- Specific, testable outcomes
+- Pass/fail criteria
+- The specific test command from the Gate Check Commands table
+- Expected pass count (prevents silent test deletion)
+
+**Verify section:**
+
+- Commands to prove functionality
+- Expected outputs
+- Success indicators
+
+**Structure:**
+
+```markdown
+### T1: [Task name]
+
+**What:** [Deliverable]
+**Where:** [File path]
+**Tests**: [unit/e2e/integration/none]
+**Gate**: [quick/full/build]
+
+**Done when:**
+
+- [ ] [Specific outcome]
+- [ ] [Specific outcome]
+- [ ] Gate check passes: `[command from Gate Check Commands]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Verify:**
+[Command to prove it works]
+[Expected output/behavior]
+```
+
+**Quality check:**
+
+- Can task be verified without human judgment?
+- Is success criteria binary (pass/fail)?
+- Can verification be automated?

--- a/.claude/skills/tlc-spec-driven/references/validate.md
+++ b/.claude/skills/tlc-spec-driven/references/validate.md
@@ -1,0 +1,256 @@
+# Execute: Validate & Verify
+
+**Goal**: Verify implementation meets spec AND coding principles. This is NOT a separate phase — verification is part of every task's completion within Execute.
+
+**Two levels of verification:**
+
+1. **Per-task verification (always):** After implementing each task, verify its "Done when" criteria before committing. This is mandatory and automatic.
+
+2. **Feature-level validation (on completion or on demand):** After all tasks for a feature (or priority group) are done, run a comprehensive validation. Includes acceptance criteria check, code quality review, and optionally interactive UAT.
+
+**Interactive UAT is triggered when:** The feature has complex user-facing behavior where human judgment matters (UI flows, interaction patterns, visual design). For backend-only or infrastructure work, automated checks are sufficient.
+
+**Trigger for explicit validation:** "Validate", "verify work", "UAT", "test with me", "walk me through it"
+
+---
+
+## Process
+
+### 1. Check Completed Tasks
+
+Go through tasks.md:
+
+- [ ] All tasks marked done?
+- [ ] Any blocked or partial?
+
+### 2. Verify Acceptance Criteria
+
+For each user story in spec.md:
+
+```markdown
+### P1: [Story Title]
+
+**Acceptance Criteria**:
+
+1. WHEN [X] THEN [Y] → [PASS/FAIL]
+2. WHEN [X] THEN [Y] → [PASS/FAIL]
+```
+
+### 3. Check Edge Cases
+
+From spec.md edge cases:
+
+- [ ] [Edge case 1] handled correctly
+- [ ] [Edge case 2] handled correctly
+
+### 4. Run Build-Level Gate Check (MANDATORY)
+
+Run the Build-level gate check from TESTING.md. This is NOT optional.
+
+If TESTING.md does not exist (greenfield project), use the gate command agreed upon with the user during the Tasks phase.
+
+1. Run: `[build gate command from TESTING.md, or the command agreed during planning]`
+2. Non-zero exit code = STOP. Do not proceed to Code Quality Check.
+3. Record results:
+   - Total test count: [N]
+   - Passed: [N]
+   - Failed: [list]
+   - Skipped: [list — each skip must be justified]
+
+**Test Integrity Check:**
+
+- Compare current test count against the count before this feature was implemented
+- If test count DECREASED: investigate why. Tests should only be deleted with explicit justification.
+- If assertions were weakened (less specific than before): flag as potential regression
+
+### 5. Code Quality Check (MANDATORY)
+
+For each changed file, verify against [coding-principles.md](coding-principles.md):
+
+| Check                                | Pass? |
+| ------------------------------------ | ----- |
+| No features beyond what was asked    |       |
+| No abstractions for single-use code  |       |
+| No unnecessary "flexibility" added   |       |
+| Only touched files required for task |       |
+| Didn't "improve" unrelated code      |       |
+| Matches existing patterns/style      |       |
+| Would senior engineer approve?       |       |
+
+❌ Any "No"? → Fix before marking complete.
+
+### 6. Interactive UAT (if user-facing feature)
+
+For each testable deliverable, present one test at a time:
+
+```
+Test [N]: [Test Name]
+
+Expected: [What should happen — specific and observable]
+
+→ Does this work? Describe what you see.
+```
+
+Wait for user response:
+
+| User says                      | Interpret as            |
+| ------------------------------ | ----------------------- |
+| "yes", "pass", "works", "next" | ✅ Pass                 |
+| "skip", "can't test", "n/a"    | ⏭️ Skip                 |
+| Anything else                  | ❌ Issue — log verbatim |
+
+**Severity inference (never ask the user for severity):**
+
+| User description contains               | Inferred severity |
+| --------------------------------------- | ----------------- |
+| crash, error, exception, fails, broken  | Blocker           |
+| doesn't work, wrong, missing, can't     | Major             |
+| slow, weird, off, minor, small          | Minor             |
+| color, font, spacing, alignment, visual | Cosmetic          |
+| (unclear)                               | Major (default)   |
+
+### 7. Generate Fix Plans (if issues found)
+
+For each issue found during UAT:
+
+1. **Diagnose** — Analyze the codebase to find root cause
+2. **Create fix task** — Write a task definition with:
+   - What: The specific fix
+   - Where: File paths
+   - Verify: How to prove the fix works
+   - Done when: Acceptance criteria for the fix
+3. **Present fix plan** — Show all fix tasks to user for approval
+
+Fix tasks follow the same format as regular tasks and can be executed with the implement phase.
+
+**Guardrail:** Maximum 3 diagnostic iterations per issue. If root cause isn't found after 3 attempts, flag for human investigation.
+
+### 8. Report
+
+---
+
+## Validation Report Template
+
+```markdown
+# [Feature] Validation
+
+**Date**: [YYYY-MM-DD]
+**Spec**: `.specs/features/[feature]/spec.md`
+
+---
+
+## Task Completion
+
+| Task | Status     | Notes   |
+| ---- | ---------- | ------- |
+| T1   | ✅ Done    | -       |
+| T2   | ✅ Done    | -       |
+| T3   | ⚠️ Partial | [Issue] |
+
+---
+
+## User Story Validation
+
+### P1: [Story Title] ⭐ MVP
+
+| Criterion     | Result  |
+| ------------- | ------- |
+| WHEN X THEN Y | ✅ PASS |
+| WHEN A THEN B | ✅ PASS |
+
+**Status**: ✅ P1 Complete
+
+### P2: [Story Title]
+
+| Criterion     | Result             |
+| ------------- | ------------------ |
+| WHEN X THEN Y | ❌ FAIL - [reason] |
+
+**Status**: ⚠️ P2 Issues
+
+---
+
+## Interactive UAT Results (if performed)
+
+| #   | Test        | Result   | Details                                         |
+| --- | ----------- | -------- | ----------------------------------------------- |
+| 1   | [Test name] | ✅ Pass  | -                                               |
+| 2   | [Test name] | ❌ Issue | [Verbatim user response] — Severity: [inferred] |
+| 3   | [Test name] | ⏭️ Skip  | [Reason]                                        |
+
+---
+
+## Code Quality
+
+| Principle        | Status |
+| ---------------- | ------ |
+| Minimum code     | ✅     |
+| Surgical changes | ✅     |
+| No scope creep   | ✅     |
+| Matches patterns | ✅     |
+
+---
+
+## Edge Cases
+
+- [x] Edge case 1: Handled correctly
+- [ ] Edge case 2: NOT handled - needs fix
+
+---
+
+## Tests
+
+- **Gate command**: [full command]
+- **Result**: [X] passed, [Y] failed, [Z] skipped
+- **Test count before feature**: [N]
+- **Test count after feature**: [M]
+- **Delta**: [+(M - N) new tests]
+- **Skipped tests**: [list with justification for each]
+- **Failures**: [list with details]
+
+---
+
+## Fix Plans (if issues found)
+
+### Fix 1: [Issue description]
+
+- **Root cause**: [What's actually wrong]
+- **Fix task**: [Task definition]
+- **Priority**: [Blocker/Major/Minor/Cosmetic]
+
+---
+
+## Requirement Traceability Update
+
+Update spec.md requirement statuses:
+
+| Requirement | Previous Status | New Status   |
+| ----------- | --------------- | ------------ |
+| [FEAT]-01   | Implementing    | ✅ Verified  |
+| [FEAT]-02   | Implementing    | ❌ Needs Fix |
+
+---
+
+## Summary
+
+**Overall**: ✅ Ready | ⚠️ Issues | ❌ Not Ready
+
+**What works**: [List]
+
+**Issues found**: [Issue 1: How to fix]
+
+**Next steps**: [Action]
+```
+
+---
+
+## Tips
+
+- **P1 first** — MVP must work before P2/P3
+- **WHEN/THEN = Test** — Each criterion is a test case
+- **Be specific** — "Doesn't work" isn't helpful
+- **Recommend fixes** — Don't just report problems, create fix tasks
+- **Quality check is mandatory** — Not optional
+- **Infer severity** — Never ask the user "how bad is this?"
+- **Max 3 diagnostic iterations** — Prevents infinite investigation loops
+- **Update traceability** — Every verified requirement updates spec.md status

--- a/.cursor/skills/codenavi/.skill-meta.json
+++ b/.cursor/skills/codenavi/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "23ac05b7f2d8df8311129d41432eba248bdcf14e9ace3f17c581976f7d888ada",
+  "downloadedAt": 1776159583971
+}

--- a/.cursor/skills/codenavi/SKILL.md
+++ b/.cursor/skills/codenavi/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: codenavi
+description: Your pathfinder for navigating unknown codebases. Investigates with precision, implements surgically, and never assumes — if it doesn't know, it says so. Maintains a .notebook/ knowledge base that grows across sessions, turning every discovery into lasting intelligence. Summons available skills, MCPs, and docs when the mission demands. Use when fixing bugs, implementing features, refactoring, investigating flows, or any development task in unfamiliar territory. Triggers on "fix this", "implement this", "how does this work", "investigate this flow", "help me with this code". Do NOT use for greenfield scaffolding, CI/CD, or infrastructure provisioning.
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: '1.0.0'
+---
+
+# CodeNavi
+
+You are the developer's companion — a methodical pathfinder for navigating unfamiliar, messy, or undocumented codebases. You investigate before acting, execute with surgical precision, and never assume what you don't know. Every discovery you make becomes lasting intelligence in the project's `.notebook/`. You and the developer are on this quest together. Your job is to make the mission succeed — no wasted effort, no guesswork, no collateral damage.
+
+## The Golden Rules
+
+These rules override everything else. They are non-negotiable.
+
+1. **Never assume, never invent.** If you don't know, say "I don't know — I need more context." Uncertainty is always explicit.
+2. **If it cost investigation, it deserves a note.** Knowledge that would take time to rediscover goes into `.notebook/`.
+3. **Pointers, not copies.** Reference code by `file:function()` or `file` (L10-25). Never paste code blocks into notes.
+4. **Surgical precision.** Touch only what the mission requires. Match existing style. Leave unrelated code alone.
+5. **Verify against source, not memory.** Language best practices, API signatures, framework behavior — always confirm with current documentation before acting.
+
+## Mission Cycle
+
+Every task follows this cycle. No exceptions, no shortcuts.
+
+```
+BRIEFING → RECON → PLAN → EXECUTE → VERIFY → DEBRIEF
+```
+
+### Step 1: Briefing
+
+Understand the mission before moving.
+
+1. Read `.notebook/INDEX.md` if it exists. This is your accumulated intelligence about the project — use it.
+2. Listen to the developer's request. Identify:
+   - What is the objective?
+   - What does success look like?
+   - What constraints exist?
+3. If anything is unclear, ask. Do not proceed with ambiguity. Frame questions precisely: "I need to understand X before I can Y."
+4. Scan for allies — check what tools, skills, and MCPs are available in the current environment. Note them for later use.
+
+Expected output: A clear understanding of what needs to happen and why.
+
+### Step 2: Recon
+
+Investigate the relevant parts of the codebase. Only the relevant parts.
+
+1. Start from the entry point closest to the problem. Do not read the entire project.
+2. Trace the flow that relates to the mission. Follow imports, calls, and data paths.
+3. Check `.notebook/` entries that might be relevant (INDEX.md tags).
+4. Note what you find — patterns, conventions, surprises, gotchas. Hold these for the Debrief.
+
+Token discipline during Recon:
+
+- Read function signatures and key logic, not every line of every file.
+- If a file is large, read the relevant section, not the whole file.
+- Use search/grep to find what you need instead of reading sequentially.
+- If the project has existing docs, check them first.
+
+Expected output: Enough understanding to form a plan. No more.
+
+### Step 3: Plan
+
+Present the plan before executing. Always.
+
+```
+Mission: [one sentence]
+Approach:
+1. [Step] → verify: [how to confirm it worked]
+2. [Step] → verify: [how to confirm it worked]
+3. [Step] → verify: [how to confirm it worked]
+Risk: [what could go wrong and how to handle it]
+```
+
+Rules for planning:
+
+- Each step has a verification criterion. No vague steps.
+- If the plan requires knowledge you're unsure about, flag it: "I need to verify X before step N — will consult docs."
+- If the plan is trivial (rename a variable, fix a typo), keep it proportional — a one-liner plan for a one-liner fix.
+- Wait for developer confirmation before executing. If the developer has given prior authorization to proceed autonomously on simple tasks, respect that — but still show the plan.
+
+Expected output: A plan the developer can approve, modify, or reject.
+
+### Step 4: Execute
+
+Implement the approved plan. Follow these principles:
+
+**Simplicity first**
+
+- Minimum code that solves the problem. Nothing speculative.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No premature flexibility or configurability.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+**Surgical changes**
+
+- Only touch what the plan requires.
+- Match existing code style, even if you'd do it differently.
+- If your changes create orphaned imports or variables, clean them.
+- Do NOT clean pre-existing dead code unless asked.
+- Every changed line traces directly to the mission objective.
+
+**Verify knowledge before applying it**
+
+- Before using any API, framework method, or language feature you're not 100% certain about, consult documentation.
+- Follow the Knowledge Verification Chain (see below).
+- Follow the language's official best practices and conventions.
+- If best practices conflict with the project's existing style, raise it to the developer — don't silently change conventions.
+
+For detailed coding principles, read `references/coding-principles.md`.
+
+Expected output: Clean implementation that solves exactly what was asked.
+
+### Step 5: Verify
+
+Validate the work against the plan's success criteria.
+
+1. Check each verification criterion from the Plan.
+2. If tests exist, run them. If the mission was a bug fix, confirm the bug no longer reproduces.
+3. If something doesn't pass, fix it before declaring success.
+4. If you cannot verify (no tests, no way to run the code), be explicit: "I cannot verify this automatically — here's what to check manually: [specific steps]."
+
+Expected output: Confirmation that the mission is complete, or a clear statement of what still needs attention.
+
+### Step 6: Debrief
+
+The mission is done. Now capture what you learned.
+
+Ask yourself: "Did I discover anything during this mission that would cost time to rediscover?"
+
+**Triggers for creating a note:**
+
+- You had to read 3+ files to understand a flow → document the flow
+- Something didn't work as the name or interface suggested → gotcha
+- You found a pattern the codebase repeats → document the pattern
+- You encountered a business term that isn't obvious → domain entry
+- You found a dependency or integration that's not straightforward → flow
+
+**Triggers for updating an existing note:**
+
+- New information enriches a note you read during Recon
+- A gotcha you documented now has a known fix
+- A flow changed because of the work you just did
+
+**Triggers for NOT creating a note:**
+
+- The discovery is trivial (obvious from file names or comments)
+- The information exists in the project's own documentation
+- The note would be a copy of what's already in the code
+
+For the `.notebook/` format specification, read `references/notebook-spec.md`.
+
+Expected output: Updated `.notebook/` with new intelligence, or explicit decision that nothing worth noting was discovered.
+
+## Summon System
+
+You don't work alone. Before struggling with a task, check your allies.
+
+### Priority order for summoning help:
+
+1. **Available skills** — Check if another loaded skill handles part of the task better (e.g., a skill for creating documents, a skill for specific frameworks). Use `view` on the available skills list if unsure.
+
+2. **MCP servers** — Check if connected MCPs provide relevant tools. Priority MCPs for development:
+
+- **Context7** → current documentation for any library or framework. Always prefer this for doc lookups.
+- **Any other connected MCP** that provides relevant capabilities.
+
+3. **Web search** — When no MCP can answer, search the web for current documentation, Stack Overflow solutions, or GitHub issues.
+
+4. **Built-in tools** — File operations, bash commands, code execution — use what's available in the environment.
+
+### Knowledge Verification Chain
+
+When you need to verify how something works:
+
+```
+Step 1: Check .notebook/ — maybe you already documented this
+Step 2: Check project's own docs (README, docs/, comments)
+Step 3: MCP Context7 → official, up-to-date documentation
+Step 4: Web search → official docs, reputable sources
+Step 5: Say "I'm not certain about X — here's my best understanding based on general principles, but please verify: [reasoning]"
+```
+
+Never skip to step 5 if steps 1-4 are available. And step 5 is always flagged as uncertain — never presented as fact.
+
+## Adapting to Mission Scale
+
+Not every mission needs the full ceremony. Scale the cycle to the task.
+
+**Trivial** (typo fix, rename, simple change):
+
+- Briefing: understood → Plan: one-liner → Execute → Verify → Debrief: skip
+- Total: ~30 seconds of overhead
+
+**Standard** (bug fix, small feature, refactoring):
+
+- Full cycle. Plan is 3-5 steps. Debrief captures 0-2 notes.
+
+**Complex** (cross-module feature, architectural change, deep investigation):
+
+- Full cycle with extended Recon. Plan may need developer input at multiple points. Debrief likely produces 2-5 notes.
+
+**Exploration** (understanding a flow, onboarding to a module):
+
+- Recon IS the mission. Plan becomes "investigate X, document Y." Debrief is the primary deliverable.
+
+## Consistency Contract
+
+This is what the developer can always expect from you:
+
+1. You always read `.notebook/INDEX.md` first if it exists.
+2. You always show a plan before executing non-trivial changes.
+3. You never present uncertain information as fact.
+4. You never modify code outside the scope of the current mission.
+5. You always verify against current docs, not training memory.
+6. You always flag when you've reached the limit of what you know.
+7. You always capture valuable discoveries in `.notebook/`.
+8. You always summon allies when they can help.
+9. You always match the project's existing code style.
+10. You always communicate in the developer's language (the human language they use, not the programming language).
+
+## Examples
+
+### Example 1: Bug fix in unknown project
+
+Developer says: "The checkout is throwing a 500 error when the user applies a coupon. Fix it."
+
+```
+BRIEFING:
+- Read .notebook/INDEX.md → found entry on checkout flow
+- Opened .notebook/checkout-flow.md → flow starts at src/routes/checkout.ts:handleCheckout()
+- Objective: find and fix the 500 error on coupon application
+- Success: coupon applies without error, existing tests pass
+
+RECON:
+- Traced handleCheckout() → calls couponService.apply()
+- couponService.apply() calls external API at /api/v2/coupons/validate
+- Found: response schema changed — expects `discount_amount` but code reads `discountAmount` (camelCase vs snake_case mismatch)
+- Existing tests mock the old schema — that's why CI passes
+
+PLAN:
+1. Fix property access in couponService.apply() to use discount_amount → verify: unit test with real schema shape
+2. Update test mocks to match current API schema → verify: tests pass with corrected mocks
+3. Check for same pattern elsewhere in coupon module → verify: grep for discountAmount in src/services/coupon/
+Risk: other parts of the code may depend on the camelCase version. Will check before changing.
+
+EXECUTE: [implements after developer approves]
+
+VERIFY: tests pass, manual verification steps provided
+
+DEBRIEF:
+- Created .notebook/coupon-api-schema.md — documents the snake_case convention of the coupon API and the mismatch pattern
+- Updated INDEX.md with new entry
+```
+
+### Example 2: Understanding a flow
+
+Developer says: "How does the authentication work in this project?"
+
+```
+BRIEFING:
+- Read .notebook/INDEX.md → no auth-related entries yet
+- Objective: map the authentication flow and document it
+- Success: clear documentation of how auth works
+
+RECON:
+- Found entry point: src/middleware/auth.ts
+- Traced: auth middleware → jwt.verify() → userService.findById()
+- Refresh token logic in src/services/auth/refresh.ts
+- OAuth2 providers configured in src/config/oauth.ts (Google, GitHub)
+- Session stored in Redis (src/lib/redis.ts:sessionStore)
+
+PLAN:
+1. Document the complete auth flow from request to response → verify: developer confirms accuracy
+2. Note the refresh token rotation mechanism (single-use tokens) → verify: code matches documentation
+
+EXECUTE: [creates notebook entry]
+
+DEBRIEF:
+- Created .notebook/auth-flow.md with full flow documentation
+- Created .notebook/session-redis.md noting Redis session pattern
+- Updated INDEX.md
+```
+
+### Example 3: Summoning allies
+
+Developer says: "Add input validation to the user registration endpoint following Zod best practices."
+
+```
+BRIEFING:
+- Need current Zod documentation for best practices
+- Check: is Context7 MCP available?
+
+RECON:
+- Context7 available → fetch Zod documentation
+- Read current validation patterns from official docs
+- Check project: already uses Zod in src/schemas/ — existing pattern
+
+PLAN:
+1. Follow existing schema pattern in src/schemas/
+2. Create userRegistration schema using current Zod API → verify: schema validates correct input, rejects invalid
+3. Integrate with existing validation middleware → verify: endpoint returns 400 with proper error messages
+```

--- a/.cursor/skills/codenavi/references/coding-principles.md
+++ b/.cursor/skills/codenavi/references/coding-principles.md
@@ -1,0 +1,143 @@
+# Coding Principles
+
+Read this file during the Execute phase when implementing changes.
+These principles reduce common AI coding mistakes and ensure
+consistent, high-quality output.
+
+## 1. Think Before Coding
+
+Before writing any code:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple approaches exist, present them with tradeoffs.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+- If the developer's approach seems wrong, say so constructively.
+  Don't be sycophantic — honesty prevents bugs.
+
+## 2. Simplicity First
+
+Write the minimum code that solves the problem.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- No speculative optimization.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+The test: "Would a senior engineer say this is overcomplicated?"
+If yes, simplify.
+
+## 3. Surgical Changes
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated issues, mention them — don't fix them.
+
+When your changes create orphans:
+
+- Remove imports, variables, and functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line traces directly to the mission objective.
+
+## 4. Goal-Driven Execution
+
+Transform vague tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with verification checkpoints.
+Strong success criteria enable autonomous execution. Weak criteria
+("make it work") require constant clarification — ask for better
+criteria rather than guessing.
+
+## 5. Respect the Codebase
+
+You are a guest in this codebase. Act like it.
+
+- Use the same naming conventions already in the project.
+- Use the same file organization patterns.
+- Use the same error handling approach.
+- Use the same import style (named vs default, relative vs absolute).
+- If the project uses semicolons, use semicolons. If it doesn't, don't.
+
+If existing conventions conflict with language best practices, flag it
+to the developer. Don't silently introduce a different convention.
+
+## 6. Language Best Practices
+
+Always follow the official best practices for the language and
+frameworks in use. This means:
+
+- Use idiomatic patterns for the language (e.g., list comprehensions
+  in Python, Optional chaining in TypeScript).
+- Follow the official style guide when the project doesn't have its own.
+- Use current, non-deprecated APIs and methods.
+- Handle errors according to the language's conventions (try/catch,
+  Result types, error returns — whatever the ecosystem prefers).
+
+Critical: Never rely on training memory for API signatures, method
+parameters, or framework behavior. Always verify against current
+documentation using the Knowledge Verification Chain:
+
+```
+.notebook/ → project docs → MCP Context7 → web search → flag as uncertain
+```
+
+## 7. Dependencies and Imports
+
+When adding new dependencies or imports:
+
+- Check if the project already has a dependency that solves the
+  problem before adding a new one.
+- Check the project's package manager and lockfile for existing
+  versions.
+- If adding a new dependency, mention it to the developer with
+  rationale — never silently add packages.
+- Match the project's import style and ordering conventions.
+
+## 8. Error Handling
+
+- Handle errors that can realistically occur.
+- Don't add catch blocks for theoretically impossible scenarios.
+- Use the project's existing error handling patterns.
+- Error messages should be actionable — tell what happened and
+  what to do about it, not just "Something went wrong."
+- Never swallow errors silently (empty catch blocks) unless
+  there's an explicit reason documented in a comment.
+
+## 9. Testing
+
+When tests are part of the mission:
+
+- Write tests that verify behavior, not implementation details.
+- Test the contract (input → output), not internal state.
+- Name tests descriptively: "should reject expired coupon"
+  not "test1" or "coupon test."
+- If modifying existing code, run existing tests first to
+  establish a baseline.
+- If adding a bug fix, write a test that reproduces the bug
+  first, then fix it.
+
+When tests are NOT part of the mission:
+
+- Don't add tests unless asked.
+- But DO mention if the change is risky and untested:
+  "This change affects the payment flow but there are no tests
+  covering this path. Consider adding tests for [specific cases]."
+
+## 10. Comments
+
+- Don't add comments that restate the code.
+- Don't remove existing comments unless they're provably wrong.
+- Add comments only for non-obvious business logic or workarounds.
+- If you add a workaround, explain WHY it's necessary and link
+  to the relevant issue/ticket if available.
+- Match the project's commenting style and language (human language).

--- a/.cursor/skills/codenavi/references/notebook-spec.md
+++ b/.cursor/skills/codenavi/references/notebook-spec.md
@@ -1,0 +1,171 @@
+# .notebook/ Specification
+
+Read this file when you need to create or update notes during the
+Debrief phase, or when you need to understand the notebook format
+during Briefing.
+
+## Structure
+
+```
+.notebook/
+├── INDEX.md          # Always read first. Compact index of all notes.
+├── auth-flow.md      # Individual note files — flat by default.
+├── error-handling.md
+└── checkout-race.md
+```
+
+Notes start flat in the root of `.notebook/`. When volume exceeds
+~15 notes, organize into subdirectories by category:
+
+```
+.notebook/
+├── INDEX.md
+├── flows/
+│   ├── auth-flow.md
+│   └── checkout-flow.md
+├── patterns/
+│   └── error-handling.md
+├── gotchas/
+│   └── checkout-race.md
+└── domain/
+    └── coupon-types.md
+```
+
+Categories:
+
+- **flows** — How things work. Integrations, sequences, data paths.
+- **patterns** — How things are done here. Conventions, recurring structures.
+- **gotchas** — Traps. Bugs, quirks, counterintuitive behavior.
+- **domain** — Business concepts. Terminology, rules, logic not obvious in code.
+
+These categories are guidelines, not rigid rules. If a note fits
+multiple categories, pick the primary one. If none fits, put it in root.
+
+## INDEX.md Format
+
+The index must be compact. One line per note. The AI reads this every
+session, so every byte counts.
+
+```markdown
+# .notebook
+> Project intelligence — read before every mission
+
+Last updated: 2026-02-22
+
+- [auth-flow](auth-flow.md) — OAuth2 + refresh rotation | flow | auth, security
+- [error-handling](error-handling.md) — Error boundaries + custom hook | pattern | react, errors
+- [checkout-race](checkout-race.md) — Race condition on cart update | gotcha | checkout, cart
+- [coupon-types](coupon-types.md) — Percentage vs fixed vs BOGO rules | domain | coupons, pricing
+```
+
+Format per line:
+
+```
+- [slug](path) — summary (max ~80 chars) | category | tags
+```
+
+Rules for INDEX.md:
+
+- Keep summaries short and scannable.
+- Tags are lowercase, comma-separated. Use them for quick grep.
+- Update `Last updated` whenever the index changes.
+- If using subdirectories, paths include the folder: `flows/auth-flow.md`.
+- Sort by most recently updated, not alphabetically.
+
+## Individual Note Format
+
+Notes are telegraphic. Think field notes, not documentation.
+
+```markdown
+# Auth Flow
+> OAuth2 with refresh token rotation
+
+Entry: `src/middleware/auth.ts:authMiddleware()` (L12)
+Flow: middleware → `services/auth/jwt.ts:verify()` → `services/user/find.ts:findById()`
+
+Refresh: `services/auth/refresh.ts:rotateToken()`
+- Single-use tokens — consumed on refresh, new pair issued
+- Stored in Redis with TTL (see `lib/redis.ts:sessionStore`)
+
+OAuth providers: `config/oauth.ts` — Google, GitHub
+- Each provider maps to `services/auth/oauth/[provider].ts`
+
+Session: Redis-backed via `lib/redis.ts` (L45-62)
+
+Updated: 2026-02-22
+```
+
+### Format principles
+
+1. **Pointers, not copies.** Always reference as:
+   - `file/path.ts:functionName()` for functions
+   - `file/path.ts` (L10-25) for specific line ranges
+   - `file/path.ts:ClassName.method()` for class methods
+   Never paste code blocks into notes. Code changes; pointers
+   can be re-checked. Pasted code becomes stale lies.
+
+2. **One concept per note.** If it needs scrolling, split it.
+   A note about auth flow should not also cover session management
+   unless they're inseparable.
+
+3. **Minimal prose.** Use fragments, arrows, dashes. Not sentences.
+   "middleware → verify JWT → load user → attach to req" is better
+   than "The middleware first verifies the JWT token, then loads
+   the user from the database, and finally attaches it to the
+   request object."
+
+4. **Always include Entry point.** Every note should have a clear
+   starting point so the reader knows where to begin exploring.
+
+5. **Always include Updated date.** So the reader knows how fresh
+   the information is.
+
+6. **No opinions, only observations.** "Uses Redux for state" not
+   "Uses Redux instead of a better solution." If something is
+   genuinely problematic, state the observable impact:
+   "Redux store has 47 top-level keys — finding relevant state
+   requires searching across 12 reducers."
+
+## Creating the .notebook/ for the First Time
+
+When `.notebook/` doesn't exist yet:
+
+1. Create the directory.
+2. Create INDEX.md with the header only:
+
+   ```markdown
+   # .notebook
+   > Project intelligence — read before every mission
+
+   Last updated: [today]
+   ```
+
+3. Do NOT do a full project analysis. Notes are created organically
+   as you work. The first notes will come from your first mission's
+   Debrief.
+
+## Updating Notes
+
+When updating an existing note:
+
+1. Read the current content.
+2. Add, modify, or remove information based on what you discovered.
+3. Update the `Updated` date at the bottom.
+4. If the summary in INDEX.md changed, update it too.
+
+When information becomes invalid (e.g., a flow changed because of
+your work), update the note immediately — stale notes are worse
+than no notes.
+
+## Token Budget
+
+The entire `.notebook/` system is designed for progressive disclosure:
+
+- **INDEX.md** is read every session (~5-50 lines). Cost: minimal.
+- **Individual notes** are read only when relevant to the current
+  mission. The AI decides which to open based on INDEX.md tags.
+- **Total cost per session:** INDEX.md + 0-3 relevant notes.
+
+If INDEX.md grows beyond 50 entries, consider archiving old notes
+into an `archive/` subdirectory and removing them from the active
+index. Archived notes are still searchable but not loaded by default.

--- a/.cursor/skills/mermaid-studio/.skill-meta.json
+++ b/.cursor/skills/mermaid-studio/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "8a240b980cee9287a20ec6ea1e4837c5d6e43c756ab17fcebbf6b1087a609815",
+  "downloadedAt": 1776159535895
+}

--- a/.cursor/skills/mermaid-studio/SKILL.md
+++ b/.cursor/skills/mermaid-studio/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: mermaid-studio
+description: Expert Mermaid diagram creation, validation, and rendering with dual-engine output (SVG/PNG/ASCII). Supports all 20+ diagram types including C4 architecture, AWS architecture-beta with service icons, flowcharts, sequence, ERD, state, class, mindmap, timeline, git graph, sankey, and more. Features code-to-diagram analysis, batch rendering, 15+ themes, and syntax validation. Use when users ask to create diagrams, visualize architecture, render mermaid files, generate ASCII diagrams, document system flows, model databases, draw AWS infrastructure, analyze code structure, or anything involving "mermaid", "diagram", "flowchart", "architecture diagram", "sequence diagram", "ERD", "C4", "ASCII diagram". Do NOT use for non-Mermaid image generation, data plotting with chart libraries, or general documentation writing.
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: 1.0.1
+---
+
+# Mermaid Studio
+
+Expert-level Mermaid diagram creation, validation, and multi-format rendering. Creates diagrams from descriptions or code analysis, validates syntax, and renders to SVG, PNG, or ASCII with professional theming.
+
+## Golden Rules — Elegant Diagrams by Default
+
+Every diagram MUST follow these principles. They are not optional — they define the difference between a mediocre diagram and a gold-standard one.
+
+### Rule 1: Always Use an Init Directive for Professional Styling
+
+**NEVER** create a diagram without an `%%{init}` directive or frontmatter config. The default Mermaid theme produces harsh black lines and generic colors. Always apply a curated palette.
+
+**For general diagrams (flowchart, sequence, state, class, ERD):**
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#3730a3', 'lineColor': '#94a3b8',
+  'secondaryColor': '#10b981', 'tertiaryColor': '#f59e0b',
+  'background': '#ffffff', 'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1', 'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0', 'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff', 'textColor': '#334155'
+}}}%%
+```
+
+**⚠️ Font Warning:** Do NOT set `fontFamily` in theme variables. The Mermaid default font (`trebuchet ms, verdana, arial, sans-serif`) works everywhere. Setting `system-ui`, `Segoe UI`, or `-apple-system` will render as Times New Roman in headless Chromium (used by `mmdc`).
+
+**For C4 diagrams — see the dedicated C4 styling section below.**
+
+**For architecture-beta diagrams — see the dedicated AWS/Architecture section below.**
+
+### Rule 2: Soft Lines, Never Harsh Black
+
+The single biggest visual improvement is using `lineColor: '#94a3b8'` (slate-400) instead of the default black. This creates a modern, breathable diagram. For dark themes, use `lineColor: '#64748b'` (slate-500).
+
+### Rule 3: Limit Density — Breathe
+
+- Maximum 15 nodes per diagram (not 20 — fewer is more elegant)
+- Use `subgraph` or boundaries to create whitespace and visual grouping
+- Prefer LR (left-right) for process flows — it reads more naturally
+- Use invisible links (`A ~~~ B`) to add spacing when the layout is cramped
+
+### Rule 4: Meaningful Labels and Consistent Style
+
+- Node IDs: camelCase (`orderService`, not `s1` or `os`)
+- Labels: short, clear natural language (`[Order Service]`)
+- Arrows: action verbs with protocol info (`"Sends order via gRPC"`)
+- Descriptions: one-line, role-focused (`"Handles order lifecycle"`)
+
+### Rule 5: Color Harmony Over Color Variety
+
+Use max 3-4 colors per diagram. Map colors to meaning:
+
+- **Blue tones** (#4f46e5, #3b82f6) → primary systems, internal services
+- **Green tones** (#10b981, #059669) → success states, data stores
+- **Amber tones** (#f59e0b, #d97706) → external systems, warnings
+- **Slate tones** (#64748b, #94a3b8) → lines, borders, secondary elements
+- **Red tones** (#ef4444) → errors ONLY, never as decoration
+
+## Modes of Operation
+
+This skill operates in three modes based on user intent:
+
+| Mode       | Trigger                                           | What happens               |
+| ---------- | ------------------------------------------------- | -------------------------- |
+| **Create** | "draw a diagram of...", "visualize my..."         | Generates .mmd code only   |
+| **Render** | "render this mermaid", "convert to SVG/PNG/ASCII" | Renders existing .mmd      |
+| **Full**   | "create and render...", ambiguous requests        | Create → Validate → Render |
+
+Default to **Full** mode when intent is unclear.
+
+## Step 1: Understand the Request
+
+Before writing any Mermaid code, determine:
+
+1. **What to diagram** — system, flow, schema, architecture, code structure?
+2. **Which diagram type** — use the Decision Matrix below
+3. **Output format** — code only, SVG, PNG, or ASCII?
+4. **Theme preference** — ask only if rendering; default to `base` theme with curated palette
+
+### Diagram Type Decision Matrix
+
+| User describes...                              | Diagram Type  | Syntax keyword       |
+| ---------------------------------------------- | ------------- | -------------------- |
+| Process, algorithm, decision tree, workflow    | Flowchart     | `flowchart TD/LR`    |
+| API calls, message passing, request/response   | Sequence      | `sequenceDiagram`    |
+| Database schema, table relationships           | ERD           | `erDiagram`          |
+| OOP classes, domain model, interfaces          | Class         | `classDiagram`       |
+| State machine, lifecycle, transitions          | State         | `stateDiagram-v2`    |
+| High-level system overview (C4 Level 1)        | C4 Context    | `C4Context`          |
+| Applications, databases, services (C4 Level 2) | C4 Container  | `C4Container`        |
+| Internal components (C4 Level 3)               | C4 Component  | `C4Component`        |
+| Request flows with numbered steps              | C4 Dynamic    | `C4Dynamic`          |
+| Infrastructure, cloud deployment               | C4 Deployment | `C4Deployment`       |
+| Cloud services with icons (AWS/GCP/Azure)      | Architecture  | `architecture-beta`  |
+| Project timeline, scheduling                   | Gantt         | `gantt`              |
+| Proportional data, percentages                 | Pie           | `pie`                |
+| Brainstorming, hierarchical ideas              | Mindmap       | `mindmap`            |
+| Historical events, chronology                  | Timeline      | `timeline`           |
+| Branching strategy, git history                | Git Graph     | `gitGraph`           |
+| Flow quantities, resource distribution         | Sankey        | `sankey-beta`        |
+| X/Y data visualization                         | XY Chart      | `xychart-beta`       |
+| Priority matrix, strategic positioning         | Quadrant      | `quadrantChart`      |
+| Layout control, grid positioning               | Block         | `block-beta`         |
+| Network packets, protocol headers              | Packet        | `packet-beta`        |
+| Task boards, kanban workflow                   | Kanban        | `kanban`             |
+| User experience, satisfaction scoring          | User Journey  | `journey`            |
+| System requirements traceability               | Requirement   | `requirementDiagram` |
+
+If the user's description doesn't clearly map to one type, suggest 2-3 options with a brief rationale for each, then let them choose.
+
+### When to Load References
+
+Load reference files ONLY when needed for the specific diagram type:
+
+- **C4 diagrams** → Read `references/c4-architecture.md` BEFORE writing code
+- **AWS/Cloud architecture** → Read `references/aws-architecture.md` BEFORE writing code
+- **Code-to-diagram** → Read `references/code-to-diagram.md` BEFORE analyzing
+- **Theming/styling** → Read `references/themes.md` when user requests custom themes
+- **Syntax errors** → Read `references/troubleshooting.md` when validation fails
+- **Any diagram type details** → Read `references/diagram-types.md` for comprehensive syntax
+
+## Step 2: Create the Diagram
+
+### 2.1 — Write Mermaid Code
+
+Follow these principles in order of priority:
+
+1. **Elegance first** — every diagram must look professional with init directives and curated colors
+2. **Correctness** — valid syntax that renders without errors
+3. **Clarity** — meaningful labels, logical flow direction, clear relationships
+4. **Simplicity** — under 15 nodes per diagram; split complex systems into multiple
+5. **Consistency** — uniform naming (camelCase for IDs, descriptive labels in brackets)
+
+### 2.2 — Structure Rules
+
+```
+%% Diagram: [Purpose] | Author: [auto] | Date: [auto]
+%%{init: {'theme': 'base', 'themeVariables': { ... }}}%%
+[diagramType]
+    [content]
+```
+
+**CRITICAL:** The `%%{init}` directive MUST go on the very first non-comment line, BEFORE the diagram type declaration. Alternatively, use YAML frontmatter at the absolute start of the file.
+
+**Naming conventions:**
+
+- Node IDs: camelCase, descriptive (`orderService`, not `s1`)
+- Labels: natural language in brackets (`[Order Service]`)
+- Relationships: action verbs (`"Sends order to"`, `"Reads from"`)
+
+**Layout best practices:**
+
+- `TD` (top-down) for hierarchical flows and processes
+- `LR` (left-right) for timelines, pipelines, and sequential processes
+- `RL` for right-to-left reading contexts
+- Use `subgraph` to group related nodes; name subgraphs meaningfully
+- Add `direction` inside subgraphs when needed for different flow
+
+### 2.3 — Quick Reference Examples
+
+**Flowchart (with professional styling):**
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'primaryTextColor': '#fff',
+  'primaryBorderColor': '#3730a3', 'lineColor': '#94a3b8',
+  'secondaryColor': '#10b981', 'tertiaryColor': '#f59e0b',
+  'background': '#ffffff', 'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1', 'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0', 'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+flowchart TD
+    Start([Start]) --> Input[/User Input/]
+    Input --> Validate{Valid?}
+    Validate -->|Yes| Process[Process Data]
+    Validate -->|No| Error[Show Error]
+    Error --> Input
+    Process --> Save[(Save to DB)]
+    Save --> End([End])
+```
+
+For sequence diagram and ERD styling examples, read `references/themes.md`.
+
+**C4 Context (with MANDATORY elegant styling):**
+
+```mermaid
+C4Context
+    title System Context — E-Commerce Platform
+
+    Person(customer, "Customer", "Places orders online")
+    System(platform, "E-Commerce Platform", "Handles orders and payments")
+    System_Ext(payment, "Payment Gateway", "Processes transactions")
+    System_Ext(email, "Email Service", "Sends notifications")
+
+    Rel(customer, platform, "Uses", "HTTPS")
+    Rel(platform, payment, "Processes payments", "API")
+    Rel(platform, email, "Sends emails", "SMTP")
+
+    UpdateRelStyle(customer, platform, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(platform, payment, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(platform, email, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+**Architecture (AWS with Iconify icons):**
+
+```mermaid
+architecture-beta
+    group vpc(logos:aws-vpc)[VPC]
+
+    service api(logos:aws-api-gateway)[API Gateway] in vpc
+    service lambda(logos:aws-lambda)[Lambda] in vpc
+    service db(logos:aws-dynamodb)[DynamoDB] in vpc
+    service s3(logos:aws-s3)[S3 Bucket]
+
+    api:R --> L:lambda
+    lambda:R --> L:db
+    lambda:B --> T:s3
+```
+
+**IMPORTANT:** Architecture-beta diagrams with `logos:*` icons require icon pack registration. When rendering with the render script, use the `--icons logos` flag. If rendering in a markdown viewer that doesn't support icon packs, use the built-in icons (`cloud`, `database`, `disk`, `server`, `internet`) as fallback. Read `references/aws-architecture.md` for the complete icon catalog and rendering instructions.
+
+For comprehensive syntax of ALL diagram types, read `references/diagram-types.md`.
+
+## C4 Diagrams — Mandatory Styling Guide
+
+C4 diagrams have **fixed element styling** (blue boxes for systems, gray for persons, etc.), but their **relationship lines default to harsh black** which creates visual noise. You MUST apply these styling rules:
+
+### The C4 Styling Pattern
+
+Every C4 diagram MUST include these directives at the end:
+
+```
+    %% === MANDATORY STYLING ===
+    %% Apply soft line colors to ALL relationships
+    UpdateRelStyle(fromAlias, toAlias, $textColor="#475569", $lineColor="#94a3b8")
+    %% Repeat for each Rel() in the diagram
+
+    %% Optimize layout spacing
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Color Values Reference
+
+| Purpose           | Color     | Hex       | Notes                                    |
+| ----------------- | --------- | --------- | ---------------------------------------- |
+| Soft line color   | Slate-400 | `#94a3b8` | Replaces harsh default black             |
+| Line text color   | Slate-600 | `#475569` | Readable but not dominant                |
+| Accent line       | Blue-400  | `#60a5fa` | For highlighted or primary relationships |
+| Warning line      | Amber-500 | `#f59e0b` | For external/risky connections           |
+| Custom element bg | Emerald   | `#10b981` | For data stores or success highlights    |
+| Custom element bg | Indigo    | `#4f46e5` | For primary system emphasis              |
+
+### C4 Layout Tips
+
+**CRITICAL — Maximum 6 `Rel()` per diagram.** More than 6 relationships causes Dagre to route arrows through nodes, creating unreadable spaghetti. If your system needs more connections, split it into multiple focused diagrams.
+
+- Use `$c4ShapeInRow="3"` for most diagrams (prevents horizontal crowding)
+- Use `$c4ShapeInRow="2"` for diagrams with long labels
+- Use `$c4BoundaryInRow="1"` always (stacks boundaries vertically for clarity)
+- Apply `$offsetY="-10"` to `UpdateRelStyle` when labels overlap with elements
+- Prefer tree-shaped topologies (1 in, 1-2 out per node) over mesh topologies
+- Declare elements in flow order — the order of `Container()` declarations affects layout
+- Use directional `Rel_D`, `Rel_R`, etc. only as a last resort when auto-layout creates overlapping
+
+For comprehensive C4 syntax, examples, and patterns, read `references/c4-architecture.md`.
+
+## Step 3: Validate
+
+Before rendering, ALWAYS validate the Mermaid syntax:
+
+```bash
+node $SKILL_DIR/scripts/validate.mjs <file.mmd>
+```
+
+If validation fails:
+
+1. Read the error message carefully
+2. Consult `references/troubleshooting.md` for common fixes
+3. Fix the syntax and re-validate
+4. Maximum 3 fix attempts before asking the user for clarification
+
+## Step 4: Render
+
+### 4.1 — Setup (First Run Only)
+
+```bash
+bash $SKILL_DIR/scripts/setup.sh
+```
+
+This auto-installs both rendering engines and icon pack dependencies. Run once per environment.
+
+### 4.2 — Single Diagram Rendering
+
+```bash
+# SVG (default — best quality)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.svg
+
+# PNG (for documents/presentations)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.png --width 1200
+
+# ASCII (for terminals/READMEs)
+node $SKILL_DIR/scripts/render-ascii.mjs -i diagram.mmd
+
+# With icon packs (architecture-beta with AWS/tech icons)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.svg --icons logos,fa
+```
+
+The `--icons` flag registers Iconify packs before rendering. Packs: `logos` (AWS/tech), `fa` (Font Awesome). Use `logos` for AWS.
+
+### 4.3 — Batch Rendering
+
+For multiple diagrams at once:
+
+```bash
+node $SKILL_DIR/scripts/batch.mjs \
+  --input-dir ./diagrams \
+  --output-dir ./rendered \
+  --format svg \
+  --theme default \
+  --workers 4
+```
+
+### 4.4 — Available Themes
+
+**beautiful-mermaid (15):** `tokyo-night` | `tokyo-night-storm` | `tokyo-night-light` | `dracula` | `nord` | `nord-light` | `catppuccin-mocha` | `catppuccin-latte` | `github-dark` | `github-light` | `solarized-dark` | `solarized-light` | `one-dark` | `zinc-dark` | `zinc-light`
+
+**mermaid-cli native (5):** `default` | `forest` | `dark` | `neutral` | `base`
+
+Custom theme: `--theme base --config '{"theme":"base","themeVariables":{"primaryColor":"#4f46e5","lineColor":"#94a3b8"}}'`
+
+For the full theme catalog, read `references/themes.md`. The render script auto-selects the best engine (mmdc primary, beautiful-mermaid fallback, Puppeteer for icon packs).
+
+## Step 5: Code-to-Diagram (When Requested)
+
+When the user asks to visualize existing code or architecture:
+
+1. Read `references/code-to-diagram.md` for the analysis methodology
+2. Analyze the codebase to identify the right diagram type:
+   - Module dependencies → Flowchart or Class diagram
+   - API routes and handlers → Sequence diagram
+   - Database models/schemas → ERD
+   - Service architecture → C4 Container or Architecture diagram
+   - State machines in code → State diagram
+3. Generate the .mmd file **with proper init directives** (Golden Rule 1)
+4. Validate and render as usual
+
+## Troubleshooting Quick Reference
+
+| Symptom               | Likely Cause       | Fix                                                    |
+| --------------------- | ------------------ | ------------------------------------------------------ |
+| Diagram won't render  | Syntax error       | Run validate.mjs, check brackets/quotes                |
+| Labels cut off        | Text too long      | Shorten labels or use line breaks `<br/>`              |
+| Layout looks wrong    | Wrong direction    | Try different TD/LR/BT/RL                              |
+| Nodes overlap         | Too many nodes     | Split into subgraphs or multiple diagrams              |
+| Lines too dark/thick  | No init directive  | Add `%%{init}` with `lineColor: '#94a3b8'`             |
+| C4 lines overlapping  | No styling applied | Add `UpdateRelStyle` with offsets to each Rel          |
+| AWS icons not showing | No icon pack       | Use `--icons logos` flag or fallback to built-in icons |
+| `mmdc` not found      | Not installed      | Run `setup.sh`                                         |
+| Theme not applied     | Wrong engine       | beautiful-mermaid themes only work with that engine    |
+
+For comprehensive troubleshooting, read `references/troubleshooting.md`.
+
+## Output Conventions
+
+- Save .mmd source files alongside rendered outputs
+- Naming: `{purpose}-{type}.mmd` (e.g., `auth-flow-sequence.mmd`)
+- For batch: maintain input filename, change extension
+- Always provide both the .mmd source and rendered file to the user

--- a/.cursor/skills/mermaid-studio/assets/puppeteer-config.json
+++ b/.cursor/skills/mermaid-studio/assets/puppeteer-config.json
@@ -1,0 +1,10 @@
+{
+  "executablePath": "",
+  "args": [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu"
+  ],
+  "headless": true
+}

--- a/.cursor/skills/mermaid-studio/references/aws-architecture.md
+++ b/.cursor/skills/mermaid-studio/references/aws-architecture.md
@@ -1,0 +1,395 @@
+# AWS Architecture Diagrams — Complete Reference
+
+Load this file when the user requests cloud architecture diagrams, AWS infrastructure visualization, or `architecture-beta` diagrams.
+
+## Overview
+
+Mermaid's `architecture-beta` diagram type enables cloud architecture visualization with icons representing services. Combined with Iconify icon packs, it produces professional infrastructure diagrams with real AWS service icons.
+
+**CRITICAL LIMITATION — The "Arrow Distance" Bug:**
+Because `architecture-beta` is built on a rigid grid system without edge routing algorithms, diagrams with more than 6-8 nodes or complex crossing relationships will suffer from **massive, unreadable distances** between nodes and arrows crossing over boxes.
+
+**The Golden Rule for AWS Diagrams:**
+
+- **Simple (< 8 nodes, linear flow):** Use `architecture-beta` with `--icons logos`.
+- **Complex (> 8 nodes, microservices, multiple tiers):** You MUST use **Option A: C4 Container Diagram**. C4 uses the `dagre` layout engine which perfectly spaces nodes and routes arrows beautifully.
+
+**Important — Icon Rendering:**
+
+- `architecture-beta` requires Mermaid v11+
+- Icons from Iconify packs (`logos:aws-*`) require icon pack registration at render time — they do NOT work in static markdown renderers (GitHub, GitLab)
+- When rendering with the render script, use `--icons logos` to auto-register icon packs
+- For environments without icon pack support, the built-in icons (`cloud`, `database`, `disk`, `server`, `internet`) work everywhere as a fallback
+- For universal compatibility, consider using C4 diagrams with descriptive labels as an alternative
+
+## Basic Syntax
+
+```mermaid
+architecture-beta
+
+    group groupId(icon)[Label]
+
+    service serviceId(icon)[Label] in groupId
+
+    serviceA:R --> L:serviceB
+```
+
+### Building Blocks
+
+| Element          | Syntax                               | Purpose                                |
+| ---------------- | ------------------------------------ | -------------------------------------- |
+| Group            | `group id(icon)[Label]`              | Visual boundary (VPC, region, account) |
+| Service          | `service id(icon)[Label]`            | Individual service node                |
+| Service in group | `service id(icon)[Label] in groupId` | Service inside a group                 |
+| Edge             | `serviceA:Side --> Side:serviceB`    | Connection with direction              |
+
+### Edge Sides
+
+Edges connect from/to specific sides of services:
+
+- `L` — Left
+- `R` — Right
+- `T` — Top
+- `B` — Bottom
+
+```
+api:R --> L:lambda        %% api's right connects to lambda's left
+lambda:B --> T:db          %% lambda's bottom connects to db's top
+```
+
+### Edge Types
+
+```
+serviceA:R --> L:serviceB     %% Solid arrow (default)
+serviceA:R -- L:serviceB      %% Solid line (no arrow)
+```
+
+## Icon Options
+
+### Option 1: Iconify Icons (Best Visual Quality)
+
+Mermaid supports 200,000+ icons from iconify.design via `registerIconPacks()`. The `logos` pack provides the best AWS icons. To render with these icons, use `--icons logos` with the render script.
+
+**Format:** `logos:aws-{service-name}`
+
+### Option 2: Built-in Icons (Universal Compatibility)
+
+Available everywhere without any registration. Use these when targeting markdown renderers or when icon packs aren't available:
+`cloud`, `database`, `disk`, `internet`, `server`
+
+## AWS Service Icons Catalog (Iconify `logos` Pack)
+
+### Compute
+
+| Service    | Icon name (logos)             | Built-in fallback |
+| ---------- | ----------------------------- | ----------------- |
+| Lambda     | `logos:aws-lambda`            | `server`          |
+| EC2        | `logos:aws-ec2`               | `server`          |
+| ECS        | `logos:aws-ecs`               | `server`          |
+| Fargate    | `logos:aws-fargate`           | `server`          |
+| Elastic BK | `logos:aws-elastic-beanstalk` | `server`          |
+
+### Storage
+
+| Service | Icon name (logos)   | Built-in fallback |
+| ------- | ------------------- | ----------------- |
+| S3      | `logos:aws-s3`      | `disk`            |
+| EBS     | `logos:aws-ebs`     | `disk`            |
+| EFS     | `logos:aws-efs`     | `disk`            |
+| Glacier | `logos:aws-glacier` | `disk`            |
+
+### Database
+
+| Service     | Icon name (logos)       | Built-in fallback |
+| ----------- | ----------------------- | ----------------- |
+| RDS         | `logos:aws-rds`         | `database`        |
+| DynamoDB    | `logos:aws-dynamodb`    | `database`        |
+| ElastiCache | `logos:aws-elasticache` | `database`        |
+| Aurora      | `logos:aws-aurora`      | `database`        |
+| Redshift    | `logos:aws-redshift`    | `database`        |
+| DocumentDB  | `logos:aws-documentdb`  | `database`        |
+
+### Networking
+
+| Service     | Icon name (logos)                  | Built-in fallback |
+| ----------- | ---------------------------------- | ----------------- |
+| API Gateway | `logos:aws-api-gateway`            | `server`          |
+| CloudFront  | `logos:aws-cloudfront`             | `internet`        |
+| Route 53    | `logos:aws-route53`                | `internet`        |
+| ELB/ALB     | `logos:aws-elastic-load-balancing` | `server`          |
+| VPC         | `logos:aws-vpc`                    | `cloud`           |
+
+### Messaging
+
+| Service     | Icon name (logos)       | Built-in fallback |
+| ----------- | ----------------------- | ----------------- |
+| SQS         | `logos:aws-sqs`         | `server`          |
+| SNS         | `logos:aws-sns`         | `server`          |
+| EventBridge | `logos:aws-eventbridge` | `server`          |
+| Kinesis     | `logos:aws-kinesis`     | `server`          |
+
+### Integration & Orchestration
+
+| Service        | Icon name (logos)          | Built-in fallback |
+| -------------- | -------------------------- | ----------------- |
+| Step Functions | `logos:aws-step-functions` | `server`          |
+| AppSync        | `logos:aws-app-sync`       | `server`          |
+
+### Monitoring & Security
+
+| Service    | Icon name (logos)      | Built-in fallback |
+| ---------- | ---------------------- | ----------------- |
+| CloudWatch | `logos:aws-cloudwatch` | `server`          |
+| IAM        | `logos:aws-iam`        | `server`          |
+| Cognito    | `logos:aws-cognito`    | `server`          |
+| WAF        | `logos:aws-waf`        | `server`          |
+
+### DevOps & CI/CD
+
+| Service      | Icon name (logos)        | Built-in fallback |
+| ------------ | ------------------------ | ----------------- |
+| CodePipeline | `logos:aws-codepipeline` | `server`          |
+| CodeBuild    | `logos:aws-codebuild`    | `server`          |
+| CodeDeploy   | `logos:aws-codedeploy`   | `server`          |
+| ECR          | `logos:aws-ecr`          | `server`          |
+
+### ML/AI
+
+| Service   | Icon name (logos)     | Built-in fallback |
+| --------- | --------------------- | ----------------- |
+| SageMaker | `logos:aws-sagemaker` | `server`          |
+
+**Note:** Not all AWS services have icons in the `logos` pack. If a specific icon is not available, use the closest category-appropriate built-in icon as fallback. You can verify icon availability at https://icon-sets.iconify.design/?q=aws.
+
+## Architecture Patterns
+
+### Pattern 1: Three-Tier Web Application
+
+**With Iconify Icons (best quality — requires `--icons logos`):**
+
+```mermaid
+architecture-beta
+    group vpc(logos:aws-vpc)[VPC]
+    group publicSubnet(cloud)[Public Subnet] in vpc
+    group privateSubnet(cloud)[Private Subnet] in vpc
+    group dataSubnet(database)[Data Subnet] in vpc
+
+    service cdn(logos:aws-cloudfront)[CloudFront]
+    service alb(logos:aws-elastic-load-balancing)[ALB] in publicSubnet
+    service ecs(logos:aws-ecs)[ECS Fargate] in privateSubnet
+    service rds(logos:aws-aurora)[Aurora PostgreSQL] in dataSubnet
+    service cache(logos:aws-elasticache)[ElastiCache Redis] in dataSubnet
+
+    cdn:R --> L:alb
+    alb:R --> L:ecs
+    ecs:R --> L:rds
+    ecs:B --> T:cache
+```
+
+**With Built-in Icons (universal compatibility):**
+
+```mermaid
+architecture-beta
+    group vpc(cloud)[VPC]
+    group publicSubnet(cloud)[Public Subnet] in vpc
+    group privateSubnet(cloud)[Private Subnet] in vpc
+    group dataSubnet(database)[Data Subnet] in vpc
+
+    service cdn(internet)[CloudFront]
+    service alb(server)[ALB] in publicSubnet
+    service ecs(server)[ECS Fargate] in privateSubnet
+    service rds(database)[Aurora PostgreSQL] in dataSubnet
+    service cache(database)[ElastiCache Redis] in dataSubnet
+
+    cdn:R --> L:alb
+    alb:R --> L:ecs
+    ecs:R --> L:rds
+    ecs:B --> T:cache
+```
+
+### Pattern 2: Serverless API
+
+```mermaid
+architecture-beta
+    group api(cloud)[API Layer]
+    group storage(cloud)[Storage]
+
+    service gw(logos:aws-api-gateway)[API Gateway] in api
+    service auth(logos:aws-cognito)[Cognito] in api
+    service fn(logos:aws-lambda)[Lambda] in api
+    service dynamo(logos:aws-dynamodb)[DynamoDB] in storage
+    service s3(logos:aws-s3)[S3] in storage
+
+    gw:R --> L:fn
+    gw:B --> T:auth
+    fn:R --> L:dynamo
+    fn:B --> T:s3
+```
+
+### Pattern 3: Data Pipeline
+
+```mermaid
+architecture-beta
+    group sources(cloud)[Data Sources]
+    group pipeline(cloud)[Pipeline]
+    group analytics(cloud)[Analytics]
+
+    service s3raw(logos:aws-s3)[S3 Raw Data] in sources
+    service kinesis(logos:aws-kinesis)[Kinesis Stream] in sources
+    service glue(logos:aws-glue)[Glue ETL] in pipeline
+    service stepFn(logos:aws-step-functions)[Step Functions] in pipeline
+    service s3processed(logos:aws-s3)[S3 Processed] in pipeline
+    service athena(logos:aws-athena)[Athena] in analytics
+    service quicksight(logos:aws-quicksight)[QuickSight] in analytics
+
+    s3raw:R --> L:glue
+    kinesis:R --> L:glue
+    glue:R --> L:stepFn
+    stepFn:R --> L:s3processed
+    s3processed:R --> L:athena
+    athena:R --> L:quicksight
+```
+
+### Pattern 4: CI/CD Pipeline
+
+```mermaid
+architecture-beta
+    group source(cloud)[Source]
+    group build(cloud)[Build & Test]
+    group deploy(cloud)[Deploy]
+    group runtime(cloud)[Runtime]
+
+    service repo(logos:aws-codecommit)[CodeCommit] in source
+    service pipeline(logos:aws-codepipeline)[CodePipeline] in build
+    service codebuild(logos:aws-codebuild)[CodeBuild] in build
+    service ecr(logos:aws-ecr)[ECR] in build
+    service codedeploy(logos:aws-codedeploy)[CodeDeploy] in deploy
+    service ecs(logos:aws-ecs)[ECS Fargate] in runtime
+    service cw(logos:aws-cloudwatch)[CloudWatch] in runtime
+
+    repo:R --> L:pipeline
+    pipeline:R --> L:codebuild
+    codebuild:R --> L:ecr
+    ecr:R --> L:codedeploy
+    codedeploy:R --> L:ecs
+    ecs:B --> T:cw
+```
+
+## Rendering with Icon Packs
+
+### Using the Render Script
+
+To render architecture-beta diagrams with proper AWS icons:
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --format svg \
+  --icons logos
+```
+
+The `--icons logos` flag tells the render script to register the Iconify `logos` pack which includes all `logos:aws-*` icons. The render script uses a Puppeteer-based pipeline for icon-enabled rendering.
+
+### Multiple Icon Packs
+
+You can register multiple packs:
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --icons logos,fa
+```
+
+Available packs: `logos` (AWS + tech logos), `fa` (Font Awesome icons).
+
+### How Icon Registration Works
+
+The render script generates an HTML page with Mermaid loaded, registers icon packs via `mermaid.registerIconPacks()`, renders the diagram, and captures the SVG output. This is equivalent to:
+
+```javascript
+import mermaid from 'mermaid'
+
+mermaid.registerIconPacks([
+  {
+    name: 'logos',
+    loader: () => fetch('https://unpkg.com/@iconify-json/logos/icons.json').then((res) => res.json()),
+  },
+])
+```
+
+## Fallback Strategy
+
+When `architecture-beta` is not supported by the rendering environment OR icons don't render, use these alternatives:
+
+### Option A: C4 Container Diagram (Best Alternative)
+
+C4 diagrams work everywhere and convey the same information:
+
+```mermaid
+C4Container
+    title AWS Architecture — Serverless API
+
+    Container(gw, "API Gateway", "AWS", "REST API endpoint")
+    Container(auth, "Cognito", "AWS", "Authentication")
+    Container(fn, "Lambda", "Node.js", "Business logic")
+    ContainerDb(db, "DynamoDB", "AWS", "NoSQL storage")
+    ContainerDb(s3, "S3", "AWS", "Object storage")
+
+    Rel(gw, auth, "Authenticates", "JWT")
+    Rel(gw, fn, "Invokes", "Event")
+    Rel(fn, db, "Reads/writes", "SDK")
+    Rel(fn, s3, "Stores files", "SDK")
+
+    UpdateRelStyle(gw, auth, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(gw, fn, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(fn, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(fn, s3, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Option B: Flowchart with AWS Labels and Professional Styling
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#FF9900', 'primaryTextColor': '#232F3E',
+  'primaryBorderColor': '#c47600', 'lineColor': '#94a3b8',
+  'secondaryColor': '#527FFF', 'tertiaryColor': '#DD344C',
+  'background': '#ffffff', 'mainBkg': '#FFF8F0',
+  'nodeBorder': '#c47600', 'clusterBkg': '#FFF8F0',
+  'clusterBorder': '#d4a574', 'edgeLabelBackground': '#ffffff'
+}}}%%
+flowchart LR
+    subgraph AWS["AWS Cloud"]
+        subgraph VPC
+            ALB[ALB<br/>Load Balancer]
+            subgraph ECS["ECS Cluster"]
+                Svc1[Service A]
+                Svc2[Service B]
+            end
+            RDS[(Aurora<br/>PostgreSQL)]
+        end
+        S3[(S3 Bucket)]
+        CF[CloudFront]
+    end
+
+    Users([Users]) --> CF
+    CF --> ALB
+    ALB --> Svc1 & Svc2
+    Svc1 & Svc2 --> RDS
+    Svc1 --> S3
+```
+
+## Best Practices
+
+1. **Group by boundary** — VPC, subnet, region, account
+2. **Left-to-right flow** — request path should read naturally
+3. **Limit to 12 services max** — split complex architectures into multiple focused diagrams
+4. **Show only one concern per diagram** — networking, compute, data, separately
+5. **Include external systems** — show what connects from outside
+6. **Security boundaries** — show public vs private subnets
+7. **Use Iconify icons when rendering** — `logos:aws-*` for best visual quality
+8. **Use built-in icons for docs** — `cloud`, `database`, `disk`, `server`, `internet` for markdown compatibility
+9. **Always provide both versions** — one with Iconify icons for rendered output, one with built-in for inline markdown

--- a/.cursor/skills/mermaid-studio/references/c4-architecture.md
+++ b/.cursor/skills/mermaid-studio/references/c4-architecture.md
@@ -1,0 +1,473 @@
+# C4 Architecture Diagrams — Complete Reference
+
+Load this file when the user requests C4 diagrams or system architecture documentation. The C4 model provides four levels of abstraction.
+
+## CRITICAL: Mandatory Rules
+
+**Every C4 diagram MUST follow these rules.** Without them, Mermaid renders harsh black lines that overlap elements and make the diagram unreadable.
+
+1. **Max 6 `Rel()` per diagram.** More relationships cause Dagre to route arrows through nodes, creating unreadable spaghetti. Split complex systems into multiple focused diagrams.
+2. **Always style all relationships.** Apply `UpdateRelStyle` to every `Rel()` with soft line colors (see template below).
+3. **Max 6-8 elements per diagram.** Tree-shaped topology (1 in, 1-2 out per node) renders best. Avoid mesh connections.
+4. **Do NOT set `fontFamily`.** Mermaid's default font works everywhere. Setting `system-ui` or `Segoe UI` will render as Times New Roman in headless Chromium.
+
+### Template: Add This to Every C4 Diagram
+
+```
+    %% === MANDATORY: Apply to ALL Rel() references ===
+    UpdateRelStyle(fromAlias, toAlias, $textColor="#475569", $lineColor="#94a3b8")
+    %% Repeat for each relationship in the diagram
+
+    %% === MANDATORY: Layout optimization ===
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### When Labels Overlap Elements
+
+Add `$offsetX` and `$offsetY` to push labels away from elements:
+
+```
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetX="-40", $offsetY="20")
+```
+
+### Highlighting Important Relationships
+
+Use accent colors for critical paths while keeping other lines soft:
+
+```
+    %% Primary relationship — emphasized
+    UpdateRelStyle(client, api, $textColor="#1e40af", $lineColor="#3b82f6")
+
+    %% Secondary relationships — soft
+    UpdateRelStyle(api, db, $textColor="#475569", $lineColor="#94a3b8")
+
+    %% External/risky connection — warning
+    UpdateRelStyle(api, extPayment, $textColor="#92400e", $lineColor="#f59e0b")
+```
+
+## C4 Levels — When to Use Each
+
+| Level | Diagram      | Audience       | Purpose                               |
+| ----- | ------------ | -------------- | ------------------------------------- |
+| 1     | C4Context    | Everyone       | System boundaries and external actors |
+| 2     | C4Container  | Technical team | Applications, databases, services     |
+| 3     | C4Component  | Developers     | Internal module structure             |
+| 4     | C4Deployment | DevOps/SRE     | Infrastructure and deployment nodes   |
+| —     | C4Dynamic    | Technical team | Numbered request flows                |
+
+**Rule of thumb:** Context + Container diagrams are sufficient for most teams. Only create Component/Code diagrams when they genuinely add clarity.
+
+### Audience-Appropriate Recommendations
+
+- **Executives/PMs:** Context only
+- **Architects:** Context + Container
+- **Developers:** Context + Container + Components for their area
+- **DevOps/SRE:** Container + Deployment
+
+## Element Syntax
+
+### People and Systems
+
+```
+Person(alias, "Label", "Description")
+Person_Ext(alias, "Label", "Description")
+System(alias, "Label", "Description")
+System_Ext(alias, "Label", "Description")
+SystemDb(alias, "Label", "Description")
+SystemDb_Ext(alias, "Label", "Description")
+SystemQueue(alias, "Label", "Description")
+SystemQueue_Ext(alias, "Label", "Description")
+```
+
+### Containers
+
+```
+Container(alias, "Label", "Technology", "Description")
+Container_Ext(alias, "Label", "Technology", "Description")
+ContainerDb(alias, "Label", "Technology", "Description")
+ContainerDb_Ext(alias, "Label", "Technology", "Description")
+ContainerQueue(alias, "Label", "Technology", "Description")
+ContainerQueue_Ext(alias, "Label", "Technology", "Description")
+```
+
+### Components
+
+```
+Component(alias, "Label", "Technology", "Description")
+Component_Ext(alias, "Label", "Technology", "Description")
+ComponentDb(alias, "Label", "Technology", "Description")
+ComponentQueue(alias, "Label", "Technology", "Description")
+```
+
+### Boundaries
+
+```
+Enterprise_Boundary(alias, "Label") { ... }
+System_Boundary(alias, "Label") { ... }
+Container_Boundary(alias, "Label") { ... }
+Boundary(alias, "Label", "type") { ... }
+```
+
+### Relationships
+
+```
+Rel(from, to, "Label")
+Rel(from, to, "Label", "Technology")
+BiRel(from, to, "Label")
+Rel_U(from, to, "Label")       %% Upward
+Rel_D(from, to, "Label")       %% Downward
+Rel_L(from, to, "Label")       %% Leftward
+Rel_R(from, to, "Label")       %% Rightward
+Rel_Back(from, to, "Label")    %% Back relationship
+```
+
+**Layout control tip:** When auto-layout causes lines to overlap, use directional variants (`Rel_D`, `Rel_R`, etc.) to force arrows in a specific direction. This is the most effective way to avoid overlapping lines.
+
+### Deployment Nodes
+
+```
+Deployment_Node(alias, "Label", "Type") { ... }
+Deployment_Node(alias, "Label", "Type", "Description") { ... }
+Node(alias, "Label") { ... }
+Node_L(alias, "Label") { ... }
+Node_R(alias, "Label") { ... }
+```
+
+## Complete Examples (All With Mandatory Styling)
+
+### Level 1 — System Context
+
+```mermaid
+C4Context
+    title System Context — Order Management Platform
+
+    Person(customer, "Customer", "Places and tracks orders")
+    Person(admin, "Admin", "Manages products and fulfillment")
+
+    Enterprise_Boundary(company, "Company") {
+        System(orderPlatform, "Order Platform", "Manages the full order lifecycle")
+    }
+
+    System_Ext(paymentGW, "Payment Gateway", "Stripe — processes payments")
+    System_Ext(shipping, "Shipping Provider", "Handles delivery logistics")
+    System_Ext(emailSvc, "Email Service", "SendGrid — transactional emails")
+    System_Ext(analytics, "Analytics", "Mixpanel — usage tracking")
+
+    Rel(customer, orderPlatform, "Places orders, tracks status", "HTTPS")
+    Rel(admin, orderPlatform, "Manages catalog, fulfills orders", "HTTPS")
+    Rel(orderPlatform, paymentGW, "Processes payments", "REST API")
+    Rel(orderPlatform, shipping, "Creates shipments", "REST API")
+    Rel(orderPlatform, emailSvc, "Sends notifications", "SMTP/API")
+    Rel(orderPlatform, analytics, "Sends events", "HTTPS")
+
+    UpdateRelStyle(customer, orderPlatform, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(admin, orderPlatform, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(orderPlatform, paymentGW, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, shipping, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, emailSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, analytics, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Level 2 — Container
+
+**Keep container diagrams focused: max 6-8 elements and 6 Rel().** For complex systems, split into multiple diagrams (one per bounded context or service area).
+
+```mermaid
+C4Container
+    title Container Diagram — Order Platform
+
+    Person(customer, "Customer", "Places orders online")
+
+    System_Boundary(platform, "Order Platform") {
+        Container(spa, "Web App", "React", "Customer-facing storefront")
+        Container(api, "API Gateway", "NestJS", "Routes requests")
+        Container(orderSvc, "Order Service", "NestJS", "Order lifecycle")
+        ContainerDb(db, "Database", "PostgreSQL", "Orders and products")
+    }
+
+    System_Ext(paymentGW, "Stripe", "Payment processing")
+
+    Rel(customer, spa, "Uses", "HTTPS")
+    Rel(spa, api, "Calls", "JSON/HTTPS")
+    Rel(api, orderSvc, "Routes to", "gRPC")
+    Rel(orderSvc, db, "Reads/writes", "SQL")
+    Rel(orderSvc, paymentGW, "Processes payment", "REST API")
+
+    UpdateRelStyle(customer, spa, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(spa, api, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Level 3 — Component (Order Service)
+
+```mermaid
+C4Component
+    title Component Diagram — Order Service
+
+    Container_Boundary(orderSvc, "Order Service") {
+        Component(orderCtrl, "Order Controller", "NestJS Controller", "HTTP/gRPC endpoints")
+        Component(orderUseCase, "Order Use Cases", "Application Layer", "Create, cancel, fulfill orders")
+        Component(paymentPort, "Payment Port", "Interface", "Payment processing abstraction")
+        Component(orderRepo, "Order Repository", "TypeORM", "Order persistence")
+        Component(eventPub, "Event Publisher", "AMQP Client", "Publishes domain events")
+        Component(orderModel, "Order Aggregate", "Domain Model", "Business rules and invariants")
+    }
+
+    ContainerDb(orderDb, "Order DB", "PostgreSQL")
+    ContainerQueue(eventBus, "Event Bus", "RabbitMQ")
+    Container_Ext(paymentGW, "Stripe", "Payment API")
+
+    Rel(orderCtrl, orderUseCase, "Invokes")
+    Rel(orderUseCase, orderModel, "Operates on")
+    Rel(orderUseCase, paymentPort, "Uses")
+    Rel(orderUseCase, orderRepo, "Persists via")
+    Rel(orderUseCase, eventPub, "Publishes events")
+    Rel(orderRepo, orderDb, "SQL queries")
+    Rel(eventPub, eventBus, "AMQP")
+    Rel(paymentPort, paymentGW, "REST API")
+
+    UpdateRelStyle(orderCtrl, orderUseCase, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, orderModel, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, paymentPort, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, orderRepo, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, eventPub, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderRepo, orderDb, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(eventPub, eventBus, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(paymentPort, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Dynamic — Request Flow
+
+```mermaid
+C4Dynamic
+    title Dynamic Diagram — Place Order Flow
+
+    Container(spa, "Web App", "React")
+    Container(api, "API Gateway", "NestJS")
+    Container(orderSvc, "Order Service", "NestJS")
+    Container(paymentGW, "Stripe", "Payment API")
+    ContainerDb(db, "Order DB", "PostgreSQL")
+    ContainerQueue(bus, "Event Bus", "RabbitMQ")
+
+    Rel(spa, api, "1. POST /orders", "JSON/HTTPS")
+    Rel(api, orderSvc, "2. CreateOrder()", "gRPC")
+    Rel(orderSvc, db, "3. INSERT order (pending)", "SQL")
+    Rel(orderSvc, paymentGW, "4. Process payment", "REST")
+    Rel(orderSvc, db, "5. UPDATE order (confirmed)", "SQL")
+    Rel(orderSvc, bus, "6. Publish OrderConfirmed", "AMQP")
+    Rel(orderSvc, api, "7. Return order", "gRPC")
+    Rel(api, spa, "8. 201 Created", "JSON/HTTPS")
+
+    UpdateRelStyle(spa, api, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8", $offsetX="-30")
+    UpdateRelStyle(orderSvc, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+    UpdateRelStyle(orderSvc, bus, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, api, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+    UpdateRelStyle(api, spa, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Deployment
+
+```mermaid
+C4Deployment
+    title Deployment — Production Environment
+
+    Deployment_Node(cdn, "CloudFront", "CDN") {
+        Container(static, "Static Assets", "React Build", "JS/CSS/HTML")
+    }
+
+    Deployment_Node(aws, "AWS", "us-east-1") {
+        Deployment_Node(ecs, "ECS Cluster", "Fargate") {
+            Deployment_Node(apiTask, "API Task", "2 vCPU, 4GB") {
+                Container(api, "API Gateway", "NestJS")
+            }
+            Deployment_Node(orderTask, "Order Task", "2 vCPU, 4GB") {
+                Container(orderSvc, "Order Service", "NestJS")
+            }
+        }
+
+        Deployment_Node(rds, "RDS", "db.r6g.xlarge") {
+            ContainerDb(db, "Order DB", "PostgreSQL 16")
+        }
+
+        Deployment_Node(elasticache, "ElastiCache", "r6g.large") {
+            ContainerDb(cache, "Cache", "Redis 7")
+        }
+
+        Deployment_Node(mq, "Amazon MQ", "mq.m5.large") {
+            ContainerQueue(bus, "Event Bus", "RabbitMQ")
+        }
+    }
+
+    Rel(cdn, api, "Routes API calls", "HTTPS")
+    Rel(api, orderSvc, "Internal", "gRPC")
+    Rel(orderSvc, db, "Reads/writes", "SQL/TLS")
+    Rel(api, cache, "Caches", "Redis/TLS")
+    Rel(orderSvc, bus, "Publishes", "AMQP/TLS")
+
+    UpdateRelStyle(cdn, api, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(api, cache, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, bus, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Styling and Layout
+
+### Layout Configuration
+
+```
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Element Styling
+
+```
+UpdateElementStyle(alias, $fontColor="red", $bgColor="grey", $borderColor="red")
+```
+
+### Relationship Styling
+
+Use `$offsetX` and `$offsetY` to fix overlapping labels:
+
+```
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+```
+
+### Professional Color Palette for Custom Element Styles
+
+| Purpose              | bgColor   | fontColor | borderColor | When to use                     |
+| -------------------- | --------- | --------- | ----------- | ------------------------------- |
+| Primary emphasis     | `#4f46e5` | `#ffffff` | `#3730a3`   | Core systems, main service      |
+| Success / Data store | `#059669` | `#ffffff` | `#047857`   | Databases, completed states     |
+| Warning / External   | `#d97706` | `#ffffff` | `#b45309`   | External systems, risky paths   |
+| Error / Critical     | `#dc2626` | `#ffffff` | `#b91c1c`   | Error states ONLY               |
+| Neutral / Secondary  | `#64748b` | `#ffffff` | `#475569`   | Supporting services, background |
+| Info / Highlight     | `#0284c7` | `#ffffff` | `#0369a1`   | Informational annotations       |
+
+## Microservices Patterns
+
+### Single-Team Ownership
+
+When one team owns all services, model each as a **container**:
+
+```mermaid
+C4Container
+    title Microservices — Single Team
+
+    System_Boundary(platform, "E-commerce Platform") {
+        Container(orderSvc, "Order Service", "NestJS", "Order processing")
+        ContainerDb(orderDb, "Order DB", "PostgreSQL")
+        Container(inventorySvc, "Inventory Service", "NestJS", "Stock management")
+        ContainerDb(inventoryDb, "Inventory DB", "MongoDB")
+    }
+
+    Rel(orderSvc, orderDb, "Reads/writes", "SQL")
+    Rel(inventorySvc, inventoryDb, "Reads/writes", "MongoDB Wire")
+
+    UpdateRelStyle(orderSvc, orderDb, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(inventorySvc, inventoryDb, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+### Multi-Team Ownership
+
+When separate teams own services, promote them to **systems**:
+
+```mermaid
+C4Context
+    title Microservices — Multi-Team
+
+    Person(customer, "Customer")
+    System(orderSys, "Order System", "Team Alpha")
+    System(inventorySys, "Inventory System", "Team Beta")
+    System(paymentSys, "Payment System", "Team Gamma")
+
+    Rel(customer, orderSys, "Places orders")
+    Rel(orderSys, inventorySys, "Checks stock")
+    Rel(orderSys, paymentSys, "Processes payment")
+
+    UpdateRelStyle(customer, orderSys, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(orderSys, inventorySys, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSys, paymentSys, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Event-Driven Architecture
+
+Show individual topics/queues as containers — NOT a single "Kafka" box:
+
+```mermaid
+C4Container
+    title Event-Driven Architecture
+
+    Container(orderSvc, "Order Service", "Java", "Creates orders")
+    Container(stockSvc, "Stock Service", "Java", "Manages inventory")
+    ContainerQueue(orderTopic, "order.created", "Kafka", "Order events")
+    ContainerQueue(stockTopic, "stock.reserved", "Kafka", "Stock events")
+
+    Rel(orderSvc, orderTopic, "Publishes to")
+    Rel(stockSvc, orderTopic, "Subscribes to")
+    Rel(stockSvc, stockTopic, "Publishes to")
+    Rel(orderSvc, stockTopic, "Subscribes to")
+
+    UpdateRelStyle(orderSvc, orderTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(stockSvc, orderTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(stockSvc, stockTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, stockTopic, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+## Essential Rules
+
+1. **Every element must have:** Name, Type, Technology (where applicable), Description
+2. **Use unidirectional arrows** — bidirectional creates ambiguity
+3. **Label arrows with action verbs** — "Sends email using", not just "uses"
+4. **Include technology labels** — "JSON/HTTPS", "SQL", "gRPC"
+5. **Under 15 elements per diagram** — split if more (elegance > completeness)
+6. **Always include a title**
+7. **Meaningful aliases** — `orderService` not `s1`
+8. **ALWAYS add UpdateRelStyle** — soft line colors are mandatory
+9. **ALWAYS add UpdateLayoutConfig** — prevents element crowding
+
+## Common Mistakes
+
+| Mistake                  | Why it's wrong                  | Fix                                  |
+| ------------------------ | ------------------------------- | ------------------------------------ |
+| Shared lib as Container  | Containers are deployable units | Model as Component                   |
+| Single "Kafka" container | Hides topic structure           | Show individual topics               |
+| "Subcomponents" level    | Not a C4 concept                | Use Component or Class               |
+| Removing type labels     | Loses information               | Always show type/tech                |
+| Bidirectional arrows     | Ambiguous flow direction        | Use unidirectional                   |
+| No technology labels     | Can't assess architecture       | Add protocol/tech                    |
+| No UpdateRelStyle        | Harsh black lines               | Add soft colors to ALL relationships |
+| No UpdateLayoutConfig    | Elements crowd together         | Add layout config at end             |
+| No offset on overlap     | Labels hidden behind elements   | Add $offsetX/$offsetY to fix         |
+
+## File Naming Convention
+
+```
+docs/architecture/
+├── c4-context.md
+├── c4-containers.md
+├── c4-components-{feature}.md
+├── c4-deployment.md
+└── c4-dynamic-{flow}.md
+```

--- a/.cursor/skills/mermaid-studio/references/code-to-diagram.md
+++ b/.cursor/skills/mermaid-studio/references/code-to-diagram.md
@@ -1,0 +1,281 @@
+# Code-to-Diagram — Analysis Methodology
+
+Load this file when the user asks to visualize existing code, analyze a codebase, or generate diagrams from source files.
+
+## Workflow
+
+1. **Identify scope** — what part of the code to diagram
+2. **Choose analysis strategy** — which patterns to look for
+3. **Extract structure** — read relevant files
+4. **Select diagram type** — based on what was found
+5. **Generate diagram** — create .mmd file
+6. **Validate and render** — as usual
+
+## Analysis Strategies by Request Type
+
+### "Show me the architecture"
+
+**What to look for:**
+
+- Project root structure (folders, entry points)
+- Package.json / pyproject.toml / Cargo.toml for dependencies
+- Docker files, docker-compose.yml for services
+- Infrastructure-as-code (CDK, Terraform, CloudFormation, Pulumi)
+- Environment variables for external service connections
+
+**Recommended diagram:** C4 Container or Architecture (for cloud infra)
+
+**File exploration order:**
+
+1. Root directory listing
+2. docker-compose.yml / Dockerfile
+3. Infrastructure files (cdk/, terraform/, cloudformation/)
+4. Main entry point (src/main.ts, app.py, cmd/main.go)
+5. Config files for external connections
+
+### "Diagram the database schema"
+
+**What to look for:**
+
+- ORM models/entities (TypeORM, Prisma, SQLAlchemy, Drizzle)
+- Migration files
+- Schema definition files (.prisma, models.py, entities/)
+- Foreign key references
+- Enum definitions
+
+**Recommended diagram:** ERD
+
+**File exploration order:**
+
+1. Schema files (schema.prisma, models/, entities/)
+2. Migration files (for relationship confirmation)
+3. Seed files (for understanding data relationships)
+
+**Extraction rules:**
+
+- Each model/entity → ERD entity
+- Each field → attribute with type
+- `@relation` / ForeignKey → relationship
+- `@id` / primary_key → PK marker
+- `@unique` → UK marker
+- Foreign key fields → FK marker
+
+**Example — Prisma to ERD:**
+
+```prisma
+// Input: schema.prisma
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String
+  orders    Order[]
+  createdAt DateTime @default(now())
+}
+
+model Order {
+  id        String      @id @default(uuid())
+  userId    String
+  user      User        @relation(fields: [userId], references: [id])
+  items     OrderItem[]
+  total     Decimal
+  status    OrderStatus
+}
+```
+
+```mermaid
+%% Output: database-erd.mmd
+erDiagram
+    USER ||--o{ ORDER : "has orders"
+    ORDER ||--|{ ORDER_ITEM : "contains"
+
+    USER {
+        uuid id PK
+        string email UK
+        string name
+        datetime createdAt
+    }
+
+    ORDER {
+        uuid id PK
+        uuid userId FK
+        decimal total
+        enum status
+    }
+```
+
+### "Show me the API flow"
+
+**What to look for:**
+
+- Route definitions (controllers, routers, handlers)
+- Middleware chain
+- Service layer calls
+- External API calls
+- Database queries in the flow
+
+**Recommended diagram:** Sequence diagram
+
+**File exploration order:**
+
+1. Route/controller files
+2. Middleware definitions
+3. Service files called by controllers
+4. Repository/data-access files
+
+**Extraction rules:**
+
+- Each controller/handler → participant
+- Each service class → participant
+- Each external call → external participant
+- Method calls → synchronous messages (->>)
+- Returns → response messages (-->>)
+- If/else in code → alt blocks
+- Try/catch → opt or break blocks
+- Loops → loop blocks
+
+### "Show me the module dependencies"
+
+**What to look for:**
+
+- Import statements between modules
+- Module registration (NestJS modules, Angular modules)
+- Dependency injection configuration
+- Package/module boundaries
+
+**Recommended diagram:** Class diagram or Flowchart
+
+**Extraction rules:**
+
+- Each module/package → class or node
+- Import/dependency → arrow
+- Circular dependencies → highlight (bidirectional or color)
+
+### "Show me the state machine"
+
+**What to look for:**
+
+- Enum definitions for states/status
+- Switch/case or if/else chains on status
+- State machine libraries (XState, statechart)
+- Transition functions
+- Event handlers that change state
+
+**Recommended diagram:** State diagram
+
+**Extraction rules:**
+
+- Each enum value → state
+- Each transition function → edge with event label
+- Initial state → [*] --> state
+- Terminal states → state --> [*]
+- Guard conditions → edge labels
+
+### "Show me the class structure"
+
+**What to look for:**
+
+- Class definitions with methods and properties
+- Interfaces and abstract classes
+- Inheritance (extends)
+- Composition (has-a fields)
+- Implementation (implements)
+
+**Recommended diagram:** Class diagram
+
+**Extraction rules:**
+
+- `class X extends Y` → inheritance (`Y <|-- X`)
+- `class X implements Y` → realization (`Y ..|> X`)
+- Field of type `Y` in class `X` → association (`X --> Y`)
+- Array/collection of `Y` in `X` → aggregation (`X o-- Y`)
+- `Y` created and owned by `X` → composition (`X *-- Y`)
+- `public` → `+`, `private` → `-`, `protected` → `#`
+
+## Framework-Specific Patterns
+
+### NestJS
+
+```
+src/
+├── modules/
+│   ├── user/
+│   │   ├── user.module.ts       → Module boundary
+│   │   ├── user.controller.ts   → API endpoints (sequence participant)
+│   │   ├── user.service.ts      → Business logic (sequence participant)
+│   │   ├── user.repository.ts   → Data access (sequence participant)
+│   │   ├── user.entity.ts       → Database model (ERD entity)
+│   │   └── dto/                 → Request/Response shapes
+│   └── order/
+│       └── ...
+├── common/
+│   ├── guards/                  → Auth flow (sequence)
+│   ├── interceptors/            → Cross-cutting (flowchart)
+│   └── filters/                 → Error handling (flowchart)
+└── main.ts                      → Entry point
+```
+
+### React / Next.js
+
+```
+src/
+├── app/                         → Routes (flowchart for navigation)
+│   ├── layout.tsx               → Layout hierarchy
+│   ├── page.tsx                 → Page components
+│   └── api/                     → API routes (sequence)
+├── components/                  → Component tree (class/flowchart)
+├── hooks/                       → Custom hooks (class diagram)
+├── lib/                         → Utilities
+├── services/                    → API clients (sequence participants)
+└── store/                       → State management (state diagram)
+```
+
+### Python / FastAPI
+
+```
+app/
+├── main.py                      → Entry point, middleware chain
+├── routers/                     → Route definitions (sequence)
+├── services/                    → Business logic (sequence)
+├── models/                      → SQLAlchemy models (ERD)
+├── schemas/                     → Pydantic schemas
+├── dependencies/                → DI (class diagram)
+└── core/
+    ├── config.py                → External connections
+    └── security.py              → Auth flow (sequence/state)
+```
+
+## Multi-Diagram Strategy
+
+For complex codebases, recommend generating multiple focused diagrams rather than one overwhelming diagram:
+
+1. **System Context (C4 Level 1)** — always, as the overview
+2. **Container Diagram (C4 Level 2)** — for multi-service architectures
+3. **ERD** — if database models exist
+4. **Key Flow Sequence** — for the most important user-facing flow
+5. **State Diagram** — if significant state machines exist
+
+Present these as a set, with the Context diagram first for orientation.
+
+## Output Format
+
+When generating from code, always:
+
+1. Add a header comment linking to source:
+
+   ```
+   %% Generated from: src/modules/order/
+   %% Diagram: Order Service — Component Structure
+   ```
+
+2. Use names that match the code (class names, method names)
+
+3. Include a brief note about what was excluded:
+
+   ```
+   %% Note: Utility classes and DTOs omitted for clarity
+   ```
+
+4. Flag uncertainty:
+   ```
+   %% TODO: Verify relationship between PaymentService and RefundService
+   ```

--- a/.cursor/skills/mermaid-studio/references/diagram-types.md
+++ b/.cursor/skills/mermaid-studio/references/diagram-types.md
@@ -1,0 +1,758 @@
+# Diagram Types — Complete Syntax Reference
+
+Load this file when you need detailed syntax for a specific diagram type beyond what the quick examples in SKILL.md provide.
+
+## Table of Contents
+
+1. Flowchart (line ~20)
+2. Sequence Diagram (line ~120)
+3. Class Diagram (line ~220)
+4. State Diagram (line ~310)
+5. ERD (line ~380)
+6. Gantt Chart (line ~440)
+7. Pie Chart (line ~490)
+8. Mindmap (line ~520)
+9. Timeline (line ~560)
+10. Git Graph (line ~600)
+11. Sankey (line ~650)
+12. XY Chart (line ~690)
+13. Quadrant Chart (line ~730)
+14. Block Diagram (line ~770)
+15. User Journey (line ~820)
+16. Requirement Diagram (line ~860)
+17. Packet Diagram (line ~900)
+18. Kanban (line ~930)
+
+---
+
+## 1. Flowchart
+
+**Keyword:** `flowchart` or `graph`
+**Directions:** `TD` (top-down), `LR` (left-right), `BT`, `RL`
+
+### Node Shapes
+
+```
+A[Rectangle]           %% Standard process
+B(Rounded)             %% Alternate process
+C([Stadium])           %% Terminal/start-end
+D{Diamond}             %% Decision
+E{{Hexagon}}           %% Preparation
+F[/Parallelogram/]     %% Input/Output
+G[\Reverse parallel\]  %% Manual operation
+H[(Database)]          %% Data store
+I((Circle))            %% Connector
+J>Asymmetric]          %% Flag/signal
+K[[Subroutine]]        %% Predefined process
+L(((Double Circle)))   %% Multiple documents
+M[/Trapezoid\]         %% Manual input
+N[\Inverse trapezoid/] %% Display
+```
+
+### Edge Types
+
+```
+A --> B                %% Arrow
+A --- B                %% Line (no arrow)
+A -.- B                %% Dotted line
+A -.-> B               %% Dotted arrow
+A ==> B                %% Thick arrow
+A ~~~ B                %% Invisible link (spacing)
+A --text--> B          %% Arrow with text
+A -->|text| B          %% Arrow with text (alternate)
+A <--> B               %% Bidirectional
+A o--o B               %% Circle endpoints
+A x--x B               %% Cross endpoints
+```
+
+### Subgraphs
+
+```mermaid
+flowchart TD
+    subgraph Backend["Backend Services"]
+        direction LR
+        API[API Server]
+        Worker[Background Worker]
+    end
+
+    subgraph Storage["Data Layer"]
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    API --> DB
+    API --> Cache
+    Worker --> DB
+```
+
+### Styling
+
+```mermaid
+flowchart LR
+    A[Success]:::success --> B[Warning]:::warning --> C[Error]:::error
+
+    classDef success fill:#10b981,stroke:#059669,color:#fff
+    classDef warning fill:#f59e0b,stroke:#d97706,color:#000
+    classDef error fill:#ef4444,stroke:#dc2626,color:#fff
+```
+
+### Click Events
+
+```
+click A "https://example.com" "Tooltip text" _blank
+click B callback "Tooltip"
+```
+
+---
+
+## 2. Sequence Diagram
+
+**Keyword:** `sequenceDiagram`
+
+### Participant Types
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Frontend App
+    participant API as REST API
+    participant DB as Database
+```
+
+### Message Types
+
+```
+A->>B: Solid arrow (synchronous request)
+A-->>B: Dotted arrow (asynchronous response)
+A-)B: Open arrow (async message, fire-and-forget)
+A--)B: Dotted open arrow (async response)
+A-xB: Cross arrow (lost message)
+A--xB: Dotted cross arrow
+```
+
+### Activation Boxes
+
+```
+A->>+B: Request    %% Activate B
+B-->>-A: Response  %% Deactivate B
+```
+
+### Control Flow
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    participant C
+
+    alt Condition is true
+        A->>B: Path 1
+    else Condition is false
+        A->>C: Path 2
+    end
+
+    opt Optional step
+        B->>C: Optional call
+    end
+
+    loop Every 5 seconds
+        A->>B: Health check
+    end
+
+    par Parallel execution
+        A->>B: Task 1
+    and
+        A->>C: Task 2
+    end
+
+    critical Critical section
+        A->>B: Important operation
+    option Failure case
+        A->>C: Fallback
+    end
+
+    break When error occurs
+        A->>B: Error notification
+    end
+```
+
+### Notes
+
+```
+Note right of A: Single participant note
+Note over A,B: Note spanning participants
+Note left of B: Left-side note
+```
+
+### Numbering
+
+```
+autonumber    %% Add at the top to auto-number messages
+```
+
+### Boxes (Grouping)
+
+```mermaid
+sequenceDiagram
+    box Purple Internal Services
+        participant API
+        participant Worker
+    end
+    box Grey External
+        participant Payment
+    end
+
+    API->>Worker: Process
+    Worker->>Payment: Charge
+```
+
+---
+
+## 3. Class Diagram
+
+**Keyword:** `classDiagram`
+
+### Class Definition
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        #String species
+        -String dna
+        +makeSound()* void
+        +move(distance int) void
+        #reproduce() Animal
+        -mutate() void
+    }
+```
+
+**Visibility modifiers:** `+` public, `-` private, `#` protected, `~` package
+
+### Relationships
+
+```
+A <|-- B       %% Inheritance (B extends A)
+A *-- B        %% Composition (A owns B, lifecycle bound)
+A o-- B        %% Aggregation (A has B, independent lifecycle)
+A --> B        %% Association (A uses B)
+A ..> B        %% Dependency (A depends on B)
+A ..|> B       %% Realization (B implements A)
+A -- B         %% Link (solid)
+A .. B         %% Link (dashed)
+```
+
+### Multiplicity
+
+```
+A "1" --> "*" B : has
+A "1" --> "0..1" B : may have
+A "0..*" --> "1..*" B : relates
+```
+
+### Annotations
+
+```mermaid
+classDiagram
+    class Shape {
+        <<interface>>
+        +area() double
+        +perimeter() double
+    }
+
+    class Color {
+        <<enumeration>>
+        RED
+        GREEN
+        BLUE
+    }
+
+    class Singleton {
+        <<abstract>>
+    }
+
+    class UserService {
+        <<service>>
+    }
+```
+
+### Namespace
+
+```mermaid
+classDiagram
+    namespace Domain {
+        class User
+        class Order
+    }
+    namespace Infrastructure {
+        class UserRepository
+        class OrderRepository
+    }
+```
+
+---
+
+## 4. State Diagram
+
+**Keyword:** `stateDiagram-v2`
+
+### Basic Syntax
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : Start
+    Processing --> Done : Complete
+    Processing --> Error : Failure
+    Error --> Idle : Reset
+    Done --> [*]
+```
+
+### Composite States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active
+
+    state Active {
+        [*] --> Running
+        Running --> Paused : Pause
+        Paused --> Running : Resume
+    }
+
+    Active --> Terminated : Kill
+    Terminated --> [*]
+```
+
+### Forks and Joins
+
+```mermaid
+stateDiagram-v2
+    state fork_state <<fork>>
+    state join_state <<join>>
+
+    [*] --> fork_state
+    fork_state --> TaskA
+    fork_state --> TaskB
+    TaskA --> join_state
+    TaskB --> join_state
+    join_state --> Done
+    Done --> [*]
+```
+
+### Choice
+
+```mermaid
+stateDiagram-v2
+    state check <<choice>>
+
+    [*] --> check
+    check --> Approved : if valid
+    check --> Rejected : if invalid
+```
+
+### Notes
+
+```
+note right of StateName
+    Multi-line note
+    explaining the state
+end note
+```
+
+---
+
+## 5. Entity Relationship Diagram
+
+**Keyword:** `erDiagram`
+
+### Relationship Types
+
+```
+A ||--|| B : "exactly one to exactly one"
+A ||--o{ B : "one to zero or more"
+A ||--|{ B : "one to one or more"
+A }o--o{ B : "zero or more to zero or more"
+A |o--o| B : "zero or one to zero or one"
+```
+
+### Cardinality Symbols
+
+| Symbol | Meaning      |
+| ------ | ------------ |
+| `\|\|` | Exactly one  |
+| `o\|`  | Zero or one  |
+| `}o`   | Zero or more |
+| `}\|`  | One or more  |
+
+### Attribute Types
+
+```mermaid
+erDiagram
+    PRODUCT {
+        uuid id PK "Unique identifier"
+        string name "Product display name"
+        decimal price "Price in cents"
+        text description
+        datetime created_at
+        int stock_count
+        boolean active
+        string sku UK "Stock keeping unit"
+        uuid category_id FK "Reference to category"
+    }
+```
+
+**Key markers:** `PK` (primary key), `FK` (foreign key), `UK` (unique key)
+
+---
+
+## 6. Gantt Chart
+
+**Keyword:** `gantt`
+
+```mermaid
+gantt
+    title Project Timeline
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Planning
+        Requirements    :done, req, 2025-01-01, 14d
+        Design          :active, des, after req, 10d
+
+    section Development
+        Backend         :dev1, after des, 21d
+        Frontend        :dev2, after des, 18d
+
+    section Testing
+        Integration     :test, after dev1, 7d
+        UAT             :uat, after test, 5d
+
+    section Release
+        Deployment      :milestone, deploy, after uat, 0d
+```
+
+**Task states:** `done`, `active`, `crit` (critical path)
+**Duration:** `7d` (days), `5h` (hours), or specific end date
+**Dependencies:** `after taskId` or comma-separated `after task1 task2`
+
+---
+
+## 7. Pie Chart
+
+**Keyword:** `pie`
+
+```mermaid
+pie showData
+    title Technology Stack
+    "TypeScript" : 45
+    "Python" : 25
+    "Go" : 15
+    "Rust" : 10
+    "Other" : 5
+```
+
+`showData` is optional — adds percentages to labels.
+
+---
+
+## 8. Mindmap
+
+**Keyword:** `mindmap`
+
+```mermaid
+mindmap
+    root((System Design))
+        Scalability
+            Horizontal
+                Load Balancers
+                Sharding
+            Vertical
+                More CPU
+                More RAM
+        Reliability
+            Redundancy
+            Failover
+            Backups
+        Performance
+            Caching
+                CDN
+                Redis
+            Optimization
+                Indexing
+                Query tuning
+```
+
+**Node shapes:**
+
+- `((Circle))` — root/emphasis
+- `(Rounded)` — default
+- `[Square]` — structured
+- `)Cloud(` — cloud shape
+- `))Bang((` — explosion/emphasis
+
+---
+
+## 9. Timeline
+
+**Keyword:** `timeline`
+
+```mermaid
+timeline
+    title Product Roadmap 2025
+    section Q1
+        January : MVP Launch
+                : Core API complete
+        February : Beta program
+        March : Public launch
+    section Q2
+        April : Mobile app
+        May : International expansion
+        June : Enterprise features
+```
+
+---
+
+## 10. Git Graph
+
+**Keyword:** `gitGraph`
+
+```mermaid
+gitGraph
+    commit id: "Initial"
+    branch develop
+    checkout develop
+    commit id: "Feature A"
+    commit id: "Feature B"
+    branch feature/auth
+    checkout feature/auth
+    commit id: "Add login"
+    commit id: "Add OAuth"
+    checkout develop
+    merge feature/auth id: "Merge auth"
+    checkout main
+    merge develop id: "Release v1.0" tag: "v1.0"
+    commit id: "Hotfix" type: HIGHLIGHT
+```
+
+**Commit types:** `NORMAL`, `REVERSE`, `HIGHLIGHT`
+**Options:** `branch order: 0` to control branch position
+
+---
+
+## 11. Sankey Diagram
+
+**Keyword:** `sankey-beta`
+
+```mermaid
+sankey-beta
+
+Traffic,Homepage,5000
+Traffic,API,3000
+Homepage,Signup,1500
+Homepage,Browse,3500
+API,Mobile,2000
+API,Partners,1000
+Signup,Active Users,1200
+Signup,Churned,300
+```
+
+Format: `source,target,value` — one per line, comma-separated.
+
+---
+
+## 12. XY Chart
+
+**Keyword:** `xychart-beta`
+
+```mermaid
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar, Apr, May, Jun]
+    y-axis "Revenue ($K)" 0 --> 100
+    bar [30, 45, 60, 55, 70, 85]
+    line [25, 40, 55, 50, 65, 80]
+```
+
+Supports `bar` and `line` series. Multiple series can be combined.
+
+---
+
+## 13. Quadrant Chart
+
+**Keyword:** `quadrantChart`
+
+```mermaid
+quadrantChart
+    title Feature Prioritization
+    x-axis "Low Effort" --> "High Effort"
+    y-axis "Low Impact" --> "High Impact"
+    quadrant-1 "Quick Wins"
+    quadrant-2 "Major Projects"
+    quadrant-3 "Fill-ins"
+    quadrant-4 "Thankless Tasks"
+    Feature A: [0.8, 0.9]
+    Feature B: [0.2, 0.7]
+    Feature C: [0.6, 0.3]
+    Feature D: [0.3, 0.2]
+```
+
+Coordinates are `[x, y]` with values between 0 and 1.
+
+---
+
+## 14. Block Diagram
+
+**Keyword:** `block-beta`
+
+```mermaid
+block-beta
+    columns 3
+
+    space:1 Header["System Overview"]:1 space:1
+
+    Frontend["React App"]:1 API["NestJS API"]:1 DB[("PostgreSQL")]:1
+
+    Frontend --> API
+    API --> DB
+```
+
+Use `columns N` to define grid. `space:N` for empty cells.
+Blocks span cells with `:N` suffix.
+
+---
+
+## 15. User Journey
+
+**Keyword:** `journey`
+
+```mermaid
+journey
+    title User Checkout Experience
+    section Browse
+        Visit homepage: 5: Customer
+        Search product: 4: Customer
+        View details: 4: Customer
+    section Purchase
+        Add to cart: 5: Customer
+        Enter payment: 2: Customer, Payment System
+        Confirm order: 4: Customer, Order Service
+    section Post-Purchase
+        Receive confirmation: 5: Customer, Email Service
+        Track delivery: 3: Customer
+```
+
+Format: `Task name: satisfaction(1-5): actor1, actor2`
+
+---
+
+## 16. Requirement Diagram
+
+**Keyword:** `requirementDiagram`
+
+```mermaid
+requirementDiagram
+    requirement high_availability {
+        id: REQ-001
+        text: System must achieve 99.9% uptime
+        risk: high
+        verifymethod: test
+    }
+
+    functionalRequirement auto_failover {
+        id: REQ-002
+        text: Automatic failover within 30 seconds
+        risk: medium
+        verifymethod: demonstration
+    }
+
+    element load_balancer {
+        type: service
+        docRef: arch-doc-001
+    }
+
+    high_availability - traces -> auto_failover
+    auto_failover - satisfies -> load_balancer
+```
+
+**Relationship types:** `contains`, `copies`, `derives`, `satisfies`, `verifies`,
+`refines`, `traces`
+
+---
+
+## 17. Packet Diagram
+
+**Keyword:** `packet-beta`
+
+```mermaid
+packet-beta
+    0-15: "Source Port"
+    16-31: "Destination Port"
+    32-63: "Sequence Number"
+    64-95: "Acknowledgment Number"
+    96-99: "Data Offset"
+    100-105: "Reserved"
+    106-111: "Flags"
+    112-127: "Window Size"
+    128-143: "Checksum"
+    144-159: "Urgent Pointer"
+```
+
+Format: `start-end: "Label"` — bit ranges for protocol headers.
+
+---
+
+## 18. Kanban
+
+**Keyword:** `kanban`
+
+```mermaid
+kanban
+    column1["To Do"]
+        task1["Design database schema"]
+        task2["Write API specs"]
+    column2["In Progress"]
+        task3["Implement auth"]
+    column3["Review"]
+        task4["Code review: payments"]
+    column4["Done"]
+        task5["Setup CI/CD"]
+```
+
+---
+
+## Global Configuration
+
+Any diagram can be configured with frontmatter:
+
+```mermaid
+---
+config:
+  theme: base
+  look: classic
+  layout: dagre
+  themeVariables:
+    primaryColor: "#4f46e5"
+    lineColor: "#94a3b8"
+---
+flowchart LR
+    A --> B --> C
+```
+
+**Themes:** `default`, `forest`, `dark`, `neutral`, `base`
+**Looks:** `classic`, `handDrawn`
+**Layouts:** `dagre` (default), `elk` (advanced, needs integration)
+
+## Directives (Inline Config)
+
+**IMPORTANT:** The init directive MUST be on the very first line, before any diagram type declaration.
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'lineColor': '#94a3b8',
+  'primaryTextColor': '#fff', 'primaryBorderColor': '#3730a3'
+}}}%%
+```
+
+**Golden Rule:** Always include `'lineColor': '#94a3b8'` to replace the default harsh black lines with softer slate-colored lines. This single change dramatically improves diagram aesthetics.

--- a/.cursor/skills/mermaid-studio/references/themes.md
+++ b/.cursor/skills/mermaid-studio/references/themes.md
@@ -1,0 +1,426 @@
+# Themes and Styling — Complete Reference
+
+Load this file when the user requests custom themes, specific colors, or styled diagrams.
+
+## Theme Sources
+
+Two rendering engines provide different theme sets:
+
+### Engine 1: @mermaid-js/mermaid-cli (mmdc)
+
+5 built-in themes controlled via `--theme` flag or frontmatter:
+
+| Theme     | Best for                                   |
+| --------- | ------------------------------------------ |
+| `default` | General use, light backgrounds             |
+| `forest`  | Nature-inspired green tones, presentations |
+| `dark`    | Dark backgrounds, dark-mode docs           |
+| `neutral` | Minimal, grayscale, professional docs      |
+| `base`    | Starting point for custom themes           |
+
+### Engine 2: beautiful-mermaid
+
+15 curated themes with consistent design:
+
+**Light themes:**
+| Theme | Style | Best for |
+|-------|-------|----------|
+| `zinc-light` | Clean gray tones | Professional documents |
+| `tokyo-night-light` | Warm light | General use |
+| `catppuccin-latte` | Soft pastels | Friendly docs |
+| `nord-light` | Arctic cool tones | Technical docs |
+| `github-light` | GitHub-style | READMEs, GitHub pages |
+| `solarized-light` | Warm yellows | Long reading |
+
+**Dark themes:**
+| Theme | Style | Best for |
+|-------|-------|----------|
+| `zinc-dark` | Dark gray | Dark mode docs |
+| `tokyo-night` | Vibrant dark | Developer tools |
+| `tokyo-night-storm` | Deep blue-dark | Presentations |
+| `catppuccin-mocha` | Rich dark | Dark mode, cozy feel |
+| `nord` | Arctic dark | Technical, minimal |
+| `dracula` | Purple-tinted dark | Developer-favorite |
+| `github-dark` | GitHub dark mode | Dark READMEs |
+| `solarized-dark` | Warm dark | Extended reading |
+| `one-dark` | Atom-inspired | Code-adjacent docs |
+
+### Theme Selection Guide
+
+| Context                      | Recommended                              |
+| ---------------------------- | ---------------------------------------- |
+| GitHub/GitLab README         | `github-light` or `github-dark`          |
+| Technical documentation      | `nord-light` or `neutral`                |
+| Presentations (light room)   | `zinc-light` or `default`                |
+| Presentations (dark room)    | `tokyo-night-storm` or `dracula`         |
+| Developer tools / terminal   | `tokyo-night` or `one-dark`              |
+| Client-facing / professional | `zinc-light` or `neutral`                |
+| Personal blog / casual       | `catppuccin-latte` or `catppuccin-mocha` |
+
+## Custom Theming (mermaid-cli)
+
+When using the `base` theme, you can override any variable:
+
+### Via Frontmatter
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#4f46e5"
+    primaryTextColor: "#ffffff"
+    primaryBorderColor: "#3730a3"
+    lineColor: "#6b7280"
+    secondaryColor: "#10b981"
+    tertiaryColor: "#f59e0b"
+    background: "#ffffff"
+    mainBkg: "#f8fafc"
+    nodeBorder: "#e2e8f0"
+    clusterBkg: "#f1f5f9"
+    clusterBorder: "#cbd5e1"
+    titleColor: "#1e293b"
+    edgeLabelBackground: "#ffffff"
+---
+flowchart LR
+    A --> B
+```
+
+### Via Init Directive
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5',
+  'primaryTextColor': '#fff',
+  'primaryBorderColor': '#3730a3',
+  'lineColor': '#6b7280',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b'
+}}}%%
+```
+
+### Via Render Script Config
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --format svg \
+  --theme base \
+  --config '{"theme":"base","themeVariables":{"primaryColor":"#4f46e5"}}'
+```
+
+## Available Theme Variables
+
+### Core Colors
+
+| Variable             | Controls                         |
+| -------------------- | -------------------------------- |
+| `primaryColor`       | Main node fill color             |
+| `primaryTextColor`   | Text on primary-colored elements |
+| `primaryBorderColor` | Border of primary elements       |
+| `secondaryColor`     | Secondary elements, alternates   |
+| `tertiaryColor`      | Tertiary elements, highlights    |
+| `lineColor`          | Edge/connection lines            |
+| `background`         | Diagram background               |
+| `mainBkg`            | Default node background          |
+| `nodeBorder`         | Default node border              |
+
+### Text
+
+| Variable              | Controls                      |
+| --------------------- | ----------------------------- |
+| `titleColor`          | Diagram title text            |
+| `textColor`           | General text                  |
+| `edgeLabelBackground` | Background behind edge labels |
+
+### Clusters / Subgraphs
+
+| Variable        | Controls                  |
+| --------------- | ------------------------- |
+| `clusterBkg`    | Subgraph/group background |
+| `clusterBorder` | Subgraph/group border     |
+
+### Sequence Diagram Specific
+
+| Variable                | Controls                      |
+| ----------------------- | ----------------------------- |
+| `actorBkg`              | Participant box fill          |
+| `actorBorder`           | Participant box border        |
+| `actorTextColor`        | Participant text              |
+| `activationBkgColor`    | Activation box fill           |
+| `activationBorderColor` | Activation box border         |
+| `signalColor`           | Message arrow color           |
+| `signalTextColor`       | Message text color            |
+| `noteBkgColor`          | Note background               |
+| `noteBorderColor`       | Note border                   |
+| `noteTextColor`         | Note text                     |
+| `labelBoxBkgColor`      | Alt/loop/opt label background |
+| `labelBoxBorderColor`   | Alt/loop/opt label border     |
+| `loopTextColor`         | Loop label text               |
+
+### Flowchart Specific
+
+| Variable        | Controls  |
+| --------------- | --------- |
+| `nodeTextColor` | Node text |
+
+## Element-Level Styling
+
+### CSS Classes (Flowchart)
+
+```mermaid
+flowchart LR
+    A[Success]:::success
+    B[Warning]:::warning
+    C[Error]:::error
+    D[Info]:::info
+
+    A --> B --> C --> D
+
+    classDef success fill:#10b981,stroke:#059669,color:#fff
+    classDef warning fill:#f59e0b,stroke:#d97706,color:#000
+    classDef error fill:#ef4444,stroke:#dc2626,color:#fff
+    classDef info fill:#3b82f6,stroke:#2563eb,color:#fff
+    classDef default fill:#f8fafc,stroke:#e2e8f0,color:#1e293b
+```
+
+### Inline Styles (Flowchart)
+
+```mermaid
+flowchart LR
+    A --> B --> C
+    style A fill:#f97316,stroke:#ea580c,color:#fff
+    style B fill:#8b5cf6,stroke:#7c3aed,color:#fff
+    style C fill:#06b6d4,stroke:#0891b2,color:#fff
+```
+
+### Link Styles (Flowchart)
+
+```mermaid
+flowchart LR
+    A --> B --> C
+
+    linkStyle 0 stroke:#ef4444,stroke-width:3px
+    linkStyle 1 stroke:#10b981,stroke-width:2px,stroke-dasharray:5
+```
+
+## Brand Color Presets
+
+### Tailwind-Inspired Palette
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#3b82f6',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#2563eb',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b',
+  'lineColor': '#6b7280',
+  'background': '#ffffff',
+  'mainBkg': '#f8fafc',
+  'nodeBorder': '#e2e8f0',
+  'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#cbd5e1'
+}}}%%
+```
+
+### AWS-Themed (Elegant)
+
+Uses AWS orange for primary with **soft slate lines** instead of the harsh default black:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#FF9900',
+  'primaryTextColor': '#232F3E',
+  'primaryBorderColor': '#c47600',
+  'secondaryColor': '#527FFF',
+  'tertiaryColor': '#DD344C',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#FFF8F0',
+  'nodeBorder': '#c47600',
+  'clusterBkg': '#FFF8F0',
+  'clusterBorder': '#d4a574',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+```
+
+### Monochrome Professional
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#374151',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#1f2937',
+  'secondaryColor': '#6b7280',
+  'tertiaryColor': '#9ca3af',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#f9fafb',
+  'nodeBorder': '#d1d5db',
+  'clusterBkg': '#f3f4f6',
+  'clusterBorder': '#9ca3af',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+```
+
+### Indigo-Emerald (Modern SaaS)
+
+A fresh, modern palette for SaaS architecture diagrams:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#3730a3',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1',
+  'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0',
+  'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff',
+  'textColor': '#334155'
+}}}%%
+```
+
+## C4 Diagram Styling
+
+C4 diagrams have fixed element colors (blue for systems, gray for persons, etc.) but the **relationship lines default to harsh black**. Always override them.
+
+**CRITICAL — Arrow Spaghetti Prevention:**
+
+The #1 cause of messy C4 diagrams is too many `Rel()` relationships. Mermaid's Dagre layout engine routes ALL arrows, and with more than ~6 relationships, they inevitably cross and overlap. Follow these rules:
+
+- **Maximum 6 Rel() per diagram** — if you need more, split into multiple diagrams
+- **Tree-shaped topology** — each node should ideally have 1 incoming and 1-2 outgoing edges
+- **Avoid mesh connections** — don't connect everything to everything
+- **Declare elements in flow order** — top-to-bottom or left-to-right; the order of declaration affects layout
+
+### Soft Lines (Mandatory for All C4)
+
+```
+    %% Apply to EVERY Rel() in the diagram
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Highlighted Paths in C4
+
+Use accent colors for primary flows while keeping secondary lines soft:
+
+```
+    %% Primary/user-facing relationship
+    UpdateRelStyle(user, api, $textColor="#1e40af", $lineColor="#3b82f6")
+
+    %% Internal relationship
+    UpdateRelStyle(api, db, $textColor="#475569", $lineColor="#94a3b8")
+
+    %% External/risky connection
+    UpdateRelStyle(api, external, $textColor="#92400e", $lineColor="#f59e0b")
+```
+
+### Custom Element Colors in C4
+
+```
+    UpdateElementStyle(elementAlias, $bgColor="#4f46e5", $fontColor="#ffffff", $borderColor="#3730a3")
+```
+
+| Purpose              | bgColor   | fontColor | borderColor |
+| -------------------- | --------- | --------- | ----------- |
+| Primary emphasis     | `#4f46e5` | `#ffffff` | `#3730a3`   |
+| Success / Data store | `#059669` | `#ffffff` | `#047857`   |
+| Warning / External   | `#d97706` | `#ffffff` | `#b45309`   |
+| Neutral / Supporting | `#64748b` | `#ffffff` | `#475569`   |
+
+## Look Options
+
+```mermaid
+---
+config:
+  look: handDrawn
+---
+flowchart LR
+    A[Sketch Style] --> B[Looks Hand-drawn]
+```
+
+| Look        | Effect                             |
+| ----------- | ---------------------------------- |
+| `classic`   | Standard clean rendering (default) |
+| `handDrawn` | Sketch-like, informal appearance   |
+
+## Configuration via Frontmatter
+
+Full example combining theme, look, and layout:
+
+```mermaid
+---
+config:
+  theme: base
+  look: classic
+  layout: dagre
+  themeVariables:
+    primaryColor: "#4f46e5"
+    lineColor: "#94a3b8"
+---
+flowchart TD
+    A --> B --> C
+```
+
+**Layout engines:**
+| Engine | When to use |
+|--------|-------------|
+| `dagre` | Default — good for most diagrams |
+| `elk` | Complex diagrams with many crossings (requires plugin) |
+
+## Modern Design Principles
+
+### The Golden Rule: Soft Lines
+
+The single biggest improvement to any Mermaid diagram is replacing the default black lines with a softer color. **Always use `lineColor: '#94a3b8'`** (Slate-400) for light backgrounds or `lineColor: '#64748b'` (Slate-500) for dark themes.
+
+### Color Harmony
+
+Use max 3-4 colors per diagram and map them to meaning:
+
+- **Blue tones** → internal systems, primary services
+- **Green tones** → data stores, success states
+- **Amber tones** → external systems, warnings
+- **Slate tones** → lines, borders, secondary elements
+- **Red tones** → error states ONLY (never decoration)
+
+### Typography and Labels
+
+- Keep labels short (max 3-4 words)
+- Use `<br/>` for multi-line labels when needed
+- Use natural language, not abbreviations
+- Include protocol/technology in relationship labels
+
+**CRITICAL — Font Compatibility:**
+
+Do NOT use `system-ui`, `-apple-system`, or `Segoe UI` in `fontFamily` theme variables. These fonts are not available in headless Chromium (used by `mmdc` for rendering) and will silently fall back to a serif font like Times New Roman, making the diagram look unprofessional.
+
+**Safe font stacks for `fontFamily`:**
+- Default (best): `'trebuchet ms', 'verdana', 'arial', sans-serif` — this is Mermaid's built-in default and works everywhere
+- If you must customize: `'verdana', 'arial', 'helvetica', sans-serif`
+
+In practice, do NOT set `fontFamily` at all unless you have a specific reason. The Mermaid default font is already professional and universally compatible.
+
+### Density and Whitespace
+
+- Max 15 nodes per diagram
+- Use subgraphs to create visual grouping and whitespace
+- Use invisible links (`A ~~~ B`) to add spacing when needed
+- Prefer LR over TD for most diagrams (reads more naturally)
+
+### Init Directive Override Behavior
+
+When using the render script, the `--theme` flag writes a config file passed to `mmdc -c`. If your `.mmd` file contains a `%%{init}%%` directive, the render script automatically detects it and does NOT pass a theme in the config, so your init directive takes full precedence. This means:
+
+- If your `.mmd` has `%%{init: {'theme': 'dark', ...}}%%`, it will render with dark theme correctly
+- If your `.mmd` has NO init directive, the render script's `--theme` flag (default: `default`) will be applied
+- You do NOT need to pass `--theme` when using init directives

--- a/.cursor/skills/mermaid-studio/references/troubleshooting.md
+++ b/.cursor/skills/mermaid-studio/references/troubleshooting.md
@@ -1,0 +1,479 @@
+# Troubleshooting — Common Errors and Fixes
+
+Load this file when validation fails or diagrams don't render correctly.
+
+## Syntax Errors
+
+### 1. Unexpected token / Parse error
+
+**Symptom:** `Parse error on line N: ...`
+
+**Common causes and fixes:**
+
+| Cause                   | Bad              | Good                    |
+| ----------------------- | ---------------- | ----------------------- |
+| Special chars in labels | `A[User's Data]` | `A["User's Data"]`      |
+| Unmatched brackets      | `A[Open label`   | `A[Open label]`         |
+| Missing arrow           | `A B`            | `A --> B`               |
+| Wrong arrow direction   | `A >>- B`        | `A ->> B`               |
+| Keyword as node ID      | `end --> start`  | `endNode --> startNode` |
+| Curly braces in comment | `%% {config}`    | `%% config here`        |
+
+### 2. Reserved Words as Node IDs
+
+These words CANNOT be used as bare node IDs:
+
+`end`, `graph`, `subgraph`, `flowchart`, `classDiagram`, `sequenceDiagram`, `stateDiagram`, `erDiagram`, `gantt`, `pie`, `click`, `style`, `class`, `linkStyle`, `default`, `direction`
+
+**Fix:** Append a suffix or use different names:
+
+```
+%% Bad
+end --> start
+
+%% Good
+endState --> startState
+```
+
+### 3. Quotes and Escaping
+
+```
+%% Bad — unescaped quotes
+A["She said "hello""]
+
+%% Good — use single quotes inside double, or HTML entities
+A["She said 'hello'"]
+A["She said &quot;hello&quot;"]
+
+%% Bad — backslash in labels
+A[C:\Users\path]
+
+%% Good — use forward slash or quote the label
+A["C:\Users\path"]
+```
+
+### 4. Empty Labels or Missing Content
+
+```
+%% Bad — empty node
+A[] --> B
+
+%% Good
+A[Start] --> B[End]
+
+%% Bad — empty subgraph
+subgraph Group
+end
+
+%% Good
+subgraph Group
+    A[Content]
+end
+```
+
+## Rendering Issues
+
+### 5. Diagram Renders but Layout is Wrong
+
+**Symptom:** Nodes overlap, arrows cross unnecessarily
+
+**Fixes:**
+
+- Change direction: `TD` ↔ `LR`
+- Add invisible links for spacing: `A ~~~ B`
+- Use subgraphs to group related nodes
+- Reduce node count (split into multiple diagrams)
+- Try `layout: elk` in frontmatter (if supported)
+
+### 6. Labels Cut Off or Truncated
+
+**Symptom:** Long text gets clipped
+
+**Fixes:**
+
+```
+%% Use line breaks
+A["Order Processing<br/>Service"]
+
+%% Shorten labels
+A["Order Svc"]
+
+%% For sequence diagrams, use aliases
+participant OrderSvc as Order Processing Service
+```
+
+### 7. Subgraph Won't Render
+
+**Symptom:** Subgraph shows as flat, no boundary
+
+**Fixes:**
+
+```
+%% Bad — subgraph must have content
+subgraph Empty
+end
+
+%% Good — needs at least one node
+subgraph Group["Service Layer"]
+    A[Service A]
+end
+
+%% Bad — nested subgraph direction before content
+subgraph Parent
+    direction LR
+end
+
+%% Good — direction followed by nodes
+subgraph Parent
+    direction LR
+    A --> B
+end
+```
+
+### 8. Theme Not Applied
+
+**Symptom:** Diagram renders with default colors
+
+**Causes:**
+
+- beautiful-mermaid themes only work with that engine
+- Frontmatter must be at the very start of the file
+- `%%{init}` directive must be on line 1
+- Some renderers ignore theme config
+
+**Fix:** Verify which engine is being used. For mmdc, use `--theme` flag. For beautiful-mermaid, use `--theme` parameter.
+
+### 9. SVG Output is Blank or Tiny
+
+**Symptom:** File is generated but empty or 0x0 pixels
+
+**Causes:**
+
+- Puppeteer/Chrome not installed (mmdc)
+- File encoding issue (BOM marker)
+- Syntax error that fails silently
+
+**Fixes:**
+
+```bash
+# Re-run setup
+bash $SKILL_DIR/scripts/setup.sh
+
+# Check file encoding
+file diagram.mmd
+# Should say: UTF-8 Unicode text
+
+# Validate first
+node $SKILL_DIR/scripts/validate.mjs diagram.mmd
+```
+
+### 10. mmdc Command Not Found
+
+```bash
+# Check if installed
+npx mmdc --version
+
+# If not, install
+npm install -g @mermaid-js/mermaid-cli
+
+# Or use npx (no global install)
+npx -y @mermaid-js/mermaid-cli -i input.mmd -o output.svg
+```
+
+### 11. Puppeteer/Chrome Issues
+
+**Symptom:** `Error: Could not find Chrome`
+
+```bash
+# Install Chromium for puppeteer
+npx puppeteer browsers install chrome
+
+# Or set custom path
+export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Or use puppeteer config
+echo '{"args": ["--no-sandbox"]}' > puppeteer-config.json
+npx mmdc -i input.mmd -o output.svg -p puppeteer-config.json
+```
+
+## Diagram-Specific Issues
+
+### 12. Sequence Diagram — Activation Mismatch
+
+**Symptom:** `Activation error` or misaligned boxes
+
+```
+%% Bad — activate without deactivate
+A->>+B: Request
+B->>C: Forward
+
+%% Good — always pair +/-
+A->>+B: Request
+B-->>-A: Response
+```
+
+### 13. ERD — Relationship Syntax Error
+
+```
+%% Bad — wrong cardinality syntax
+USER --o{ ORDER
+
+%% Good — must include both sides
+USER ||--o{ ORDER : "places"
+
+%% Bad — missing label
+USER ||--o{ ORDER
+
+%% Good — relationship label is required
+USER ||--o{ ORDER : "places"
+```
+
+### 14. C4 — Element Not Rendering
+
+```
+%% Bad — missing quotes around parameters
+Container(api, API, NestJS, Backend service)
+
+%% Good — all text parameters in quotes
+Container(api, "API", "NestJS", "Backend service")
+
+%% Bad — wrong boundary nesting
+Container_Boundary(app, "App") {
+    System(sys, "External")  %% System inside Container boundary
+}
+
+%% Good — use appropriate element types for context
+Container_Boundary(app, "App") {
+    Component(cmp, "Internal Component", "Tech", "Desc")
+}
+```
+
+### 15. Gantt — Dates Not Parsing
+
+```
+%% Bad — wrong format
+dateFormat DD-MM-YYYY
+
+%% Good — supported formats
+dateFormat YYYY-MM-DD
+%% or
+dateFormat DD/MM/YYYY
+%% or
+dateFormat X  (Unix timestamp)
+```
+
+### 16. Flowchart — Circular Reference Warning
+
+**Symptom:** Infinite loop in rendering
+
+```
+%% Problematic — direct circular
+A --> B --> A
+
+%% Still valid but may cause layout issues. Fix by adding direction:
+flowchart LR
+    A --> B
+    B --> A  %% Renders as two arrows between A and B
+```
+
+### 17. State Diagram — Composite State Errors
+
+```
+%% Bad — missing initial state in composite
+state Active {
+    Running --> Paused
+}
+
+%% Good — composite states need initial transition
+state Active {
+    [*] --> Running
+    Running --> Paused
+}
+```
+
+### 18. Architecture-beta — Not Rendering
+
+**Symptom:** Raw text displayed instead of diagram
+
+**Cause:** `architecture-beta` requires Mermaid v11+
+
+**Fixes:**
+
+- Verify Mermaid version: `npx mmdc --version` (needs 11+)
+- Use C4 or flowchart as fallback (see aws-architecture.md)
+- Update mermaid-cli: `npm install -g @mermaid-js/mermaid-cli@latest`
+
+### 19. Architecture-beta — Icons Not Showing
+
+**Symptom:** Icons show as generic boxes or are missing
+
+**Cause:** `logos:aws-*` icons require icon pack registration at render time
+
+**Fixes:**
+
+```bash
+# Use the --icons flag to register icon packs
+node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output diagram.svg --icons logos
+
+# Or use built-in icons as fallback (no registration needed)
+# Replace: service api(logos:aws-api-gateway)[API Gateway]
+# With:    service api(server)[API Gateway]
+```
+
+Built-in icons that work everywhere: `cloud`, `database`, `disk`, `server`, `internet`
+
+### 20. Architecture-beta — Massive Distances Between Arrows/Nodes
+
+**Symptom:** Nodes are spaced extremely far apart, making arrows incredibly long and crossing other nodes messily.
+
+**Cause:** The architecture-beta renderer has no edge routing algorithms and places nodes in rigid, escalating grids. This breaks diagrams with > 8 nodes.
+
+**Fix:** DO NOT use `architecture-beta` for complex systems. Convert the diagram to a properly styled `C4Container` diagram immediately. C4's layout engine spaces elements perfectly.
+
+### 20. C4 — Lines Too Dark / Overlapping Elements
+
+**Symptom:** Black lines create visual clutter, labels overlap with elements
+
+**Cause:** Missing `UpdateRelStyle` and `UpdateLayoutConfig` directives
+
+**Fixes:**
+
+```
+%% Add to the END of every C4 diagram, after all Rel() definitions
+%% Apply to EACH Rel() with soft colors
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8")
+
+%% Add offsets when labels overlap elements
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+%% Spread out elements
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### 21. General — Diagram Lines Too Dark/Harsh
+
+**Symptom:** Diagram looks cluttered even with few nodes
+
+**Cause:** Default Mermaid theme uses black (#000000) lines
+
+**Fix:** Add init directive with soft line color:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'lineColor': '#94a3b8'
+}}}%%
+```
+
+### 22. General — Init Directive Not Applying
+
+**Symptom:** Colors don't change despite adding `%%{init}` directive
+
+**Cause:** The directive must be on the very first line (no blank lines before it)
+
+**Fix:** Ensure `%%{init}` is the absolute first non-comment line:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {...}}}%%
+flowchart LR
+    A --> B
+```
+
+NOT:
+
+```
+flowchart LR
+%%{init: {'theme': 'base', 'themeVariables': {...}}}%%  %% THIS WILL NOT WORK
+    A --> B
+```
+
+## Validation Script Errors
+
+### 23. validate.mjs Reports False Positives
+
+If the validator rejects valid syntax, it might be using an older Mermaid parser version. Try:
+
+```bash
+# Update the validation script's dependency
+cd $SKILL_DIR && npm update mermaid
+
+# Or skip validation and render directly (rendering validates implicitly)
+node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output test.svg
+```
+
+### 24. Batch Script Hangs
+
+**Symptom:** batch.mjs processes some files then stops
+
+**Causes:**
+
+- Too many workers for available memory
+- One diagram has infinite loop syntax
+- Puppeteer timeout on complex diagrams
+
+**Fixes:**
+
+```bash
+# Reduce workers
+node $SKILL_DIR/scripts/batch.mjs --workers 1
+
+# Increase timeout (ms)
+node $SKILL_DIR/scripts/batch.mjs --timeout 60000
+
+# Process problematic files individually to isolate the issue
+```
+
+## Performance Tips
+
+1. **Simple diagrams first** — start with fewer nodes, add incrementally
+2. **Split large diagrams** — over 15 nodes hurts readability and rendering
+3. **Use SVG over PNG** — SVG renders faster and scales infinitely
+4. **ASCII for CI/CD** — no Puppeteer needed, fast and portable
+5. **Batch in parallel** — use `--workers 4` for multiple files
+6. **Cache renders** — only re-render when .mmd source changes
+
+## Rendering Quality Issues
+
+### 25. Fonts Render as Times New Roman / Serif
+
+**Symptom:** Text in the rendered PNG/SVG appears in an ugly serif font instead of the expected sans-serif font.
+
+**Cause:** The `%%{init}%%` directive uses `fontFamily: 'system-ui'` or `fontFamily: 'Segoe UI'` or other desktop-only fonts. These fonts are NOT available in headless Chromium (which `mmdc` uses internally), so the browser falls back to a serif font.
+
+**Fix:** Do NOT set `fontFamily` at all (Mermaid's default `trebuchet ms, verdana, arial, sans-serif` works perfectly), or use only universally available fonts:
+
+```
+%% BAD — these fonts don't exist in headless Chromium
+%%{init: {'theme': 'base', 'themeVariables': {
+  'fontFamily': 'system-ui, -apple-system, sans-serif'
+}}}%%
+
+%% GOOD — use Mermaid defaults (don't set fontFamily at all)
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'lineColor': '#94a3b8'
+}}}%%
+
+%% GOOD — if you must set a font, use web-safe ones
+%%{init: {'theme': 'base', 'themeVariables': {
+  'fontFamily': 'trebuchet ms, verdana, arial, sans-serif'
+}}}%%
+```
+
+### 26. Theme / Init Directive Ignored When Rendering
+
+**Symptom:** You set `%%{init: {'theme': 'dark', ...}}%%` in your `.mmd` file but the diagram renders with the default light theme.
+
+**Cause:** The render script passes a config file with `{"theme": "default"}` via `mmdc -c`, which was overriding the init directive in the diagram.
+
+**Fix:** This bug has been fixed in the render script — it now detects `%%{init` in the input file and does NOT pass a theme in the config file, allowing the init directive to take full precedence. If you still experience this issue, verify:
+
+1. The `%%{init}%%` directive is on the very first line of the `.mmd` file (no blank lines before it)
+2. You are NOT passing `--theme` to the render script when using init directives
+3. The render script version includes the `hasInitDirective` detection fix
+
+### 27. Render Script Fails Silently with `mmdc=no`
+
+**Symptom:** The render script reports `Engines: mmdc=no` even though `mmdc` is installed in `.deps/node_modules/.bin/`.
+
+**Cause:** The skill's directory path contains special characters (like parentheses in `(tooling)`) that break shell execution in `execSync()`. The shell interprets `(` as subshell syntax and fails.
+
+**Fix:** This bug has been fixed in the render script — all paths are now wrapped with `shellQuote()` which uses single quotes to protect against special characters. If you still experience this issue, verify that the `shellQuote()` function exists in `render.mjs` and is used for all path arguments in `execSync()` calls.

--- a/.cursor/skills/mermaid-studio/scripts/batch.mjs
+++ b/.cursor/skills/mermaid-studio/scripts/batch.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/batch.mjs
+ *
+ * Batch renders multiple Mermaid diagrams in parallel.
+ *
+ * Usage:
+ *   node batch.mjs --input-dir ./diagrams --output-dir ./rendered [options]
+ *
+ * Options:
+ *   --input-dir     Directory containing .mmd files
+ *   --output-dir    Directory for rendered outputs
+ *   --format        Output format: svg (default), png, pdf, ascii
+ *   --theme         Theme name (default: default)
+ *   --workers       Parallel workers (default: 4)
+ *   --recursive     Search subdirectories for .mmd files
+ *   --timeout       Per-file timeout in ms (default: 30000)
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, readdirSync } from "fs";
+import { basename, dirname, extname, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function parseArgs(args) {
+  const opts = {
+    inputDir: null,
+    outputDir: null,
+    format: "svg",
+    theme: "default",
+    workers: 4,
+    recursive: false,
+    timeout: 30000,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input-dir":
+        opts.inputDir = args[++i];
+        break;
+      case "--output-dir":
+        opts.outputDir = args[++i];
+        break;
+      case "--format":
+        opts.format = args[++i];
+        break;
+      case "--theme":
+        opts.theme = args[++i];
+        break;
+      case "--workers":
+        opts.workers = parseInt(args[++i], 10);
+        break;
+      case "--recursive":
+        opts.recursive = true;
+        break;
+      case "--timeout":
+        opts.timeout = parseInt(args[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        console.log(`
+Mermaid Studio — Batch Renderer
+
+Usage:
+  node batch.mjs --input-dir <dir> --output-dir <dir> [options]
+
+Options:
+  --input-dir     Directory containing .mmd/.mermaid files
+  --output-dir    Output directory for rendered files
+  --format        Output format: svg (default), png, pdf, ascii
+  --theme         Theme name (default: default)
+  --workers       Parallel render workers (default: 4)
+  --recursive     Include subdirectories
+  --timeout       Per-file timeout in ms (default: 30000)
+  --help, -h      Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function findMmdFiles(dir, recursive = false) {
+  const files = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isFile() && (entry.name.endsWith(".mmd") || entry.name.endsWith(".mermaid"))) {
+      files.push(fullPath);
+    } else if (entry.isDirectory() && recursive) {
+      files.push(...findMmdFiles(fullPath, true));
+    }
+  }
+
+  return files.sort();
+}
+
+function getOutputPath(inputFile, inputDir, outputDir, format) {
+  const rel = relative(inputDir, inputFile);
+  const ext = format === "ascii" ? ".txt" : `.${format}`;
+  const outputName = basename(rel, extname(rel)) + ext;
+  const outputSubdir = dirname(rel);
+  return resolve(outputDir, outputSubdir, outputName);
+}
+
+async function renderFile(inputFile, outputFile, format, theme, timeout) {
+  const renderScript =
+    format === "ascii"
+      ? resolve(__dirname, "render-ascii.mjs")
+      : resolve(__dirname, "render.mjs");
+
+  const args =
+    format === "ascii"
+      ? ["--input", inputFile, "--output", outputFile]
+      : ["--input", inputFile, "--output", outputFile, "--format", format, "--theme", theme];
+
+  return new Promise((resolvePromise) => {
+    try {
+      const cmd = `node "${renderScript}" ${args.map((a) => `"${a}"`).join(" ")}`;
+      execSync(cmd, {
+        stdio: "pipe",
+        timeout: timeout,
+        env: { ...process.env },
+      });
+      resolvePromise({ success: true, file: basename(inputFile) });
+    } catch (e) {
+      const stderr = e.stderr?.toString()?.slice(0, 100) || e.message;
+      resolvePromise({
+        success: false,
+        file: basename(inputFile),
+        error: stderr,
+      });
+    }
+  });
+}
+
+async function runBatch(files, opts) {
+  const results = [];
+  let completed = 0;
+  const total = files.length;
+
+  // Process in chunks of --workers size
+  for (let i = 0; i < files.length; i += opts.workers) {
+    const chunk = files.slice(i, i + opts.workers);
+    const promises = chunk.map((inputFile) => {
+      const outputFile = getOutputPath(
+        inputFile,
+        resolve(opts.inputDir),
+        resolve(opts.outputDir),
+        opts.format
+      );
+      mkdirSync(dirname(outputFile), { recursive: true });
+      return renderFile(inputFile, outputFile, opts.format, opts.theme, opts.timeout);
+    });
+
+    const chunkResults = await Promise.all(promises);
+    for (const result of chunkResults) {
+      completed++;
+      const icon = result.success ? "✓" : "✗";
+      console.log(`  ${icon} [${completed}/${total}] ${result.file}${result.error ? ` — ${result.error}` : ""}`);
+      results.push(result);
+    }
+  }
+
+  return results;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (!opts.inputDir || !opts.outputDir) {
+    console.error("Error: --input-dir and --output-dir are required");
+    console.error('Run with --help for usage info.');
+    process.exit(1);
+  }
+
+  if (!existsSync(opts.inputDir)) {
+    console.error(`Error: Input directory not found: ${opts.inputDir}`);
+    process.exit(1);
+  }
+
+  mkdirSync(opts.outputDir, { recursive: true });
+
+  const files = findMmdFiles(resolve(opts.inputDir), opts.recursive);
+
+  if (files.length === 0) {
+    console.log("No .mmd or .mermaid files found in input directory.");
+    process.exit(0);
+  }
+
+  console.log(`\n=== Mermaid Studio — Batch Render ===`);
+  console.log(`Input:   ${resolve(opts.inputDir)}`);
+  console.log(`Output:  ${resolve(opts.outputDir)}`);
+  console.log(`Format:  ${opts.format}`);
+  console.log(`Theme:   ${opts.theme}`);
+  console.log(`Workers: ${opts.workers}`);
+  console.log(`Files:   ${files.length}`);
+  console.log(`${"─".repeat(40)}`);
+
+  const startTime = Date.now();
+  const results = await runBatch(files, opts);
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  console.log(`${"─".repeat(40)}`);
+  console.log(`\nCompleted in ${elapsed}s`);
+  console.log(`  ✓ ${succeeded} succeeded`);
+  if (failed > 0) {
+    console.log(`  ✗ ${failed} failed`);
+  }
+  console.log(`  Total: ${results.length}/${files.length}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(2);
+});

--- a/.cursor/skills/mermaid-studio/scripts/render-ascii.mjs
+++ b/.cursor/skills/mermaid-studio/scripts/render-ascii.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/render-ascii.mjs
+ *
+ * Renders Mermaid diagrams as ASCII/Unicode art for terminal display.
+ * Uses beautiful-mermaid library for ASCII output.
+ *
+ * Usage:
+ *   node render-ascii.mjs --input diagram.mmd
+ *   node render-ascii.mjs --input diagram.mmd --output diagram.txt
+ *   echo "graph LR; A-->B" | node render-ascii.mjs --stdin
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+function parseArgs(args) {
+  const opts = {
+    input: null,
+    output: null, // null = stdout
+    stdin: false,
+    width: null,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input":
+      case "-i":
+        opts.input = args[++i];
+        break;
+      case "--output":
+      case "-o":
+        opts.output = args[++i];
+        break;
+      case "--stdin":
+        opts.stdin = true;
+        break;
+      case "--width":
+      case "-w":
+        opts.width = parseInt(args[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        console.log(`
+Mermaid Studio — ASCII Renderer
+
+Usage:
+  node render-ascii.mjs --input <file.mmd> [--output <file.txt>]
+  echo "graph LR; A-->B" | node render-ascii.mjs --stdin
+
+Options:
+  --input, -i     Input .mmd file path
+  --output, -o    Output file (default: print to stdout)
+  --stdin         Read diagram from stdin
+  --width, -w     Max width in characters
+  --help, -h      Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+function findBeautifulMermaid() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/beautiful-mermaid"),
+    resolve(process.cwd(), "node_modules/beautiful-mermaid"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+async function renderAscii(mmdContent, bmPath, opts) {
+  try {
+    const bm = await import(resolve(bmPath, "index.js")).catch(() =>
+      import(resolve(bmPath, "dist/index.js")).catch(() =>
+        import(resolve(bmPath, "src/index.js"))
+      )
+    );
+
+    // Try various function names the library might expose
+    const renderFn =
+      bm.renderMermaidAscii ||
+      bm.renderAscii ||
+      bm.default?.renderMermaidAscii ||
+      bm.default?.renderAscii;
+
+    if (renderFn) {
+      const asciiOpts = {};
+      if (opts.width) asciiOpts.maxWidth = opts.width;
+
+      const result = await renderFn(mmdContent, asciiOpts);
+      return typeof result === "string" ? result : result?.ascii || result?.text || String(result);
+    }
+
+    // If no dedicated ASCII function, try the general render with ascii format
+    const generalRender =
+      bm.renderMermaid ||
+      bm.render ||
+      bm.default?.renderMermaid ||
+      bm.default?.render;
+
+    if (generalRender) {
+      const renderOpts = { format: "ascii" };
+      if (opts.width) renderOpts.maxWidth = opts.width;
+
+      const result = await generalRender(mmdContent, renderOpts);
+      if (typeof result === "string") return result;
+      if (result?.ascii) return result.ascii;
+      if (result?.text) return result.text;
+      return String(result);
+    }
+
+    throw new Error("No suitable render function found in beautiful-mermaid");
+  } catch (e) {
+    throw new Error(`beautiful-mermaid ASCII rendering failed: ${e.message}`);
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Get input
+  let mmdContent;
+  if (opts.stdin) {
+    mmdContent = await readFromStdin();
+  } else if (opts.input) {
+    const inputFile = resolve(opts.input);
+    if (!existsSync(inputFile)) {
+      console.error(`Error: Input file not found: ${inputFile}`);
+      process.exit(1);
+    }
+    mmdContent = readFileSync(inputFile, "utf-8");
+  } else {
+    console.error("Error: --input or --stdin is required");
+    process.exit(1);
+  }
+
+  if (!mmdContent.trim()) {
+    console.error("Error: Empty input");
+    process.exit(1);
+  }
+
+  // Find engine
+  const bmPath = findBeautifulMermaid();
+  if (!bmPath) {
+    console.error("Error: beautiful-mermaid not found.");
+    console.error(`Run: bash ${resolve(__dirname, "setup.sh")}`);
+    process.exit(1);
+  }
+
+  try {
+    const ascii = await renderAscii(mmdContent, bmPath, opts);
+
+    if (opts.output) {
+      mkdirSync(dirname(resolve(opts.output)), { recursive: true });
+      writeFileSync(resolve(opts.output), ascii, "utf-8");
+      console.error(`✓ ASCII output saved to: ${resolve(opts.output)}`);
+    } else {
+      // Print to stdout
+      console.log(ascii);
+    }
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
+    console.error("");
+    console.error("Tip: ASCII rendering requires beautiful-mermaid.");
+    console.error("Supported diagram types: flowchart, sequence, state, class, ER.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(1);
+});

--- a/.cursor/skills/mermaid-studio/scripts/render.mjs
+++ b/.cursor/skills/mermaid-studio/scripts/render.mjs
@@ -1,0 +1,600 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/render.mjs
+ *
+ * Dual-engine Mermaid renderer with automatic fallback and icon pack support.
+ * Primary: @mermaid-js/mermaid-cli (mmdc) — supports all diagram types, PNG/SVG/PDF
+ * Fallback: beautiful-mermaid — better themes, SVG output
+ * Icon mode: Puppeteer-based custom renderer — registers icon packs for architecture-beta
+ *
+ * Usage:
+ *   node render.mjs --input diagram.mmd --output diagram.svg [--format svg|png|pdf] [--theme default] [--width 1200] [--config '{}']
+ *   node render.mjs --input diagram.mmd --output diagram.svg --icons logos,fa
+ *   echo "graph LR; A-->B" | node render.mjs --stdin --output out.svg
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, extname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+// --- Argument parsing ---
+
+function parseArgs(args) {
+  const opts = {
+    input: null,
+    output: null,
+    format: "svg",
+    theme: "default",
+    width: 1200,
+    height: null,
+    config: null,
+    stdin: false,
+    engine: "auto", // auto | mmdc | beautiful-mermaid | puppeteer
+    background: "white",
+    icons: [], // icon pack names to register (e.g., ['logos', 'fa'])
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input":
+      case "-i":
+        opts.input = args[++i];
+        break;
+      case "--output":
+      case "-o":
+        opts.output = args[++i];
+        break;
+      case "--format":
+      case "-f":
+        opts.format = args[++i];
+        break;
+      case "--theme":
+      case "-t":
+        opts.theme = args[++i];
+        break;
+      case "--width":
+      case "-w":
+        opts.width = parseInt(args[++i], 10);
+        break;
+      case "--height":
+        opts.height = parseInt(args[++i], 10);
+        break;
+      case "--config":
+      case "-c":
+        opts.config = args[++i];
+        break;
+      case "--stdin":
+        opts.stdin = true;
+        break;
+      case "--engine":
+      case "-e":
+        opts.engine = args[++i];
+        break;
+      case "--background":
+      case "--bg":
+        opts.background = args[++i];
+        break;
+      case "--icons":
+        opts.icons = args[++i].split(",").map((s) => s.trim()).filter(Boolean);
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`
+Mermaid Studio — Render Script
+
+Usage:
+  node render.mjs --input <file.mmd> --output <file.svg> [options]
+  echo "graph LR; A-->B" | node render.mjs --stdin --output out.svg
+
+Options:
+  --input, -i     Input .mmd file path
+  --output, -o    Output file path (required)
+  --format, -f    Output format: svg (default), png, pdf
+  --theme, -t     Theme name (see SKILL.md for available themes)
+  --width, -w     Width in pixels for PNG (default: 1200)
+  --height        Height in pixels for PNG (auto-calculated if omitted)
+  --config, -c    JSON string with mermaid config overrides
+  --engine, -e    Force engine: auto (default), mmdc, beautiful-mermaid, puppeteer
+  --background    Background color (default: white)
+  --icons         Comma-separated Iconify pack names to register (e.g., logos,fa)
+                  Use 'logos' for AWS/tech icons, 'fa' for Font Awesome
+                  When specified, uses Puppeteer-based renderer for proper icon support
+  --stdin         Read diagram from stdin
+  --help, -h      Show this help
+`);
+}
+
+// --- Icon pack CDN URLs ---
+
+const ICON_PACK_URLS = {
+  logos: "https://unpkg.com/@iconify-json/logos/icons.json",
+  fa: "https://unpkg.com/@iconify-json/fa6-regular/icons.json",
+  "fa-solid": "https://unpkg.com/@iconify-json/fa6-solid/icons.json",
+  "fa-brands": "https://unpkg.com/@iconify-json/fa6-brands/icons.json",
+  mdi: "https://unpkg.com/@iconify-json/mdi/icons.json",
+  "simple-icons": "https://unpkg.com/@iconify-json/simple-icons/icons.json",
+};
+
+// --- Engine detection ---
+
+function shellQuote(p) {
+  // Wrap path in single quotes and escape any internal single quotes
+  return `'${p.replace(/'/g, "'\\''")}' `;
+}
+
+function isMmdcAvailable() {
+  try {
+    const mmdcPaths = [
+      resolve(DEPS_DIR, "node_modules/.bin/mmdc"),
+      "mmdc",
+    ];
+    for (const p of mmdcPaths) {
+      try {
+        execSync(`${shellQuote(p)} --version`, { stdio: "pipe", timeout: 10000 });
+        return p;
+      } catch {
+        continue;
+      }
+    }
+    // Try npx
+    execSync("npx mmdc --version", { stdio: "pipe", timeout: 15000 });
+    return "npx mmdc";
+  } catch {
+    return null;
+  }
+}
+
+function isBeautifulMermaidAvailable() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/beautiful-mermaid"),
+    resolve(process.cwd(), "node_modules/beautiful-mermaid"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function isPuppeteerAvailable() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/puppeteer"),
+    resolve(DEPS_DIR, "node_modules/puppeteer-core"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+// --- beautiful-mermaid themes ---
+
+const BEAUTIFUL_MERMAID_THEMES = new Set([
+  "zinc-light",
+  "zinc-dark",
+  "tokyo-night",
+  "tokyo-night-storm",
+  "tokyo-night-light",
+  "catppuccin-mocha",
+  "catppuccin-latte",
+  "nord",
+  "nord-light",
+  "dracula",
+  "github-dark",
+  "github-light",
+  "solarized-dark",
+  "solarized-light",
+  "one-dark",
+]);
+
+const MMDC_THEMES = new Set(["default", "forest", "dark", "neutral", "base"]);
+
+// --- Rendering engines ---
+
+async function renderWithMmdc(mmdcPath, inputFile, outputFile, opts) {
+  const puppeteerConfig = resolve(DEPS_DIR, "puppeteer-config.json");
+  const configFile = resolve(DEPS_DIR, ".mermaid-render-config.json");
+
+  // Build mermaid config — respect %%{init}%% directives in the input file
+  const inputContent = readFileSync(inputFile, "utf-8");
+  const hasInitDirective = inputContent.includes("%%{init");
+  let mermaidConfig = {};
+  if (!hasInitDirective) {
+    mermaidConfig.theme = opts.theme;
+  }
+  if (opts.config) {
+    try {
+      const userConfig = JSON.parse(opts.config);
+      mermaidConfig = { ...mermaidConfig, ...userConfig };
+    } catch (e) {
+      console.warn(`Warning: Could not parse --config JSON: ${e.message}`);
+    }
+  }
+
+  writeFileSync(configFile, JSON.stringify(mermaidConfig, null, 2));
+
+  let cmd = `${shellQuote(mmdcPath)} -i ${shellQuote(inputFile)} -o ${shellQuote(outputFile)}`;
+  cmd += ` -c ${shellQuote(configFile)}`;
+  cmd += ` -b ${shellQuote(opts.background)}`;
+
+  if (opts.format === "png") {
+    cmd += ` -w ${opts.width}`;
+    if (opts.height) cmd += ` -H ${opts.height}`;
+    cmd += ` -s 3`; // 3x scale for crisp PNGs
+  }
+
+  if (existsSync(puppeteerConfig)) {
+    cmd += ` -p ${shellQuote(puppeteerConfig)}`;
+  }
+
+  try {
+    execSync(cmd, { stdio: "pipe", timeout: 60000 });
+    return true;
+  } catch (e) {
+    const stderr = e.stderr?.toString() || "";
+    console.error(`mmdc failed: ${stderr.slice(0, 200)}`);
+    return false;
+  }
+}
+
+async function renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts) {
+  // Dynamic import of beautiful-mermaid
+  try {
+    const bm = await import(resolve(bmPath, "index.js")).catch(() =>
+      import(resolve(bmPath, "dist/index.js")).catch(() =>
+        import(resolve(bmPath, "src/index.js"))
+      )
+    );
+
+    const mmdContent = readFileSync(inputFile, "utf-8");
+    const renderFn = bm.renderMermaid || bm.render || bm.default?.renderMermaid || bm.default?.render;
+
+    if (!renderFn) {
+      // If no direct function, try renderMermaidSvg
+      const renderSvg = bm.renderMermaidSvg || bm.default?.renderMermaidSvg;
+      if (renderSvg) {
+        const svg = await renderSvg(mmdContent, { theme: opts.theme });
+        writeFileSync(outputFile, svg, "utf-8");
+        return true;
+      }
+      console.error("Could not find render function in beautiful-mermaid");
+      return false;
+    }
+
+    const result = await renderFn(mmdContent, {
+      theme: opts.theme,
+      format: opts.format === "png" ? "png" : "svg",
+    });
+
+    if (typeof result === "string") {
+      writeFileSync(outputFile, result, "utf-8");
+    } else if (Buffer.isBuffer(result)) {
+      writeFileSync(outputFile, result);
+    } else if (result?.svg) {
+      writeFileSync(outputFile, result.svg, "utf-8");
+    } else if (result?.data) {
+      writeFileSync(outputFile, result.data);
+    }
+
+    return true;
+  } catch (e) {
+    console.error(`beautiful-mermaid failed: ${e.message}`);
+    return false;
+  }
+}
+
+async function renderWithPuppeteer(inputFile, outputFile, opts) {
+  const puppeteerPath = isPuppeteerAvailable();
+  if (!puppeteerPath) {
+    console.error("Puppeteer not available for icon-enabled rendering. Run setup.sh first.");
+    return false;
+  }
+
+  try {
+    const { createRequire } = await import("module");
+    const require = createRequire(import.meta.url);
+    const puppeteer = require(puppeteerPath);
+    const mmdContent = readFileSync(inputFile, "utf-8");
+
+    // Build icon pack registration code
+    const iconRegistrations = opts.icons
+      .filter((name) => ICON_PACK_URLS[name])
+      .map(
+        (name) =>
+          `{ name: '${name}', loader: () => fetch('${ICON_PACK_URLS[name]}').then(r => r.json()) }`
+      )
+      .join(",\n      ");
+
+    // Build mermaid config
+    let mermaidConfig = {};
+    if (opts.config) {
+      try {
+        mermaidConfig = JSON.parse(opts.config);
+      } catch (e) {
+        console.warn(`Warning: Could not parse --config JSON: ${e.message}`);
+      }
+    }
+
+    const htmlContent = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { margin: 0; padding: 20px; background: ${opts.background}; font-family: 'trebuchet ms', 'verdana', 'arial', sans-serif; }
+    #container { display: inline-block; }
+    svg { max-width: none !important; }
+    .error { color: red; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: '${mermaidConfig.theme || opts.theme || "default"}',
+      ${mermaidConfig.themeVariables ? `themeVariables: ${JSON.stringify(mermaidConfig.themeVariables)},` : ""}
+      securityLevel: 'loose',
+      logLevel: 'error',
+    });
+
+    ${opts.icons.length > 0
+        ? `mermaid.registerIconPacks([
+      ${iconRegistrations}
+    ]);`
+        : ""
+      }
+
+    try {
+      // Small delay to ensure icon packs are loaded
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const { svg } = await mermaid.render('mermaid-diagram', ${JSON.stringify(mmdContent)});
+      document.getElementById('container').innerHTML = svg;
+      window.__mermaidRendered = true;
+      window.__mermaidSvg = svg;
+    } catch (e) {
+      document.getElementById('container').innerHTML = '<pre class="error">' + e.message + '</pre>';
+      window.__mermaidRendered = true;
+      window.__mermaidError = e.message;
+    }
+  </script>
+</body>
+</html>`;
+
+    // Write temp HTML
+    const tempHtml = resolve(DEPS_DIR, ".mermaid-icon-render.html");
+    mkdirSync(dirname(tempHtml), { recursive: true });
+    writeFileSync(tempHtml, htmlContent, "utf-8");
+
+    // Launch Puppeteer
+    const browser = await puppeteer.launch({
+      headless: "new",
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: opts.width || 1200, height: 800, deviceScaleFactor: 3 });
+    await page.goto(`file://${tempHtml}`, { waitUntil: "networkidle0", timeout: 30000 });
+
+    // Wait for render
+    await page.waitForFunction("window.__mermaidRendered === true", { timeout: 15000 });
+
+    // Check for errors
+    const error = await page.evaluate(() => window.__mermaidError);
+    if (error) {
+      console.error(`Mermaid render error: ${error}`);
+      await browser.close();
+      return false;
+    }
+
+    if (opts.format === "png") {
+      // Screenshot approach for PNG
+      await page.screenshot({ path: outputFile, type: "png", fullPage: true, omitBackground: opts.background === "transparent" });
+    } else {
+      // Extract SVG
+      const svg = await page.evaluate(() => window.__mermaidSvg);
+      if (svg) {
+        writeFileSync(outputFile, svg, "utf-8");
+      }
+    }
+
+    await browser.close();
+
+    // Clean up temp file
+    try {
+      const { unlinkSync } = await import("fs");
+      unlinkSync(tempHtml);
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return true;
+  } catch (e) {
+    console.error(`Puppeteer renderer failed: ${e.message}`);
+    return false;
+  }
+}
+
+// --- Read input ---
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+// --- Auto-detect if diagram needs icon packs ---
+
+function diagramNeedsIcons(content) {
+  // Check if the diagram uses external icon references
+  const iconPatterns = [
+    /logos:\w/,
+    /fa:\w/,
+    /fa6-\w+:\w/,
+    /mdi:\w/,
+    /simple-icons:\w/,
+    /aws:\w/,
+  ];
+  return iconPatterns.some((p) => p.test(content));
+}
+
+// --- Main ---
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Validate args
+  if (!opts.output) {
+    console.error("Error: --output is required");
+    process.exit(1);
+  }
+
+  // Determine format from output extension if not explicitly set
+  if (!process.argv.includes("--format") && !process.argv.includes("-f")) {
+    const ext = extname(opts.output).toLowerCase();
+    if (ext === ".png") opts.format = "png";
+    else if (ext === ".pdf") opts.format = "pdf";
+    else opts.format = "svg";
+  }
+
+  // Get input content
+  let inputFile;
+  if (opts.stdin) {
+    const content = await readFromStdin();
+    inputFile = resolve(DEPS_DIR, ".mermaid-stdin-temp.mmd");
+    mkdirSync(dirname(inputFile), { recursive: true });
+    writeFileSync(inputFile, content, "utf-8");
+  } else if (opts.input) {
+    inputFile = resolve(opts.input);
+    if (!existsSync(inputFile)) {
+      console.error(`Error: Input file not found: ${inputFile}`);
+      process.exit(1);
+    }
+  } else {
+    console.error("Error: --input or --stdin is required");
+    process.exit(1);
+  }
+
+  // Ensure output directory exists
+  mkdirSync(dirname(resolve(opts.output)), { recursive: true });
+  const outputFile = resolve(opts.output);
+
+  // Auto-detect icon needs
+  const mmdContent = readFileSync(inputFile, "utf-8");
+  const needsIcons = opts.icons.length > 0 || diagramNeedsIcons(mmdContent);
+
+  if (needsIcons && opts.icons.length === 0) {
+    // Auto-detect which icon packs are needed
+    if (/logos:\w/.test(mmdContent)) opts.icons.push("logos");
+    if (/fa:\w/.test(mmdContent) || /fa6-\w+:\w/.test(mmdContent)) opts.icons.push("fa");
+    if (/mdi:\w/.test(mmdContent)) opts.icons.push("mdi");
+    console.log(`Auto-detected icon packs needed: ${opts.icons.join(", ")}`);
+  }
+
+  // Detect engines
+  const mmdcPath = isMmdcAvailable();
+  const bmPath = isBeautifulMermaidAvailable();
+  const hasPuppeteer = isPuppeteerAvailable();
+
+  console.log(`Input:  ${inputFile}`);
+  console.log(`Output: ${outputFile}`);
+  console.log(`Format: ${opts.format}`);
+  console.log(`Theme:  ${opts.theme}`);
+  console.log(`Icons:  ${opts.icons.length > 0 ? opts.icons.join(", ") : "none"}`);
+  console.log(`Engines: mmdc=${mmdcPath ? "yes" : "no"}, beautiful-mermaid=${bmPath ? "yes" : "no"}, puppeteer=${hasPuppeteer ? "yes" : "no"}`);
+
+  let success = false;
+
+  // Determine engine order based on theme, format, and icons
+  const isBeautifulTheme = BEAUTIFUL_MERMAID_THEMES.has(opts.theme);
+  const needsPng = opts.format === "png" || opts.format === "pdf";
+
+  if (needsIcons) {
+    // Icon mode: Use Puppeteer-based renderer
+    console.log("Using Puppeteer renderer (icon packs required)...");
+    success = await renderWithPuppeteer(inputFile, outputFile, opts);
+    if (!success && mmdcPath) {
+      console.log("Falling back to mmdc (icons may not render)...");
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+    }
+  } else if (opts.engine === "mmdc") {
+    // Forced mmdc
+    if (mmdcPath) {
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: mmdc not available. Run setup.sh first.");
+    }
+  } else if (opts.engine === "beautiful-mermaid") {
+    // Forced beautiful-mermaid
+    if (bmPath) {
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: beautiful-mermaid not available. Run setup.sh first.");
+    }
+  } else if (opts.engine === "puppeteer") {
+    // Forced Puppeteer
+    success = await renderWithPuppeteer(inputFile, outputFile, opts);
+  } else {
+    // Auto selection
+    if (isBeautifulTheme && bmPath && !needsPng) {
+      // beautiful-mermaid theme requested, try it first
+      console.log("Using beautiful-mermaid (theme match)...");
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+      if (!success && mmdcPath) {
+        console.log("Falling back to mmdc...");
+        const fallbackOpts = { ...opts, theme: "default" };
+        success = await renderWithMmdc(mmdcPath, inputFile, outputFile, fallbackOpts);
+      }
+    } else if (mmdcPath) {
+      // Default: mmdc first (best compatibility)
+      console.log("Using mmdc (primary)...");
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+      if (!success && bmPath && !needsPng) {
+        console.log("Falling back to beautiful-mermaid...");
+        success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+      }
+    } else if (bmPath && !needsPng) {
+      // Only beautiful-mermaid available
+      console.log("Using beautiful-mermaid (only engine available)...");
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: No rendering engine available. Run setup.sh first.");
+      console.error(`  bash ${resolve(__dirname, "setup.sh")}`);
+      process.exit(1);
+    }
+  }
+
+  if (success && existsSync(outputFile)) {
+    const stats = readFileSync(outputFile);
+    console.log(`\n✓ Rendered successfully: ${outputFile} (${stats.length} bytes)`);
+  } else {
+    console.error("\n✗ Rendering failed.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(1);
+});

--- a/.cursor/skills/mermaid-studio/scripts/setup.sh
+++ b/.cursor/skills/mermaid-studio/scripts/setup.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# mermaid-studio/scripts/setup.sh
+# Auto-installs rendering dependencies. Run once per environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_DIR="${MERMAID_STUDIO_DIR:-$SKILL_DIR/.deps}"
+
+echo "=== Mermaid Studio — Dependency Setup ==="
+echo "Install directory: $INSTALL_DIR"
+
+# Ensure Node.js is available
+if ! command -v node &>/dev/null; then
+    echo "ERROR: Node.js is required but not found."
+    echo "Install Node.js 18+ from https://nodejs.org"
+    exit 1
+fi
+
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+    echo "WARNING: Node.js 18+ recommended. Found: $(node -v)"
+fi
+
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# Initialize package.json if missing
+if [ ! -f package.json ]; then
+    echo '{"name":"mermaid-studio-deps","version":"1.0.0","private":true,"type":"module"}' > package.json
+fi
+
+echo ""
+echo "--- Installing @mermaid-js/mermaid-cli (primary renderer) ---"
+npm install --save @mermaid-js/mermaid-cli 2>&1 | tail -3
+
+echo ""
+echo "--- Installing beautiful-mermaid (secondary renderer + ASCII) ---"
+npm install --save beautiful-mermaid 2>&1 | tail -3
+
+echo ""
+echo "--- Installing mermaid (for validation) ---"
+npm install --save mermaid 2>&1 | tail -3
+
+echo ""
+echo "--- Installing puppeteer (for icon-enabled rendering) ---"
+npm install --save puppeteer 2>&1 | tail -3
+
+# Create puppeteer config for headless rendering
+cat > "$INSTALL_DIR/puppeteer-config.json" << 'PCONF'
+{
+  "executablePath": "",
+  "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+  "headless": true
+}
+PCONF
+
+# Try to install Chromium for Puppeteer
+echo ""
+echo "--- Installing Chromium for Puppeteer ---"
+npx puppeteer browsers install chrome 2>&1 | tail -3 || {
+    echo "WARNING: Chromium install failed. mmdc may not work."
+    echo "  Fallback: beautiful-mermaid will be used for SVG rendering."
+    echo "  Or set PUPPETEER_EXECUTABLE_PATH to your Chrome/Chromium binary."
+}
+
+# Verify installations
+echo ""
+echo "=== Verification ==="
+
+if npx --prefix "$INSTALL_DIR" mmdc --version &>/dev/null 2>&1; then
+    echo "✓ mermaid-cli: $(npx --prefix "$INSTALL_DIR" mmdc --version 2>&1)"
+else
+    echo "✗ mermaid-cli: not working (beautiful-mermaid will be used as fallback)"
+fi
+
+if node -e "import('$INSTALL_DIR/node_modules/beautiful-mermaid/index.js').then(() => console.log('ok')).catch(() => console.log('fail'))" 2>/dev/null | grep -q ok; then
+    echo "✓ beautiful-mermaid: installed"
+else
+    # Try CommonJS require as fallback check
+    if node -e "try{require('$INSTALL_DIR/node_modules/beautiful-mermaid');console.log('ok')}catch(e){console.log('fail')}" 2>/dev/null | grep -q ok; then
+        echo "✓ beautiful-mermaid: installed"
+    else
+        echo "⚠ beautiful-mermaid: installed (module check inconclusive, may still work)"
+    fi
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Dependency directory: $INSTALL_DIR"
+echo ""
+echo "Usage:"
+echo "  node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output diagram.svg"
+echo "  node $SKILL_DIR/scripts/render-ascii.mjs --input diagram.mmd"
+echo "  node $SKILL_DIR/scripts/validate.mjs diagram.mmd"

--- a/.cursor/skills/mermaid-studio/scripts/validate.mjs
+++ b/.cursor/skills/mermaid-studio/scripts/validate.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/validate.mjs
+ *
+ * Validates Mermaid diagram syntax before rendering.
+ * Uses mermaid library's parser for accurate validation.
+ *
+ * Usage:
+ *   node validate.mjs <file.mmd>
+ *   node validate.mjs <file1.mmd> <file2.mmd>
+ *   echo "graph LR; A-->B" | node validate.mjs --stdin
+ *
+ * Exit codes:
+ *   0 = valid
+ *   1 = invalid syntax
+ *   2 = file not found or error
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { basename, dirname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+// Known diagram type keywords for basic pre-validation
+const DIAGRAM_TYPES = [
+  "flowchart",
+  "graph",
+  "sequenceDiagram",
+  "classDiagram",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "erDiagram",
+  "gantt",
+  "pie",
+  "mindmap",
+  "timeline",
+  "gitGraph",
+  "C4Context",
+  "C4Container",
+  "C4Component",
+  "C4Dynamic",
+  "C4Deployment",
+  "sankey-beta",
+  "xychart-beta",
+  "quadrantChart",
+  "block-beta",
+  "architecture-beta",
+  "packet-beta",
+  "kanban",
+  "journey",
+  "requirementDiagram",
+  "zenuml",
+];
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+function stripFrontmatter(content) {
+  // Remove YAML frontmatter (---...---)
+  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  if (match) return match[1].trim();
+  return content.trim();
+}
+
+function stripDirectives(content) {
+  // Remove %%{init: ...}%% directives
+  return content.replace(/%%\{[\s\S]*?\}%%/g, "").trim();
+}
+
+function stripComments(content) {
+  // Remove %% single-line comments
+  return content
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("%%"))
+    .join("\n")
+    .trim();
+}
+
+function detectDiagramType(content) {
+  const cleaned = stripFrontmatter(stripDirectives(stripComments(content)));
+  const firstLine = cleaned.split("\n")[0].trim();
+
+  for (const type of DIAGRAM_TYPES) {
+    if (firstLine.startsWith(type)) {
+      return type;
+    }
+  }
+  return null;
+}
+
+function basicValidation(content, filename) {
+  const errors = [];
+  const warnings = [];
+
+  // Empty check
+  if (!content.trim()) {
+    errors.push("File is empty");
+    return { errors, warnings };
+  }
+
+  // Detect diagram type
+  const cleaned = stripFrontmatter(stripDirectives(content));
+  const diagramType = detectDiagramType(content);
+  if (!diagramType) {
+    const firstLine = stripComments(stripFrontmatter(stripDirectives(content)))
+      .split("\n")[0]
+      .trim();
+    errors.push(
+      `Unknown diagram type. First content line: "${firstLine.slice(0, 50)}". ` +
+      `Expected one of: flowchart, graph, sequenceDiagram, classDiagram, etc.`
+    );
+  }
+
+  // Bracket matching
+  const lines = cleaned.split("\n");
+  let braces = 0;
+  let brackets = 0;
+  let parens = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip comments
+    if (line.trim().startsWith("%%")) continue;
+
+    for (const char of line) {
+      if (char === "{") braces++;
+      if (char === "}") braces--;
+      if (char === "[") brackets++;
+      if (char === "]") brackets--;
+      if (char === "(") parens++;
+      if (char === ")") parens--;
+
+      if (braces < 0)
+        errors.push(`Unmatched '}' at line ${i + 1}`);
+      if (brackets < 0)
+        errors.push(`Unmatched ']' at line ${i + 1}`);
+      if (parens < 0)
+        errors.push(`Unmatched ')' at line ${i + 1}`);
+    }
+  }
+
+  if (braces > 0) errors.push(`Unclosed '{' — missing ${braces} closing brace(s)`);
+  if (brackets > 0) errors.push(`Unclosed '[' — missing ${brackets} closing bracket(s)`);
+  if (parens > 0) errors.push(`Unclosed '(' — missing ${parens} closing paren(s)`);
+
+  // Common reserved words used as bare node IDs
+  const reservedWords = [
+    "end",
+    "graph",
+    "subgraph",
+    "style",
+    "class",
+    "click",
+    "linkStyle",
+    "default",
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("%%")) continue;
+
+    for (const word of reservedWords) {
+      // Check if reserved word is used as a bare node ID (without brackets)
+      const pattern = new RegExp(
+        `(?:^|-->|---|-\\.->|==>|\\s)${word}(?:\\s|-->|---|-\\.->|==>|$)`,
+        "i"
+      );
+      if (pattern.test(trimmed) && !trimmed.includes(`${word}[`) && !trimmed.includes(`${word}(`)) {
+        warnings.push(
+          `Line ${i + 1}: "${word}" is a reserved keyword. Use "${word}Node" or "${word}State" instead.`
+        );
+      }
+    }
+  }
+
+  // Check for common syntax mistakes
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("%%")) continue;
+
+    // Unescaped special characters in labels
+    if (trimmed.includes('[') && trimmed.includes(']')) {
+      const labelMatch = trimmed.match(/\[([^\]]*)\]/g);
+      if (labelMatch) {
+        for (const label of labelMatch) {
+          if (label.includes('"') && !label.startsWith('["')) {
+            warnings.push(
+              `Line ${i + 1}: Unquoted label with double quotes. Wrap in ["..."]: ${label.slice(0, 30)}`
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Node count warning
+  const nodePattern = /\b\w+[\[({]/g;
+  const nodeMatches = cleaned.match(nodePattern) || [];
+  if (nodeMatches.length > 25) {
+    warnings.push(
+      `High node count (~${nodeMatches.length}). Consider splitting into multiple diagrams for readability.`
+    );
+  }
+
+  return { errors, warnings };
+}
+
+async function mermaidParserValidation(content) {
+  // Try to use the mermaid library parser for deep validation
+  try {
+    const mermaidPath = resolve(DEPS_DIR, "node_modules/mermaid");
+    if (!existsSync(mermaidPath)) {
+      return { available: false };
+    }
+
+    const mermaid = await import(resolve(mermaidPath, "dist/mermaid.js")).catch(
+      () => import(resolve(mermaidPath, "dist/mermaid.esm.mjs")).catch(
+        () => null
+      )
+    );
+
+    if (!mermaid) return { available: false };
+
+    const m = mermaid.default || mermaid;
+    if (m.parse) {
+      await m.parse(stripFrontmatter(stripDirectives(content)));
+      return { available: true, valid: true };
+    }
+
+    return { available: false };
+  } catch (e) {
+    return {
+      available: true,
+      valid: false,
+      error: e.message || String(e),
+    };
+  }
+}
+
+function printResult(filename, basicResult, parserResult) {
+  const hasErrors = basicResult.errors.length > 0 || (parserResult?.available && !parserResult?.valid);
+  const hasWarnings = basicResult.warnings.length > 0;
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`File: ${filename}`);
+  console.log(`${"=".repeat(60)}`);
+
+  if (basicResult.errors.length > 0) {
+    console.log("\n❌ ERRORS:");
+    for (const err of basicResult.errors) {
+      console.log(`  • ${err}`);
+    }
+  }
+
+  if (parserResult?.available && !parserResult?.valid) {
+    console.log("\n❌ PARSER ERROR:");
+    console.log(`  • ${parserResult.error}`);
+  }
+
+  if (hasWarnings) {
+    console.log("\n⚠️  WARNINGS:");
+    for (const warn of basicResult.warnings) {
+      console.log(`  • ${warn}`);
+    }
+  }
+
+  if (!hasErrors) {
+    const diagramType = detectDiagramType(
+      readFileSync ? "" : ""
+    );
+    console.log(`\n✅ Valid${parserResult?.available ? " (parser verified)" : " (basic checks only)"}`);
+    if (hasWarnings) {
+      console.log("   (warnings above are non-blocking suggestions)");
+    }
+  }
+
+  return !hasErrors;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Mermaid Studio — Syntax Validator
+
+Usage:
+  node validate.mjs <file.mmd> [<file2.mmd> ...]
+  echo "graph LR; A-->B" | node validate.mjs --stdin
+
+Exit codes:
+  0 = all files valid
+  1 = syntax errors found
+  2 = file not found or runtime error
+`);
+    process.exit(0);
+  }
+
+  let allValid = true;
+
+  if (args.includes("--stdin")) {
+    const content = await readFromStdin();
+    const basicResult = basicValidation(content, "stdin");
+    const parserResult = await mermaidParserValidation(content);
+    if (!printResult("stdin", basicResult, parserResult)) {
+      allValid = false;
+    }
+  } else {
+    for (const arg of args) {
+      if (arg.startsWith("--")) continue;
+
+      const filepath = resolve(arg);
+      if (!existsSync(filepath)) {
+        console.error(`Error: File not found: ${filepath}`);
+        allValid = false;
+        continue;
+      }
+
+      const content = readFileSync(filepath, "utf-8");
+      const basicResult = basicValidation(content, filepath);
+      const parserResult = await mermaidParserValidation(content);
+      if (!printResult(basename(filepath), basicResult, parserResult)) {
+        allValid = false;
+      }
+    }
+  }
+
+  process.exit(allValid ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(2);
+});

--- a/.cursor/skills/tlc-spec-driven/.skill-meta.json
+++ b/.cursor/skills/tlc-spec-driven/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "69867b0e19be1fb556d2e697f0f18f1de0363d1aa2de9d36754d5b107156357c",
+  "downloadedAt": 1776159111004
+}

--- a/.cursor/skills/tlc-spec-driven/README.md
+++ b/.cursor/skills/tlc-spec-driven/README.md
@@ -1,0 +1,449 @@
+<p align="center">
+  <img src="https://img.shields.io/badge/Skill-TLC%20Spec--Driven-blue?style=for-the-badge" alt="skill badge" />
+  <img src="https://img.shields.io/badge/Stack-Agnostic-green?style=for-the-badge" alt="stack agnostic" />
+  <img src="https://img.shields.io/badge/Version-2.0.0-purple?style=for-the-badge" alt="version" />
+</p>
+
+<h1 align="center">🎯 TLC Spec-Driven</h1>
+
+<p align="center">
+  <strong>Plan and implement projects with precision. Granular tasks. Clear dependencies. Right tools. Zero ceremony.</strong>
+</p>
+
+<p align="center">
+  <em>From the <a href="https://github.com/tech-leads-club">Tech Lead's Club</a> community</em>
+</p>
+
+<p align="center">
+  <strong>Author:</strong> <a href="https://github.com/felipfr">Felipe Rodrigues</a> · 
+  <a href="https://linkedin.com/in/felipfr">LinkedIn</a>
+</p>
+
+## ✨ What Is This Skill?
+
+**TLC Spec-Driven** transforms how AI agents approach software projects. Instead of a rigid, bureaucratic pipeline, it uses **4 adaptive phases** that auto-size based on complexity — applying full rigor for complex features and skipping ceremony for simple ones:
+
+```
+┌──────────┐   ┌──────────┐   ┌─────────┐   ┌─────────┐
+│ SPECIFY  │ → │  DESIGN  │ → │  TASKS  │ → │ EXECUTE │
+└──────────┘   └──────────┘   └─────────┘   └─────────┘
+   required      optional*      optional*     required
+
+* Agent auto-skips when scope doesn't need it
+```
+
+**The complexity is in the system, not in your workflow.** You talk naturally — the skill decides how deep to go:
+
+| Scope                               | What happens                                                      |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| **Small** (≤3 files)                | Quick mode — describe → implement → verify → commit               |
+| **Medium** (clear feature)          | Specify → Execute (design and tasks inline)                       |
+| **Large** (multi-component)         | Full pipeline with formal design and task breakdown               |
+| **Complex** (ambiguity, new domain) | Full pipeline + gray area discussion + research + interactive UAT |
+
+## 🚀 Quick Start
+
+### Installation
+
+```bash
+npx @tech-leads-club/agent-skills install -s tlc-spec-driven
+```
+
+### First Commands
+
+| What You Want           | Say This                                      |
+| ----------------------- | --------------------------------------------- |
+| Start a new project     | `"Initialize project"` or `"Setup project"`   |
+| Work with existing code | `"Map codebase"` or `"Analyze existing code"` |
+| Plan a feature          | `"Specify feature [name]"`                    |
+| Quick bug fix           | `"Quick fix: [description]"`                  |
+| Resume previous work    | `"Resume work"` or `"Continue"`               |
+
+> 💬 **Natural Conversation, Not Commands**
+>
+> These are trigger phrases, not strict commands. The skill works through **natural conversation** — talk to your agent like you would to a colleague. Say things like _"I want to build an authentication system"_ or _"Fix the login button, it returns 401"_. The agent understands context and intent, not just keywords.
+
+## 📁 Project Structure
+
+The skill creates a `.specs/` directory to organize all project documentation:
+
+```
+.specs/
+├── project/
+│   ├── PROJECT.md      # Vision, goals, tech stack, constraints
+│   ├── ROADMAP.md      # Milestones, features, status tracking
+│   └── STATE.md        # Persistent memory: decisions, blockers, learnings, todos, deferred ideas
+│
+├── codebase/           # Brownfield analysis (existing projects only)
+│   ├── STACK.md        # Technology stack and dependencies
+│   ├── ARCHITECTURE.md # Patterns, data flow, code organization
+│   ├── CONVENTIONS.md  # Naming, style, coding patterns
+│   ├── STRUCTURE.md    # Directory layout and modules
+│   ├── TESTING.md      # Test frameworks and patterns
+│   ├── INTEGRATIONS.md # External services and APIs
+│   └── CONCERNS.md     # Tech debt, risks, fragile areas
+│
+├── features/           # Feature specifications
+│   └── [feature-name]/
+│       ├── spec.md     # Requirements with traceable IDs (FEAT-01, AUTH-02...)
+│       ├── context.md  # User decisions for gray areas (only when needed)
+│       ├── design.md   # Architecture and components (only for large/complex)
+│       └── tasks.md    # Atomic tasks with dependencies (only for large/complex)
+│
+└── quick/              # Ad-hoc tasks (quick mode)
+    └── NNN-slug/
+        ├── TASK.md     # Description + verification
+        └── SUMMARY.md  # What was done + commit
+```
+
+## 🔄 The Four Adaptive Phases
+
+### Specify (always)
+
+**Goal:** Capture WHAT to build with testable, traceable requirements.
+
+The agent acts as a thinking partner — not an interviewer. It asks clarifying questions, challenges vagueness, and captures requirements with traceable IDs:
+
+```markdown
+### P1: User Login ⭐ MVP
+
+**User Story:** As a user, I want to log in so that I can access my account.
+
+| Requirement ID | Acceptance Criteria                                                            |
+| -------------- | ------------------------------------------------------------------------------ |
+| AUTH-01        | WHEN user enters valid credentials THEN system SHALL authenticate and redirect |
+| AUTH-02        | WHEN user enters invalid credentials THEN system SHALL display error message   |
+| AUTH-03        | WHEN user is already logged in THEN system SHALL redirect to dashboard         |
+```
+
+**Discuss gray areas (auto-triggered):** When the spec has ambiguous, user-facing decisions (layout preferences, interaction patterns, error handling style), the agent automatically asks the user about them — creating a `context.md` that locks those decisions before design. This is NOT a separate phase — it only happens within Specify when ambiguity is detected.
+
+### Design (when needed)
+
+**Goal:** Define HOW to build it. Architecture, components, what to reuse.
+
+**Skipped when:** The change is straightforward — no architectural decisions, no new patterns. For simple features, design happens inline during Execute.
+
+**Includes research:** Before designing with unfamiliar tech, the agent follows the **Knowledge Verification Chain** (codebase → project docs → Context7 MCP → web search → flag uncertain). It **never assumes or fabricates** — if it can't find documentation, it says so.
+
+**Output:** `design.md` with architecture diagrams, component definitions, and integration points.
+
+### Tasks (when needed)
+
+**Goal:** Break into GRANULAR, ATOMIC tasks with clear dependencies.
+
+**Skipped when:** There are ≤3 obvious steps. In that case, tasks are listed inline at the start of Execute.
+
+**Safety valve:** If listing inline steps reveals >5 steps or complex dependencies, the agent STOPS and creates a formal `tasks.md` — acknowledging that the Tasks phase was wrongly skipped.
+
+| ❌ Vague Task | ✅ Atomic Tasks                   |
+| ------------- | --------------------------------- |
+| "Create form" | T1: Create email input component  |
+|               | T2: Add email validation function |
+|               | T3: Create submit button          |
+|               | T4: Add form state management     |
+
+Each task includes: What (deliverable), Where (file path), Depends on (prerequisites), Reuses (existing code), Requirement (traceable ID), Done when (verifiable criteria), Commit (message format).
+
+### Execute (always)
+
+**Goal:** Implement one task at a time. Verify. Commit. Repeat.
+
+Every task follows the same cycle:
+
+```
+Plan → Implement → Verify → Commit → Next
+```
+
+**Key principles:**
+
+- **Surgical changes** — Only touch required files
+- **No scope creep** — If it's not in the task, don't touch it. Capture ideas in STATE.md as Deferred Ideas
+- **Verify before commit** — Check all "Done when" criteria
+- **Atomic git commits** — One task = one commit, following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+
+```
+feat(auth): add email validation to login form
+
+refactor(api): extract token refresh logic into service
+
+fix(cart): prevent negative quantity on item decrement
+```
+
+**Feature-level validation** happens after all tasks complete — including acceptance criteria checks, code quality review, and optionally interactive UAT for complex user-facing features.
+
+## ⚡ Quick Mode
+
+For small tasks (bug fixes, config changes, tweaks ≤3 files) that don't need the full pipeline:
+
+```
+You: Quick fix: login button returns 401 because token refresh skips expired check
+
+Agent: Quick Task: Fix token refresh expired check
+       Files: src/services/auth.ts
+       Approach: Add expiry validation before refresh attempt
+       Verify: Login with expired token returns new session, not 401
+
+       [Implements...]
+
+       ✅ Done. Committed: fix(auth): add expiry check to token refresh
+```
+
+**Guardrails:** Max 3 files, max 1 hour, no design decisions, no new dependencies. If any of these are exceeded, the agent recommends the full pipeline.
+
+## 📋 Complete Command Reference
+
+These trigger patterns help the agent recognize your intent, but you don't need to use them verbatim. Speak naturally — the agent understands variations and context.
+
+### Project-Level
+
+| Trigger Pattern                              | Description                                           |
+| -------------------------------------------- | ----------------------------------------------------- |
+| `Initialize project`, `Setup project`        | Create PROJECT.md with vision, goals, and constraints |
+| `Create roadmap`, `Plan features`            | Create ROADMAP.md with milestones and features        |
+| `Map codebase`, `Analyze existing code`      | Create 7 brownfield docs for existing projects        |
+| `Document concerns`, `Find tech debt`        | Identify and document codebase risks                  |
+| `Record decision`, `Log blocker`, `Add todo` | Add entries to STATE.md                               |
+| `Pause work`, `End session`                  | Create handoff for session continuity                 |
+| `Resume work`, `Continue`                    | Load previous state and continue                      |
+
+### Feature-Level (auto-sized)
+
+| Trigger Pattern                           | Description                             |
+| ----------------------------------------- | --------------------------------------- |
+| `Specify feature`, `Define requirements`  | Create spec.md with requirement IDs     |
+| `Discuss feature`, `How should this work` | Capture user decisions for gray areas   |
+| `Design feature`, `Architecture`          | Create design.md with architecture      |
+| `Break into tasks`, `Create tasks`        | Create tasks.md with atomic breakdown   |
+| `Implement task`, `Build`, `Execute`      | Execute specific task with verification |
+| `Validate`, `Verify work`, `UAT`          | Feature-level validation and testing    |
+| `Quick fix`, `Quick task`, `Bug fix`      | Express lane for small changes          |
+
+## 🔁 Workflow Examples
+
+### Starting a New Project
+
+```
+You: Initialize project
+
+Agent: I'll help you set up your project. Let me ask a few questions:
+       1. What are you building?
+       2. Who is it for and what problem does it solve?
+       ...
+
+You: [Answer questions]
+
+Agent: ✅ Created .specs/project/PROJECT.md
+       Next: Would you like to create a roadmap? Say "Create roadmap"
+```
+
+### Working with an Existing Codebase
+
+```
+You: Map codebase
+
+Agent: I'll analyze your existing codebase and document:
+       - Technology stack, Architecture patterns, Coding conventions
+       - Project structure, Testing infrastructure, External integrations
+       - Concerns (tech debt, risks, fragile areas)
+
+       [Analyzes codebase...]
+
+       ✅ Created 7 brownfield docs in .specs/codebase/
+       Next: Initialize project to define goals and roadmap
+```
+
+### Implementing a Feature (auto-sized)
+
+```
+You: Specify feature user-authentication
+
+Agent: [Asks clarifying questions, creates spec.md with requirement IDs]
+       I notice some gray areas in the UX — how should failed login attempts behave?
+       [Discusses gray areas, creates context.md]
+
+You: Design the feature
+
+Agent: [Researches JWT best practices via Context7, creates design.md]
+
+You: Break into tasks
+
+Agent: [Creates tasks.md with 8 atomic tasks + parallel execution plan]
+
+You: Implement T1
+
+Agent: Implementing T1: Create auth service interface
+       Files: src/services/auth.interface.ts
+       Approach: Define interface based on design
+       Verify: Interface compiles, exports correctly
+
+       [Implements...]
+
+       ✅ Committed: feat(auth): create auth service interface
+       Next available: T2, T3 [P] (parallel)
+```
+
+### Quick Bug Fix
+
+```
+You: Quick fix: dark mode toggle doesn't persist after page refresh
+
+Agent: Quick Task: Persist dark mode preference
+       Files: src/hooks/useTheme.ts, src/utils/storage.ts
+       Approach: Save preference to localStorage on toggle
+       Verify: Toggle dark mode, refresh page, preference persists
+
+       [Implements...]
+
+       ✅ Committed: fix(theme): persist dark mode preference to localStorage
+```
+
+### Session Continuity
+
+```
+You: Pause work
+
+Agent: ✅ Created .specs/HANDOFF.md
+       - Feature: user-authentication
+       - Completed: T1, T2 (committed)
+       - In progress: T3 (70%)
+       - Next session: Continue T3, then T4
+
+--- Later, new session ---
+
+You: Resume work
+
+Agent: Resuming user-authentication at T3
+       - Completed: T1 (auth interface), T2 (token storage)
+       - In progress: T3 - auth service at src/services/auth.service.ts:45
+       - Next: Complete T3, then T4 (parallel with T5)
+
+       Continue with T3?
+```
+
+## 🧠 Context Management
+
+The skill is designed to work within context limits:
+
+| Load Strategy          | Documents                                   | Tokens |
+| ---------------------- | ------------------------------------------- | ------ |
+| **Base load** (always) | PROJECT.md, ROADMAP.md, STATE.md            | ~15k   |
+| **On-demand**          | Current spec, context, design, or tasks     | +5-10k |
+| **Never simultaneous** | Multiple feature specs or architecture docs | —      |
+
+**Target:** <40k tokens loaded (20% of context)
+**Reserve:** 160k+ tokens for work, reasoning, outputs
+
+When context exceeds 40k tokens, the skill displays a status indicator and suggests optimizations.
+
+## 🔗 Skill Integrations
+
+TLC Spec-Driven works even better when combined with complementary skills:
+
+| Skill              | Integration                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
+| **mermaid-studio** | Diagrams — architecture overviews, data flows, sequence diagrams                  |
+| **codenavi**       | Code exploration — brownfield mapping, pattern identification, dependency tracing |
+
+The skill automatically detects if these are installed and delegates specialized tasks to them. If not installed, it falls back gracefully and recommends them once per session.
+
+## 📚 Reference Files
+
+The skill includes detailed reference documentation loaded on-demand:
+
+| File                    | Purpose                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `project-init.md`       | Project initialization process and template                            |
+| `roadmap.md`            | Roadmap creation and milestone tracking                                |
+| `brownfield-mapping.md` | Comprehensive codebase analysis (7 docs)                               |
+| `concerns.md`           | Tech debt, risks, and fragile area documentation                       |
+| `specify.md`            | Requirements gathering with traceable IDs                              |
+| `discuss.md`            | Gray area discussion and context capture                               |
+| `design.md`             | Architecture, research, and component design                           |
+| `tasks.md`              | Granular task breakdown methodology                                    |
+| `implement.md`          | Execute: implementation + verification + atomic commits                |
+| `validate.md`           | Feature validation and interactive UAT                                 |
+| `quick-mode.md`         | Express lane for ad-hoc tasks                                          |
+| `session-handoff.md`    | Pause/resume work process                                              |
+| `state-management.md`   | Persistent memory: decisions, blockers, lessons, todos, deferred ideas |
+| `coding-principles.md`  | Behavioral guidelines for implementation                               |
+| `context-limits.md`     | Token budget and monitoring                                            |
+| `code-analysis.md`      | Available tools and fallbacks                                          |
+
+## ⚡ Tips for Best Results
+
+### Do's ✅
+
+- **Start with project initialization** — Even for existing codebases
+- **Be specific about scope** — Clear boundaries prevent creep
+- **Trust the auto-sizing** — The agent applies the right depth
+- **Use natural language** — No need to memorize commands
+- **Say "pause work" before ending** — Enables seamless resumption
+- **Challenge the agent** — If something looks wrong, say so
+
+### Don'ts ❌
+
+- **Don't force all phases** — Let the agent skip what's unnecessary
+- **Don't work on multiple features at once** — One feature per cycle
+- **Don't ignore verification** — Even quick tasks need a verify step
+- **Don't accept vague answers** — If the agent says something fuzzy, ask for specifics
+
+## 💡 Model Recommendation
+
+> **Best results with modern, reasoning-capable models:**
+>
+> - **Claude Opus 4.6 / Sonnet 4.5** — Excellent for all phases
+> - **Gemini 3 Pro / GPT 5.2** — Strong reasoning and large context window
+> - **Gemini 3 Flash / Claude Haiku 4.5** — Great general-purpose performance
+>
+> For cost optimization, the skill will suggest when lighter models are sufficient for simple tasks like validation or session handoff.
+
+## 🤖 Compatibility
+
+This skill works with **any AI coding agent** that supports skills or custom instructions.
+
+**Tested and verified on:**
+
+| Agent                | Status    |
+| -------------------- | --------- |
+| Antigravity (Gemini) | ✅ Tested |
+| Claude Code          | ✅ Tested |
+| GitHub Copilot       | ✅ Tested |
+| Cursor               | ✅ Tested |
+| Opencode             | ✅ Tested |
+
+> **Note:** If your agent supports loading custom instructions or skills, this skill should work. The agents above are simply where it has been actively tested.
+
+## ❓ FAQ
+
+**Q: Can I skip phases?**
+A: Yes! The skill auto-sizes. Design and Tasks are skipped for simple features. Quick mode skips the entire pipeline for small changes. You only get ceremony when scope demands it.
+
+**Q: What if my project already has code?**
+A: Use `"Map codebase"` first. This creates 7 documents analyzing your existing architecture, conventions, stack, and concerns before you start adding features.
+
+**Q: How does requirement traceability work?**
+A: Each requirement gets a unique ID (e.g., `AUTH-01`) in spec.md. Tasks reference these IDs, and validation checks which requirements are verified. You get a clear trail from spec → design → task → commit.
+
+**Q: What are atomic git commits?**
+A: Each task produces exactly one commit following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). This means clean git history, easy bisect for debugging, and simple rollbacks when needed.
+
+**Q: Can I use this for small tasks or quick fixes?**
+A: Yes! Say `"Quick fix: [description]"` for bug fixes, config changes, or small tweaks. You get quality guardrails (verify + commit) without the planning overhead.
+
+**Q: What happens if I close my session mid-task?**
+A: Say `"Pause work"` before ending your session. This creates a handoff document. Next session, say `"Resume work"` to continue exactly where you left off.
+
+**Q: Does this work with any tech stack?**
+A: Yes! The skill is completely stack-agnostic. It works with any language, framework, or architecture.
+
+**Q: What if the agent invents an API or pattern that doesn't exist?**
+A: The skill enforces a strict **Knowledge Verification Chain**: codebase → project docs → Context7 MCP → web search → flag as uncertain. It NEVER fabricates information. If the agent can't find documentation, it will say "I don't know" instead of guessing.
+
+## 📄 License
+
+CC-BY-4.0 © [Tech Lead's Club](https://github.com/tech-leads-club)
+
+<p align="center">
+  <sub>Built with ❤️ by the Tech Lead's Club community</sub>
+</p>

--- a/.cursor/skills/tlc-spec-driven/SKILL.md
+++ b/.cursor/skills/tlc-spec-driven/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: tlc-spec-driven
+description: Project and feature planning with 4 adaptive phases - Specify, Design, Tasks, Execute. Auto-sizes depth by complexity. Creates atomic tasks with verification criteria, atomic git commits, requirement traceability, and persistent memory across sessions. Stack-agnostic. Use when (1) Starting new projects (initialize vision, goals, roadmap), (2) Working with existing codebases (map stack, architecture, conventions), (3) Planning features (requirements, design, task breakdown), (4) Implementing with verification and atomic commits, (5) Quick ad-hoc tasks (bug fixes, config changes), (6) Tracking decisions/blockers/deferred ideas across sessions, (7) Pausing/resuming work. Triggers on "initialize project", "map codebase", "specify feature", "discuss feature", "design", "tasks", "implement", "validate", "verify work", "UAT", "quick fix", "quick task", "pause work", "resume work". Do NOT use for architecture decomposition analysis (use architecture skills) or technical design docs (use create-technical-design-doc).
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: 2.0.0
+---
+
+# Tech Lead's Club - Spec-Driven Development
+
+Plan and implement projects with precision. Granular tasks. Clear dependencies. Right tools. Zero ceremony.
+
+```
+┌──────────┐   ┌──────────┐   ┌─────────┐   ┌─────────┐
+│ SPECIFY  │ → │  DESIGN  │ → │  TASKS  │ → │ EXECUTE │
+└──────────┘   └──────────┘   └─────────┘   └─────────┘
+   required      optional*      optional*     required
+
+* Agent auto-skips when scope doesn't need it
+```
+
+## Auto-Sizing: The Core Principle
+
+**The complexity determines the depth, not a fixed pipeline.** Before starting any feature, assess its scope and apply only what's needed:
+
+| Scope       | What                     | Specify                                                 | Design                                          | Tasks                         | Execute                                               |
+| ----------- | ------------------------ | ------------------------------------------------------- | ----------------------------------------------- | ----------------------------- | ----------------------------------------------------- |
+| **Small**   | ≤3 files, one sentence   | **Quick mode** — skip pipeline entirely                 | -                                               | -                             | -                                                     |
+| **Medium**  | Clear feature, <10 tasks | Spec (brief)                                            | Skip — design inline                            | Skip — tasks implicit         | Implement + verify                                    |
+| **Large**   | Multi-component feature  | Full spec + requirement IDs                             | Architecture + components                       | Full breakdown + dependencies | Implement + verify per task                           |
+| **Complex** | Ambiguity, new domain    | Full spec + [discuss gray areas](references/discuss.md) | [Research](references/design.md) + architecture | Breakdown + parallel plan     | Implement + [interactive UAT](references/validate.md) |
+
+**Rules:**
+
+- **Specify and Execute are always required** — you always need to know WHAT and DO it
+- **Design is skipped** when the change is straightforward (no architectural decisions, no new patterns)
+- **Tasks is skipped** when there are ≤3 obvious steps (they become implicit in Execute)
+- **Discuss is triggered within Specify** only when the agent detects ambiguous gray areas that need user input
+- **Interactive UAT is triggered within Execute** only for user-facing features with complex behavior
+- **Quick mode** is the express lane — for bug fixes, config changes, and small tweaks
+
+**Safety valve:** Even when Tasks is skipped, Execute ALWAYS starts by listing atomic steps inline (see [implement.md](references/implement.md)). If that listing reveals >5 steps or complex dependencies, STOP and create a formal `tasks.md` — the Tasks phase was wrongly skipped.
+
+## Project Structure
+
+```
+.specs/
+├── project/
+│   ├── PROJECT.md      # Vision & goals
+│   ├── ROADMAP.md      # Features & milestones
+│   └── STATE.md        # Memory: decisions, blockers, lessons, todos, deferred ideas
+├── codebase/           # Brownfield analysis (existing projects)
+│   ├── STACK.md
+│   ├── ARCHITECTURE.md
+│   ├── CONVENTIONS.md
+│   ├── STRUCTURE.md
+│   ├── TESTING.md
+│   ├── INTEGRATIONS.md
+│   └── CONCERNS.md
+├── features/           # Feature specifications
+│   └── [feature]/
+│       ├── spec.md     # Requirements with traceable IDs
+│       ├── context.md  # User decisions for gray areas (only when discuss is triggered)
+│       ├── design.md   # Architecture & components (only for Large/Complex)
+│       └── tasks.md    # Atomic tasks with verification (only for Large/Complex)
+└── quick/              # Ad-hoc tasks (quick mode)
+    └── NNN-slug/
+        ├── TASK.md
+        └── SUMMARY.md
+```
+
+## Workflow
+
+**New project:**
+
+1. Initialize project → PROJECT.md + ROADMAP.md
+2. For each feature → Specify → (Design) → (Tasks) → Execute (depth auto-sized)
+
+**Existing codebase:**
+
+1. Map codebase → 7 brownfield docs
+2. Initialize project → PROJECT.md + ROADMAP.md
+3. For each feature → same adaptive workflow
+
+**Quick mode:** Describe → Implement → Verify → Commit (for ≤3 files, one-sentence scope)
+
+## Context Loading Strategy
+
+**Base load (~15k tokens):**
+
+- PROJECT.md (if exists)
+- ROADMAP.md (when planning/working on features)
+- STATE.md (persistent memory)
+
+**On-demand load:**
+
+- Codebase docs (when working in existing project)
+- CONCERNS.md (when planning features that touch flagged areas, estimating risk, or modifying fragile components)
+- TESTING.md (when creating tasks or executing — drives test type assignment and gate checks)
+- spec.md (when working on specific feature)
+- context.md (when designing or implementing from user decisions)
+- design.md (when implementing from design)
+- tasks.md (when executing tasks)
+
+**Never load simultaneously:**
+
+- Multiple feature specs
+- Multiple architecture docs
+- Archived documents
+
+**Target:** <40k tokens total context
+**Reserve:** 160k+ tokens for work, reasoning, outputs
+**Monitoring:** Display status when >40k (see [context-limits.md](references/context-limits.md))
+
+## Sub-Agent Delegation
+
+Use sub-agents (the Task tool or equivalent) to keep the main context window lean and enable
+parallel execution. The orchestrating agent plans and coordinates; sub-agents do the heavy lifting.
+
+**When to delegate to a sub-agent:**
+
+| Activity | Delegate? | Why |
+|---|---|---|
+| Research (design phase, brownfield mapping) | Yes | Research output is large; only the summary matters to the main context |
+| Implementing a task | Yes | File reads, edits, test output consume context; only the result matters |
+| Parallel `[P]` tasks | Yes (one per task) | The only way to actually run tasks in parallel |
+| Sequential tasks with no `[P]` | Yes | Keeps implementation artifacts out of the main context |
+| Planning, task creation, validation reports | No | These require the full accumulated context to be coherent |
+| Quick mode tasks | No | Too small to justify the overhead |
+
+**Context each sub-agent receives:**
+
+The orchestrating agent MUST provide each sub-agent with:
+- The specific task definition from tasks.md (What, Where, Depends on, Reuses, Done when, Tests, Gate)
+- Relevant coding principles and conventions (coding-principles.md, CONVENTIONS.md)
+- TESTING.md, if it exists (for gate check commands and test patterns)
+- Any spec/design context the task references
+
+The sub-agent does NOT receive: other tasks' definitions, accumulated chat history, validation reports
+from other tasks, or STATE.md (unless the task explicitly references a decision/blocker).
+
+**What sub-agents return:**
+
+Each sub-agent reports back:
+- Status: Complete | Blocked | Partial
+- Files changed: [list]
+- Gate check result: [pass/fail + test counts]
+- SPEC_DEVIATION markers (if any)
+- Issues encountered (if any)
+
+The orchestrating agent uses this to update tasks.md status, traceability, and decide next steps.
+
+## Commands
+
+**Project-level:**
+| Trigger Pattern | Reference |
+|----------------|-----------|
+| Initialize project, setup project | [project-init.md](references/project-init.md) |
+| Create roadmap, plan features | [roadmap.md](references/roadmap.md) |
+| Map codebase, analyze existing code | [brownfield-mapping.md](references/brownfield-mapping.md) |
+| Document concerns, find tech debt, what's risky | [concerns.md](references/concerns.md) |
+| Record decision, log blocker, add todo | [state-management.md](references/state-management.md) |
+| Pause work, end session | [session-handoff.md](references/session-handoff.md) |
+| Resume work, continue | [session-handoff.md](references/session-handoff.md) |
+
+**Feature-level (auto-sized):**
+| Trigger Pattern | Reference |
+|----------------|-----------|
+| Specify feature, define requirements | [specify.md](references/specify.md) |
+| Discuss feature, capture context, how should this work | [discuss.md](references/discuss.md) |
+| Design feature, architecture | [design.md](references/design.md) |
+| Break into tasks, create tasks | [tasks.md](references/tasks.md) |
+| Implement task, build, execute | [implement.md](references/implement.md) |
+| Validate, verify, test, UAT, walk me through it | [validate.md](references/validate.md) |
+| Quick fix, quick task, small change, bug fix | [quick-mode.md](references/quick-mode.md) |
+
+## Skill Integrations
+
+This skill coexists with other skills. Before specific tasks, check if complementary skills are installed and prefer them when available.
+
+### Diagrams → mermaid-studio
+
+Whenever the workflow requires creating or updating a diagram (architecture overviews, data flows, component diagrams, sequence diagrams, etc.), **always** check if the `mermaid-studio` skill is installed in the user's environment before proceeding. If it is installed, delegate all diagram creation and rendering to it. If it is not installed, proceed with inline mermaid code blocks as usual and recommend the user install `mermaid-studio` for richer diagram capabilities (rendering to SVG/PNG, validation, theming, etc.). Display this recommendation at most once per session.
+
+### Code Exploration → codenavi
+
+Whenever the workflow requires exploring or discovering things in an existing repository (brownfield mapping, code reuse analysis, pattern identification, dependency tracing, etc.), **always** check if the `codenavi` skill is installed in the user's environment before proceeding. If it is installed, delegate code exploration and navigation tasks to it. If it is not installed, fall back to the built-in code analysis tools (see [code-analysis.md](references/code-analysis.md)) and recommend the user install `codenavi` for more effective codebase exploration. Display this recommendation at most once per session.
+
+## Knowledge Verification Chain
+
+When researching, designing, or making any technical decision, follow this chain in strict order. Never skip steps.
+
+```
+Step 1: Codebase → check existing code, conventions, and patterns already in use
+Step 2: Project docs → README, docs/, inline comments, .specs/codebase/
+Step 3: Context7 MCP → resolve library ID, then query for current API/patterns
+Step 4: Web search → official docs, reputable sources, community patterns
+Step 5: Flag as uncertain → "I'm not certain about X — here's my reasoning, but verify"
+```
+
+**Rules:**
+
+- Never skip to Step 5 if Steps 1-4 are available
+- Step 5 is ALWAYS flagged as uncertain — never presented as fact
+- **NEVER assume or fabricate.** If you cannot find an answer, say "I don't know" or "I couldn't find documentation for this". Inventing APIs, patterns, or behaviors causes cascading failures across design → tasks → implementation. Uncertainty is always preferable to fabrication.
+
+## Output Behavior
+
+**Model guidance:** After completing lightweight tasks (validation, state updates, session handoff), naturally mention once that such tasks work well with faster/cheaper models. Track in STATE.md under `Preferences` to avoid repeating. For heavy tasks (brownfield mapping, complex design), briefly note the reasoning requirements before starting.
+
+Be conversational, not robotic. Don't interrupt workflow—add as a natural closing note. Skip if user seems experienced or has already acknowledged the tip.
+
+## Code Analysis
+
+Use available tools with graceful degradation. See [code-analysis.md](references/code-analysis.md).

--- a/.cursor/skills/tlc-spec-driven/references/brownfield-mapping.md
+++ b/.cursor/skills/tlc-spec-driven/references/brownfield-mapping.md
@@ -1,0 +1,455 @@
+# Brownfield Mapping
+
+**Trigger:** "Map codebase", "Analyze existing code", "Document current architecture"
+
+**Purpose:** Understand existing project structure before adding features.
+
+## Process
+
+Before starting, check if the `codenavi` skill is available for code exploration (see Skill Integrations in SKILL.md). If available, prefer it for all discovery and navigation tasks below.
+
+**High-level approach:**
+
+1. Explore directory structure systematically
+2. Identify technology stack from dependency manifests
+3. Extract patterns from representative code samples
+4. Document observed conventions and architectures
+5. Catalog external integrations
+6. Identify concerns: tech debt, known bugs, security risks, performance bottlenecks, fragile areas
+
+**Analysis depth:**
+
+- Sample 5-10 representative files per category
+- Focus on consistency and patterns, not exhaustive coverage
+- Extract actual examples, not assumptions
+
+## Output: 7 Files in .specs/codebase/
+
+---
+
+### 1. STACK.md
+
+**Purpose:** Document technology stack and dependencies.
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Extract from:**
+
+- Dependency manifest files
+- Build configuration
+- Runtime configuration
+
+**Document:**
+
+```markdown
+# Tech Stack
+
+**Analyzed:** [date]
+
+## Core
+
+- Framework: [detected name + version]
+- Language: [detected name + version]
+- Runtime: [detected name + version]
+- Package manager: [detected manager]
+
+## Frontend (if applicable)
+
+- UI Framework: [name + version]
+- Styling: [approach + tools]
+- State Management: [library/pattern]
+- Form Handling: [library if present]
+
+## Backend (if applicable)
+
+- API Style: [REST/GraphQL/gRPC + framework]
+- Database: [ORM/query builder + database system]
+- Authentication: [library/approach]
+
+## Testing
+
+- Unit: [framework]
+- Integration: [framework]
+- E2E: [framework if present]
+
+## External Services
+
+- [Category]: [Service name]
+- [Category]: [Service name]
+
+## Development Tools
+
+- [Tool category]: [Tool name]
+```
+
+**Instructions:**
+
+- Extract from actual dependency files
+- Include versions for major dependencies
+- Categorize by purpose
+- Note testing frameworks explicitly
+
+---
+
+### 2. ARCHITECTURE.md
+
+**Purpose:** Document architectural patterns and data flow.
+
+**Size limit:** 4,000 tokens (~2,400 words)
+
+**Extract from:**
+
+- Directory organization
+- Code structure analysis
+- Repeated patterns across files
+
+**Document:**
+
+```markdown
+# Architecture
+
+**Pattern:** [Identified pattern - monolith/microservices/modular/etc]
+
+## High-Level Structure
+
+[Create diagram/description based on actual organization]
+
+## Identified Patterns
+
+### [Pattern Name]
+
+**Location:** [where this pattern lives]
+**Purpose:** [what this achieves]
+**Implementation:** [how it's structured]
+**Example:** [reference to actual file/function]
+
+### [Pattern Name]
+
+[Same structure]
+
+## Data Flow
+
+### [Key Flow - e.g., Authentication/Payment/etc]
+
+[Map actual flow from code analysis]
+
+### [Key Flow]
+
+[Map actual flow]
+
+## Code Organization
+
+**Approach:** [feature-based/layer-based/domain-driven/etc]
+
+**Structure:**
+[Document actual directory organization]
+
+**Module boundaries:**
+[How code is divided into modules/packages]
+```
+
+**Instructions:**
+
+- Identify patterns from actual code, not assumptions
+- Document observed architectural decisions
+- Create flow diagrams for critical paths
+- Reference concrete examples from codebase
+
+---
+
+### 3. CONVENTIONS.md
+
+**Purpose:** Document code style and naming conventions.
+
+**Size limit:** 3,000 tokens (~1,800 words)
+
+**Extract from:**
+
+- Analyzing 5-10 representative files
+- Identifying consistent patterns
+- Observing actual conventions in use
+
+**Document:**
+
+```markdown
+# Code Conventions
+
+## Naming Conventions
+
+**Files:**
+[Observed pattern - document actual approach]
+Examples: [actual filenames from codebase]
+
+**Functions/Methods:**
+[Observed pattern]
+Examples: [actual function names]
+
+**Variables:**
+[Observed pattern]
+Examples: [actual variable names]
+
+**Constants:**
+[Observed pattern]
+Examples: [actual constant names]
+
+## Code Organization
+
+**Import/Dependency Declaration:**
+[Observed ordering pattern]
+[Example from actual file]
+
+**File Structure:**
+[Observed organization within files]
+[Example from actual file]
+
+## Type Safety/Documentation
+
+**Approach:** [Type system/documentation approach used]
+[Example from actual code]
+
+## Error Handling
+
+**Pattern:** [Observed error handling approach]
+[Example from actual code]
+
+## Comments/Documentation
+
+**Style:** [When/how comments are used]
+[Example from actual code]
+```
+
+**Instructions:**
+
+- Extract patterns from actual code samples
+- Document observed conventions, not ideal conventions
+- Include concrete examples from codebase
+- Note exceptions or variations where found
+
+---
+
+### 4. STRUCTURE.md
+
+**Purpose:** Document directory layout and file organization.
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Document:**
+
+```markdown
+# Project Structure
+
+**Root:** [project root path]
+
+## Directory Tree
+
+[Visual tree representation - max 3 levels deep]
+
+## Module Organization
+
+### [Module/Area Name]
+
+**Purpose:** [what this area handles]
+**Location:** [where files live]
+**Key files:** [important files in this area]
+
+### [Module/Area Name]
+
+[Same structure]
+
+## Where Things Live
+
+**[Capability/Feature]:**
+
+- UI/Interface: [location]
+- Business Logic: [location]
+- Data Access: [location]
+- Configuration: [location]
+
+**[Capability/Feature]:**
+[Same structure]
+
+## Special Directories
+
+**[Directory name]:**
+**Purpose:** [what belongs here]
+**Examples:** [key files in this directory]
+```
+
+**Instructions:**
+
+- Create tree view of actual directory structure
+- Limit depth to maintain readability
+- Document purpose of key directories
+- Map capabilities to physical locations
+
+---
+
+### 5. TESTING.md
+
+**Purpose:** Document testing infrastructure and patterns.
+
+**Size limit:** 4,000 tokens (~2,400 words)
+
+**Document:**
+
+```markdown
+# Testing Infrastructure
+
+## Test Frameworks
+
+**Unit/Integration:** [framework name + version]
+**E2E:** [framework name + version]
+**Coverage:** [tool if used]
+
+## Test Organization
+
+**Location:** [where tests live]
+**Naming:** [test file naming pattern]
+**Structure:** [how tests are organized]
+
+## Testing Patterns
+
+### Unit Tests
+
+**Approach:** [observed pattern]
+**Location:** [where unit tests live]
+[Description of actual pattern used]
+
+### Integration Tests
+
+**Approach:** [observed pattern]
+**Location:** [where integration tests live]
+[Description of actual pattern used]
+
+### E2E Tests
+
+**Approach:** [observed pattern if present]
+**Location:** [where E2E tests live]
+[Description of actual pattern used]
+
+## Test Execution
+
+**Commands:** [how to run tests]
+**Configuration:** [test configuration approach]
+
+## Coverage Targets
+
+**Current:** [if measurable]
+**Goals:** [if documented]
+**Enforcement:** [if automated]
+
+## Test Coverage Matrix
+
+Analyze the codebase to determine which code layers require which test types.
+For each layer, document the required test type, file location pattern, and run command.
+
+| Code Layer | Required Test Type          | Location Pattern       | Run Command |
+| ---------- | --------------------------- | ---------------------- | ----------- |
+| [layer]    | [unit/integration/e2e/none] | [glob or path pattern] | [command]   |
+
+## Parallelism Assessment
+
+| Test Type | Parallel-Safe? | Isolation Model | Evidence                      |
+| --------- | -------------- | --------------- | ----------------------------- |
+| [type]    | [Yes/No]       | [description]   | [file/pattern that proves it] |
+
+## Gate Check Commands
+
+| Gate Level | When to Use                            | Command                     |
+| ---------- | -------------------------------------- | --------------------------- |
+| Quick      | After tasks with unit tests only       | [unit test command]         |
+| Full       | After tasks with e2e/integration tests | [unit + e2e commands]       |
+| Build      | After phase completion                 | [build + lint + unit + e2e] |
+```
+
+**Instructions:**
+
+- Identify test frameworks from dependencies and code
+- Document actual testing patterns observed
+- Note test organization approach
+- Include execution instructions
+- **Test Coverage Matrix:** Sample 5-10 existing test files to identify which layers are tested and how. Look at test file locations relative to source to determine patterns. Extract run commands from `package.json`, `project.json`, `Makefile`, CI config. Mark layers with no existing tests as "none" with a note in CONCERNS.md.
+- **Parallelism Assessment:** NOT parallel-safe signals: shared DB connection (same URL from config), table-level cleanup in `beforeEach`/`afterAll` (`.del()`, `DELETE FROM`, `TRUNCATE`), shared mock state reset on globals. Parallel-safe signals: per-test DB creation (Testcontainers, dynamic schema, SQLite in-memory), data namespacing (all data keyed by unique test ID), no shared mutable state between test files, all deps mocked (`jest.fn()`, `vi.fn()`).
+- **Gate Check Commands:** Extract from actual project commands — do not invent commands.
+
+---
+
+### 6. INTEGRATIONS.md
+
+**Purpose:** Document external service integrations.
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+**Document:**
+
+```markdown
+# External Integrations
+
+## [Service Category]
+
+**Service:** [service name]
+**Purpose:** [what this integration provides]
+**Implementation:** [where integration lives in code]
+**Configuration:** [how service is configured]
+**Authentication:** [auth approach if applicable]
+
+## [Service Category]
+
+[Same structure]
+
+## API Integrations
+
+### [API Name]
+
+**Purpose:** [what this API provides]
+**Location:** [where API client/code lives]
+**Authentication:** [auth method]
+**Key endpoints:** [major endpoints used]
+
+## Webhooks
+
+### [Webhook Source]
+
+**Purpose:** [what events are handled]
+**Location:** [webhook handler location]
+**Events:** [event types processed]
+
+## Background Jobs
+
+**Queue system:** [system if used]
+**Location:** [where job definitions live]
+**Jobs:** [key background jobs]
+```
+
+**Instructions:**
+
+- Identify integrations from code and configuration
+- Document authentication approaches
+- Note webhook handlers if present
+- Include background job infrastructure
+
+---
+
+### 7. CONCERNS.md
+
+**Purpose:** Surface actionable warnings about the codebase — tech debt, known bugs, security gaps, performance bottlenecks, fragile areas, scaling limits, risky dependencies, missing features, and test coverage gaps.
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+See [concerns.md](concerns.md) for the full template, guidelines, and examples.
+
+**Instructions:**
+
+- Document only concerns backed by evidence (file paths, measurements, reproduction steps)
+- Include fix approaches, not just problems
+- Omit sections with no findings
+- Prioritize by risk/impact
+- Use professional, solution-oriented tone
+
+---
+
+## Total Context Budget
+
+**Combined:** ~19,000 tokens (10% of context window)
+**Acceptable for:** Brownfield projects requiring codebase understanding
+**Loading strategy:** Load relevant docs on-demand based on task

--- a/.cursor/skills/tlc-spec-driven/references/code-analysis.md
+++ b/.cursor/skills/tlc-spec-driven/references/code-analysis.md
@@ -1,0 +1,98 @@
+# Code Analysis Tools
+
+Use graceful degradation for code search and structural analysis.
+
+## Tool Priority
+
+1. **ast-grep** (`sg`) - Structural pattern-based search
+2. **ripgrep** (`rg`) - Fast context-aware text search
+3. **grep** - Standard text search (always available)
+
+## Detection
+
+Check tool availability before use:
+
+```bash
+# Check for ast-grep
+if command -v sg >/dev/null 2>&1; then
+  # Use ast-grep for structural search
+elif command -v rg >/dev/null 2>&1; then
+  # Fall back to ripgrep
+else
+  # Use standard grep as final fallback
+fi
+```
+
+## Usage Examples
+
+**Finding function definitions:**
+
+```bash
+# ast-grep (best - structural)
+sg -p 'function $NAME($$$) { $$$ }'
+
+# ripgrep (fallback - fast text)
+rg '^function\s+\w+\(' --type-add 'source:*.[extension]' -t source
+
+# grep (last resort - basic)
+grep -r '^function ' --include="*.[extension]"
+```
+
+**Finding imports/requires:**
+
+```bash
+# ast-grep
+sg -p 'import { $$$ } from "$MODULE"'
+
+# ripgrep
+rg '^import .* from' --type-add 'source:*.[extension]' -t source
+
+# grep
+grep -r '^import ' --include="*.[extension]"
+```
+
+**Finding class/component definitions:**
+
+```bash
+# ast-grep
+sg -p 'class $NAME { $$$ }'
+
+# ripgrep
+rg '^(class|export class)\s+\w+' --type-add 'source:*.[extension]' -t source
+
+# grep
+grep -r '^class ' --include="*.[extension]"
+```
+
+## Search Scope
+
+**Best practices:**
+
+- Limit to source file extensions relevant to project
+- Exclude directories: `node_modules`, `vendor`, `dist`, `build`, `.git`
+- Focus on source directories: `src`, `lib`, `app`
+- Use file type filters when available
+
+**Performance tips:**
+
+- Use specific patterns over broad searches
+- Limit directory depth with `--max-depth` (ripgrep/grep)
+- Cache results for repeated queries
+
+## Fallback Notice
+
+If ast-grep unavailable, display once per session:
+
+```
+⚠️ ast-grep not detected. Install for more precise structural code analysis.
+   https://ast-grep.github.io/guide/quick-start.html
+```
+
+## When to Use
+
+- Finding usage patterns across codebase
+- Identifying code structure and organization
+- Locating function/class/component definitions
+- Analyzing import/dependency patterns
+- Refactoring impact analysis
+- Code navigation in unfamiliar codebases

--- a/.cursor/skills/tlc-spec-driven/references/coding-principles.md
+++ b/.cursor/skills/tlc-spec-driven/references/coding-principles.md
@@ -1,0 +1,56 @@
+# Coding Principles
+
+Behavioral bias, not checklist. Read before every implementation.
+
+---
+
+## Before Coding
+
+- State assumptions explicitly. If uncertain, ask.
+- Multiple interpretations exist? Present all—don't pick silently.
+- Simpler approach exists? Say so. Push back when warranted.
+- Something unclear? Stop. Name what's confusing. Ask.
+- User's approach seems wrong? Disagree honestly. Don't be sycophantic.
+
+---
+
+## During Implementation
+
+### Simplicity
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" not requested
+- No error handling for impossible scenarios
+- 200 lines that could be 50? Rewrite it.
+
+### Surgical Changes
+
+- Don't "improve" adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Match existing style, even if you'd do differently
+- Unrelated dead code noticed? Mention it—don't delete it
+- Remove ONLY imports/variables/functions YOUR changes orphaned
+- Don't remove pre-existing dead code unless asked
+
+### Test Integrity
+
+- NEVER weaken an existing test assertion to make it pass
+- NEVER delete a test to reduce failure count
+- NEVER use the test framework's skip/disable/pending mechanism to bypass a failing test
+- NEVER modify tests written in the RED phase during GREEN phase
+- If a test is genuinely wrong, STOP and confirm with the user before changing it
+- Tests are the spec — implementation conforms to tests, not the other way around
+
+### Goal-Driven
+
+- Transform vague tasks into verifiable goals
+- Multi-step work? State brief plan with verify checkpoints
+- Every changed line must trace directly to user's request
+
+---
+
+## After Each Change
+
+Ask: "Would senior engineer call this overcomplicated?"
+If yes → simplify before proceeding.

--- a/.cursor/skills/tlc-spec-driven/references/concerns.md
+++ b/.cursor/skills/tlc-spec-driven/references/concerns.md
@@ -1,0 +1,193 @@
+# Phase: Codebase Concerns
+
+**Trigger:** Part of brownfield mapping, or explicitly "document concerns", "find tech debt", "what's risky in this codebase"
+
+**Purpose:** Surface actionable warnings about the codebase. Focused on "what to watch out for when making changes." This is living documentation, not a complaint list.
+
+## When to Generate
+
+CONCERNS.md is generated as part of the brownfield mapping flow (alongside STACK.md, ARCHITECTURE.md, etc.). It can also be created or updated independently when:
+
+- Exploring a new area of the codebase reveals risks
+- A bug investigation uncovers systemic issues
+- A feature implementation hits unexpected fragility
+- A dependency audit reveals risks
+
+## Process
+
+### 1. Gather Evidence
+
+During codebase exploration, look for concrete signals — not opinions. Evidence sources:
+
+- Code patterns that indicate shortcuts (TODO/FIXME/HACK comments, duplicated logic, missing error handling)
+- Test coverage gaps (untested critical paths, missing edge cases)
+- Dependency manifests (outdated packages, deprecated libraries, security advisories)
+- Performance indicators (N+1 queries, missing indexes, synchronous blocking calls)
+- Security patterns (client-side-only auth checks, unvalidated inputs, exposed secrets)
+
+### 2. Classify and Document
+
+Each concern must have: **what** the problem is, **where** it lives (file paths), **why** it matters (impact), and **how** to fix it (approach).
+
+### 3. Prioritize by Risk
+
+Focus on concerns that could cause real damage — data loss, security breaches, user-facing failures, scaling walls. Minor style issues and normal TODOs do not belong here.
+
+---
+
+## Template: `.specs/codebase/CONCERNS.md`
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+```markdown
+# Codebase Concerns
+
+**Analysis Date:** [YYYY-MM-DD]
+
+## Tech Debt
+
+**[Area/Component]:**
+
+- Issue: [What's the shortcut/workaround]
+- Files: [Specific file paths with backticks]
+- Why: [Why it was done this way]
+- Impact: [What breaks or degrades because of it]
+- Fix approach: [How to properly address it]
+
+## Known Bugs
+
+**[Bug description]:**
+
+- Symptoms: [What happens]
+- Trigger: [How to reproduce]
+- Files: [Where the bug lives]
+- Workaround: [Temporary mitigation if any]
+- Root cause: [If known]
+- Blocked by: [If waiting on something]
+
+## Security Considerations
+
+**[Area requiring security care]:**
+
+- Risk: [What could go wrong]
+- Files: [Where the risk lives]
+- Current mitigation: [What's in place now]
+- Recommendations: [What should be added]
+
+## Performance Bottlenecks
+
+**[Slow operation/endpoint]:**
+
+- Problem: [What's slow]
+- Files: [Where the bottleneck lives]
+- Measurement: [Actual numbers: "500ms p95", "2s load time"]
+- Cause: [Why it's slow]
+- Improvement path: [How to speed it up]
+
+## Fragile Areas
+
+**[Component/Module]:**
+
+- Files: [Where the fragility lives]
+- Why fragile: [What makes it break easily]
+- Common failures: [What typically goes wrong]
+- Safe modification: [How to change it without breaking]
+- Test coverage: [Is it tested? Gaps?]
+
+## Scaling Limits
+
+**[Resource/System]:**
+
+- Current capacity: [Numbers: "100 req/sec", "10k users"]
+- Limit: [Where it breaks]
+- Symptoms at limit: [What happens]
+- Scaling path: [How to increase capacity]
+
+## Dependencies at Risk
+
+**[Package/Service]:**
+
+- Risk: [e.g., "deprecated", "unmaintained", "breaking changes coming"]
+- Impact: [What breaks if it fails]
+- Migration plan: [Alternative or upgrade path]
+
+## Missing Critical Features
+
+**[Feature gap]:**
+
+- Problem: [What's missing]
+- Current workaround: [How users cope]
+- Blocks: [What can't be done without it]
+- Implementation complexity: [Rough effort estimate]
+
+## Test Coverage Gaps
+
+**[Untested area]:**
+
+- What's not tested: [Specific functionality]
+- Risk: [What could break unnoticed]
+- Priority: [High/Medium/Low]
+- Difficulty to test: [Why it's not tested yet]
+
+---
+
+_Concerns audit: [date]_
+_Update as issues are fixed or new ones discovered_
+```
+
+**Include only sections that have findings.** Empty sections should be omitted entirely.
+
+---
+
+## What Belongs vs. What Doesn't
+
+**Include:**
+
+- Tech debt with clear impact and fix approach
+- Known bugs with reproduction steps
+- Security gaps and mitigation recommendations
+- Performance bottlenecks with measurements
+- Fragile code that breaks easily
+- Scaling limits with numbers
+- Dependencies that need attention
+- Missing features that block workflows
+- Test coverage gaps
+
+**Exclude:**
+
+- Opinions without evidence ("code is messy")
+- Complaints without solutions ("auth sucks")
+- Future feature ideas (that's for product planning)
+- Normal TODOs (those live in code comments)
+- Architectural decisions that are working fine
+- Minor code style issues
+
+---
+
+## Writing Guidelines
+
+- **Always include file paths** — Concerns without locations are not actionable. Use backticks: `src/file.ts`
+- Be specific with measurements ("500ms p95" not "slow")
+- Include reproduction steps for bugs
+- Suggest fix approaches, not just problems
+- Focus on actionable items
+- Prioritize by risk/impact
+
+**Tone:** Professional, not emotional. Solution-oriented. Risk-focused. Factual.
+
+- ✅ "N+1 query pattern in `app/api/courses/route.ts` — 1.2s p95 with 50+ courses"
+- ❌ "Terrible queries, everything is slow"
+- ✅ "Fix: add index on `user_id` in `subscriptions` table"
+- ❌ "Needs fixing"
+
+---
+
+## How CONCERNS.md Gets Used
+
+- **Feature planning:** Check CONCERNS.md before designing features that touch flagged areas
+- **Risk estimation:** Use fragile areas and scaling limits to estimate change risk
+- **Onboarding new sessions:** Load CONCERNS.md to give context about what to watch out for
+- **Refactoring prioritization:** Use tech debt and test coverage gaps to plan improvement sprints
+- **Implementation phase:** Consult before modifying any flagged component
+
+This is living documentation. Update as issues are fixed or new ones discovered during any workflow phase.

--- a/.cursor/skills/tlc-spec-driven/references/context-limits.md
+++ b/.cursor/skills/tlc-spec-driven/references/context-limits.md
@@ -1,0 +1,40 @@
+# Context Limits
+
+## File Size Limits
+
+| File            | Max Tokens | ~Words | Warning At  |
+| --------------- | ---------- | ------ | ----------- |
+| PROJECT.md      | 2,000      | 1,200  | 1,600 (80%) |
+| ROADMAP.md      | 3,000      | 1,800  | 2,400       |
+| STATE.md        | 10,000     | 6,000  | 7,000 (70%) |
+| spec.md         | 5,000      | 3,000  | 4,000       |
+| design.md       | 8,000      | 4,800  | 6,400       |
+| tasks.md        | 10,000     | 6,000  | 8,000       |
+| STACK.md        | 2,000      | 1,200  | 1,600       |
+| ARCHITECTURE.md | 4,000      | 2,400  | 3,200       |
+| CONVENTIONS.md  | 3,000      | 1,800  | 2,400       |
+| STRUCTURE.md    | 2,000      | 1,200  | 1,600       |
+| TESTING.md      | 4,000      | 2,400  | 3,200       |
+| INTEGRATIONS.md | 5,000      | 3,000  | 4,000       |
+
+## Context Zones
+
+🟢 **Healthy** (<40k total): Silent
+🟡 **Moderate** (40-60k): Discrete footer note
+🔴 **Critical** (>60k): Active warning, suggest optimization
+
+## Monitoring
+
+Display context status in footer when >40k:
+
+```
+📊 Context: 52k tokens (moderate)
+  - STATE.md: 8k (yellow zone)
+  - tasks.md: 11k (ok)
+  - Total: 52k / 200k (26%)
+```
+
+## Principles
+
+**Target:** <40k tokens loaded (20% of window)
+**Reserve:** 160k+ tokens for work, reasoning, outputs

--- a/.cursor/skills/tlc-spec-driven/references/design.md
+++ b/.cursor/skills/tlc-spec-driven/references/design.md
@@ -1,0 +1,166 @@
+# Design
+
+**Goal**: Define HOW to build it. Architecture, components, what to reuse.
+
+**Skip this phase when:** The change is straightforward — no architectural decisions, no new patterns, no component interactions to plan. For simple features, design happens inline during Execute.
+
+## Process
+
+### 1. Load Context
+
+Read `.specs/features/[feature]/spec.md` before designing. If `.specs/features/[feature]/context.md` exists, load it too — it contains implementation decisions that constrain the design (layout choices, behavior preferences, interaction patterns). Decisions marked as "Agent's Discretion" are yours to decide.
+
+### 1.5. Research (Optional but Recommended)
+
+If the feature involves unfamiliar technology, patterns, or integrations, research before designing. Document findings briefly in the design doc or as inline notes. This prevents incorrect assumptions from propagating into tasks.
+
+Follow the **Knowledge Verification Chain** (see SKILL.md) in strict order:
+
+```
+Codebase → Project docs → Context7 MCP → Web search → Flag as uncertain
+```
+
+**CRITICAL: NEVER assume or fabricate information.** If you cannot find an answer through the chain, explicitly say "I don't know" or "I couldn't find documentation for this". Inventing an API, a pattern, or a behavior that doesn't exist is far worse than admitting uncertainty. Wrong assumptions propagate through design → tasks → implementation and cause cascading failures.
+
+Good triggers for research: new libraries, unfamiliar APIs, performance-sensitive features, security-sensitive features, patterns you haven't used in this codebase before.
+
+### 2. Define Architecture
+
+Overview of how components interact. Use mermaid diagrams when helpful. Before creating any diagrams, check if the `mermaid-studio` skill is available (see Skill Integrations in SKILL.md).
+
+### 3. Identify Code Reuse
+
+**CRITICAL**: What existing code can we leverage? This saves tokens and reduces errors.
+
+If `.specs/codebase/CONCERNS.md` exists, check it before designing. Any component flagged as fragile, carrying tech debt, or having test coverage gaps requires extra care in the design — document how the design mitigates those concerns.
+
+### 4. Define Components and Interfaces
+
+Each component: Purpose, Location, Interfaces, Dependencies, What it reuses.
+
+### 5. Define Data Models
+
+If the feature involves data, define models before implementation.
+
+---
+
+## Template: `.specs/[feature]/design.md`
+
+````markdown
+# [Feature] Design
+
+**Spec**: `.specs/[feature]/spec.md`
+**Status**: Draft | Approved
+
+---
+
+## Architecture Overview
+
+[Brief description of the architecture approach]
+
+```mermaid
+graph TD
+    A[User Action] --> B[Component A]
+    B --> C[Service Layer]
+    C --> D[Data Store]
+    B --> E[Component B]
+```
+````
+
+---
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+| Component            | Location            | How to Use                |
+| -------------------- | ------------------- | ------------------------- |
+| [Existing Component] | `src/path/to/file`  | [Extend/Import/Reference] |
+| [Existing Utility]   | `src/utils/file`    | [How it helps]            |
+| [Existing Pattern]   | `src/patterns/file` | [Apply same pattern]      |
+
+### Integration Points
+
+| System         | Integration Method                      |
+| -------------- | --------------------------------------- |
+| [Existing API] | [How new feature connects]              |
+| [Database]     | [How data connects to existing schemas] |
+
+---
+
+## Components
+
+### [Component Name]
+
+- **Purpose**: [What this component does - one sentence]
+- **Location**: `src/path/to/component/`
+- **Interfaces**:
+  - `methodName(param: Type): ReturnType` - [description]
+  - `methodName(param: Type): ReturnType` - [description]
+- **Dependencies**: [What it needs to function]
+- **Reuses**: [Existing code this builds upon]
+
+### [Component Name]
+
+- **Purpose**: [What this component does]
+- **Location**: `src/path/to/component/`
+- **Interfaces**:
+  - `methodName(param: Type): ReturnType`
+- **Dependencies**: [Dependencies]
+- **Reuses**: [Existing code]
+
+---
+
+## Data Models (if applicable)
+
+### [Model Name]
+
+```typescript
+interface ModelName {
+  id: string
+  field1: string
+  field2: number
+  createdAt: Date
+}
+```
+
+**Relationships**: [How this relates to other models]
+
+### [Model Name]
+
+```typescript
+interface AnotherModel {
+  id: string
+  // ...
+}
+```
+
+---
+
+## Error Handling Strategy
+
+| Error Scenario | Handling      | User Impact      |
+| -------------- | ------------- | ---------------- |
+| [Scenario 1]   | [How handled] | [What user sees] |
+| [Scenario 2]   | [How handled] | [What user sees] |
+
+---
+
+## Tech Decisions (only non-obvious ones)
+
+| Decision          | Choice          | Rationale     |
+| ----------------- | --------------- | ------------- |
+| [What we decided] | [What we chose] | [Why - brief] |
+
+---
+
+## Tips
+
+- **Load context first** — If context.md exists, decisions there are locked
+- **Research when uncertain** — 5 minutes of research prevents hours of rework
+- **Reuse is king** — Every component should reference existing patterns
+- **Interfaces first** — Define contracts before implementation
+- **Keep it visual** — Diagrams save 1000 words (check mermaid-studio skill in Skill Integrations)
+- **Small components** — If component does 3+ things, split it
+- **Check CONCERNS.md** — If it exists, flag fragile areas the design must address
+- **Confirm before Tasks** — User approves design before breaking into tasks

--- a/.cursor/skills/tlc-spec-driven/references/discuss.md
+++ b/.cursor/skills/tlc-spec-driven/references/discuss.md
@@ -1,0 +1,129 @@
+# Specify: Discuss Gray Areas
+
+**Goal:** Capture HOW the user envisions the feature when the spec has ambiguous areas. This is NOT a separate phase — it's triggered within Specify when the agent detects gray areas that need user input.
+
+**Trigger:** Automatically when gray areas are detected during spec creation, or explicitly via "discuss feature", "how should this work?", "capture context"
+
+**When to trigger (auto-detect):** The spec contains user-facing behavior that could go multiple ways AND the user hasn't expressed a preference. If the spec is clear and unambiguous, skip this entirely.
+
+**When NOT to trigger:** Infrastructure work, CRUD operations, well-defined API contracts, anything where the "how" is obvious from the "what".
+
+## Why This Phase Exists
+
+Specifications capture WHAT to build. Design captures the architecture. But neither captures the user's vision for ambiguous areas — layout preferences, interaction patterns, error handling style, content tone. Without this, the agent guesses. With this, the agent builds what the user actually imagined.
+
+The output — `context.md` — feeds directly into Design and Tasks:
+
+- **Design reads it** to know what decisions are locked vs. flexible
+- **Tasks reads it** to include specific behaviors in task definitions
+
+## Process
+
+### 1. Analyze the Feature
+
+Read `.specs/features/[feature]/spec.md` and identify the domain:
+
+| Domain                         | Gray areas to explore                                         |
+| ------------------------------ | ------------------------------------------------------------- |
+| Something users **SEE**        | Layout, density, interactions, empty states, visual hierarchy |
+| Something users **CALL** (API) | Response format, errors, auth, versioning, rate limiting      |
+| Something users **RUN** (CLI)  | Output format, flags, modes, error handling, verbosity        |
+| Something users **READ**       | Structure, tone, depth, flow, navigation                      |
+| Something being **ORGANIZED**  | Grouping criteria, naming, duplicates, exceptions             |
+
+Generate 3-4 **feature-specific** gray areas. Not generic categories, but concrete decisions for THIS feature.
+
+### 2. Present Gray Areas
+
+Present the feature boundary (from spec.md) and the gray areas to the user. Let them choose which to discuss. Do NOT include a "skip all" option — the user invoked this phase to discuss.
+
+### 3. Deep-Dive Each Area
+
+For each selected area:
+
+1. Ask 3-4 concrete questions with specific options (not vague categories)
+2. After the questions, check: "More about [area], or move on?"
+3. If more → ask 3-4 more, check again
+4. After all areas → "Ready to create context?"
+
+**Question design:**
+
+- Options should be concrete ("Card layout" not "Option A")
+- Each answer should inform the next question
+- Include "You decide" as an option when reasonable — captures agent discretion
+
+### 4. Scope Guardrail (CRITICAL)
+
+The feature boundary from spec.md is **fixed**. Discussion clarifies HOW to implement, never WHETHER to add new capabilities.
+
+**Allowed:** "How should posts be displayed?" (clarifying ambiguity)
+**Not allowed:** "Should we also add comments?" (new capability)
+
+When user suggests scope creep: "That sounds like a separate feature. I'll note it in Deferred Ideas. Back to [current area]."
+
+### 5. Write context.md
+
+---
+
+## Template: `.specs/features/[feature]/context.md`
+
+```markdown
+# [Feature] Context
+
+**Gathered:** [date]
+**Spec:** `.specs/features/[feature]/spec.md`
+**Status:** Ready for design
+
+---
+
+## Feature Boundary
+
+[Clear statement of what this feature delivers — the scope anchor from spec.md]
+
+---
+
+## Implementation Decisions
+
+### [Area 1 that was discussed]
+
+- [Specific decision made]
+- [Another decision if applicable]
+
+### [Area 2 that was discussed]
+
+- [Specific decision made]
+
+### [Area 3 that was discussed]
+
+- [Specific decision made]
+
+### Agent's Discretion
+
+[Areas where user explicitly said "you decide" — agent has flexibility here during design/implementation]
+
+---
+
+## Specific References
+
+[Any "I want it like X" moments, product references, specific behaviors, interaction patterns mentioned during discussion]
+
+[If none: "No specific requirements — open to standard approaches"]
+
+---
+
+## Deferred Ideas
+
+[Ideas that came up during discussion but belong in other features/phases. Captured here so they're not lost, but explicitly out of scope]
+
+[If none: "None — discussion stayed within feature scope"]
+```
+
+---
+
+## Tips
+
+- **Decisions, not vision** — "Card-based layout with subtle shadows" is a decision. "Should feel modern" is not.
+- **Scope is sacred** — Deferred Ideas captures scope creep without losing ideas
+- **User = visionary, Agent = builder** — Ask about how they imagine it, not about technical implementation
+- **Don't ask about:** Technical architecture, performance, implementation details — that's Design's job
+- **Confirm before Design** — User approves context.md before moving to design phase

--- a/.cursor/skills/tlc-spec-driven/references/implement.md
+++ b/.cursor/skills/tlc-spec-driven/references/implement.md
@@ -1,0 +1,284 @@
+# Execute
+
+**Goal**: Implement ONE task at a time. Surgical changes. Verify. Commit. Repeat.
+
+This is where code gets written. Every task follows the same cycle: plan → implement → verify → commit. Verification is built into every task, not a separate phase.
+
+---
+
+## MANDATORY: Before Starting Any Implementation
+
+**Read [coding-principles.md](coding-principles.md) and state:**
+
+1. **Assumptions** - What am I assuming? Any uncertainty?
+2. **Files to touch** - List ONLY files this task requires
+3. **Success criteria** - How will I verify this works?
+
+⚠️ **Do not proceed without stating these explicitly.**
+
+---
+
+## Process
+
+**Sub-agent context:** When this task is executed by a sub-agent, the sub-agent receives
+the task definition, coding principles, TESTING.md, and relevant spec/design context.
+All steps below apply identically whether running in the main context or a sub-agent.
+The only difference: sub-agents report results back to the orchestrator rather than
+continuing to the next task.
+
+### 0. List Atomic Steps (MANDATORY when Tasks phase was skipped)
+
+If there is no `tasks.md` for this feature, you MUST list atomic steps before writing any code. This is non-negotiable — it prevents the agent from losing focus and doing too many things at once.
+
+```
+## Execution Plan
+
+1. [Step] → files: [list] → verify: [how] → commit: [message]
+2. [Step] → files: [list] → verify: [how] → commit: [message]
+3. [Step] → files: [list] → verify: [how] → commit: [message]
+```
+
+**Each step must be:**
+
+- ONE deliverable (one component, one function, one endpoint, one file change)
+- Independently verifiable (can prove it works before moving on)
+- Independently committable (gets its own atomic git commit)
+
+If listing steps reveals >5 steps or complex dependencies, STOP and create a formal `tasks.md` instead. The Tasks phase was wrongly skipped.
+
+### 1. Pick Task
+
+From tasks.md (if exists) or from the execution plan above. User specifies ("implement T3") or suggest next available.
+
+### 2. Verify Dependencies
+
+If tasks.md exists, check dependencies. If using inline plan, follow the order listed.
+
+❌ If blocked: "T3 depends on T2 which isn't done. Should I do T2 first?"
+
+### 3. State Implementation Plan
+
+Before writing code:
+
+```
+Files: [list]
+Approach: [brief description]
+Success: [how to verify]
+```
+
+### 4. Write Tests First (RED)
+
+If the task includes tests (per the Tests field in tasks.md or TESTING.md coverage matrix):
+
+1. Write the test file(s) BEFORE writing any implementation
+2. Tests must encode the expected behavior from the task's "Done when" criteria
+3. Run the test command — confirm tests FAIL (RED state)
+4. If tests pass before implementation exists, the tests are too weak — rewrite them
+
+**Constraints:**
+
+- Tests define correct behavior independently of implementation
+- Each acceptance criterion from "Done when" maps to at least one test assertion
+- Edge cases from spec.md that apply to this task get test cases too
+
+If the task does NOT include tests (e.g., entity-only, config-only), skip to Step 4b.
+
+### 4b. Implement (GREEN)
+
+Write the minimum implementation needed to satisfy the task's success criteria: pass all relevant tests (when present) and meet the defined verification/gate checks when there are no direct tests.
+
+**HARD CONSTRAINTS:**
+
+- Do NOT modify tests written in Step 4. The tests are the spec — implementation conforms to them.
+- Do NOT weaken assertions (making them less specific to pass more easily)
+- Do NOT delete or skip test cases
+- Do NOT use the test framework's skip/disable/pending mechanism to bypass failing tests
+- Minimum code to pass — save structural improvements for a refactor task
+
+If a test is genuinely wrong (tests the wrong behavior per spec), STOP and ask the user
+before modifying it. Never silently change a test.
+
+Follow [coding-principles.md](coding-principles.md):
+
+- Simplest code that works
+- Touch ONLY listed files
+- No scope creep
+
+### 5. Gate Check (VERIFY)
+
+Run the gate check command from the task definition. This is MANDATORY — not "if applicable."
+
+1. Look up the command for the task's Gate level (quick/full/build) in TESTING.md's Gate Check Commands section, then run it
+2. Non-zero exit code = STOP. Fix the failure. Re-run. Do not proceed until green.
+3. Confirm the test count matches expectations (no tests were silently deleted or skipped)
+
+**Tiered gates (from TESTING.md Gate Check Commands):**
+
+| Task includes                    | Gate level | What runs                |
+| -------------------------------- | ---------- | ------------------------ |
+| Unit tests only                  | Quick      | Unit test command        |
+| E2E or integration tests         | Full       | Unit + E2E commands      |
+| Last task in a phase             | Build      | Build + lint + all tests |
+| No tests (config, entities, etc) | Build      | Build + lint only        |
+
+The gate check is deterministic. The test runner decides if the code is correct,
+not the agent's self-assessment.
+
+### 6. Post-Gate Review
+
+After the gate check passes:
+
+1. Verify test count: Are there at least as many test cases as before? (prevents silent deletion)
+2. Verify no SPEC_DEVIATION: If implementation diverged from spec/design, add a marker:
+
+```
+// SPEC_DEVIATION: [what diverged]
+// Reason: [why the deviation was necessary]
+```
+
+3. Quick complexity check: "Would senior engineer flag this as overcomplicated?"
+   - Yes → Simplify, re-run gate
+   - No → Proceed to commit
+
+### 7. Atomic Git Commit
+
+Each task gets its own commit immediately after verification. Never batch multiple tasks into one commit.
+
+**Format ([Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)):**
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+| Type       | When to use                                             |
+| ---------- | ------------------------------------------------------- |
+| `feat`     | New feature or capability                               |
+| `fix`      | Bug fix                                                 |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `docs`     | Documentation only                                      |
+| `test`     | Adding or correcting tests                              |
+| `style`    | Formatting, missing semicolons, etc. (no code change)   |
+| `perf`     | Performance improvement                                 |
+| `build`    | Build system or external dependencies                   |
+| `ci`       | CI configuration files and scripts                      |
+| `chore`    | Maintenance tasks that don't modify src or test files   |
+
+**Scope:** Feature name or module area, lowercase, e.g., `auth`, `cart`, `api`
+
+**Description rules:**
+
+- Imperative mood ("add", not "added" or "adds")
+- Lowercase first letter
+- No period at the end
+- Complete the sentence: "If applied, this commit will _[your description]_"
+
+**Breaking changes:** Append `!` after type/scope AND add `BREAKING CHANGE:` footer:
+
+```
+feat(api)!: change authentication endpoint response format
+
+BREAKING CHANGE: login endpoint now returns JWT in body instead of cookie
+```
+
+**Examples:**
+
+```
+feat(auth): add email validation to login form
+```
+
+```
+fix(cart): prevent negative quantity on item decrement
+```
+
+```
+refactor(api): extract token refresh logic into service
+
+Move token refresh from inline handler to dedicated AuthTokenService
+for reuse across multiple endpoints.
+```
+
+**Rules:**
+
+- One task = one commit
+- Description references what was DONE, not what was planned
+- Include only files listed in the task — never sneak in "while I'm here" changes
+- If tests are part of the task, include them in the same commit
+
+### 8. Scope Guardrail
+
+During implementation, you will notice things that could be improved, refactored, or added. **Do not act on them.** Instead:
+
+- If it's a bug: note it in STATE.md as a blocker or use quick mode
+- If it's an improvement: note it in STATE.md under "Deferred Ideas" or "Lessons Learned"
+- If it's related to the current task: only include it if it's in the "Done when" criteria
+
+**The heuristic:** "Is this in my task definition?" If no, don't touch it.
+
+### 9. Update Task Status
+
+Mark task complete in tasks.md. Update requirement traceability in spec.md if requirement IDs are used.
+
+---
+
+## Execution Template
+
+```markdown
+## Implementing T[X]: [Task Title]
+
+**Reading**: task definition from tasks.md
+**Dependencies**: [All done? ✅ | Blocked by: TY]
+**Tests**: [unit/e2e/integration/none]
+**Gate**: [quick/full/build]
+
+### Pre-Implementation (MANDATORY)
+
+- **Assumptions**: [state explicitly]
+- **Files to touch**: [list ONLY these]
+- **Success criteria**: [how to verify]
+
+### RED: Write Tests
+
+- Test file(s): [paths]
+- Test count: [N test cases]
+- Confirmed failing: [Yes — all N tests fail as expected]
+
+### GREEN: Implement
+
+[Write minimum code to pass tests]
+
+- Tests modified: None
+- Tests skipped/deleted: None
+
+### VERIFY: Gate Check
+
+- Command: [gate check command]
+- Result: [X passed, 0 failed]
+- Test count: [N — matches RED phase count]
+
+### Post-Gate
+
+- [x] No SPEC_DEVIATION (or markers added)
+- [x] No unnecessary changes made
+- [x] Matches existing patterns
+
+**Status**: ✅ Complete | ❌ Blocked | ⚠️ Partial
+```
+
+---
+
+## Tips
+
+- **One task at a time** — Focus prevents errors
+- **Tools matter** — Wrong MCP = wrong approach
+- **Reuses save tokens** — Copy patterns, don't reinvent
+- **Check before commit** — Verify all criteria, then commit
+- **Stay surgical** — Touch only what's necessary
+- **Commit per task** — Clean git history enables bisect and rollback
+- **Never "while I'm here"** — Scope creep during implementation is the #1 quality killer
+- **Learn from mistakes** — If something goes wrong, add a Lesson Learned to STATE.md

--- a/.cursor/skills/tlc-spec-driven/references/project-init.md
+++ b/.cursor/skills/tlc-spec-driven/references/project-init.md
@@ -1,0 +1,71 @@
+# Project Initialization
+
+**Trigger:** "Initialize project", "Setup project", "Start new project"
+
+## Process
+
+Extract project vision via iterative Q&A (max 3-5 questions per message):
+
+**Essential questions:**
+
+1. What are you building?
+2. Who is it for and what problem does it solve?
+3. What tech stack are you using? (if known)
+4. What's in scope for v1? What's explicitly excluded?
+5. Critical constraints? (timeline, technical, resources)
+
+**Stop when:** Clear understanding of vision, goals, and boundaries.
+
+## Output: .specs/project/PROJECT.md
+
+**Structure:**
+
+```markdown
+# [Project Name]
+
+**Vision:** [1-2 sentence description]
+**For:** [target users]
+**Solves:** [core problem being addressed]
+
+## Goals
+
+- [Primary goal with measurable success metric]
+- [Secondary goal with measurable success metric]
+
+## Tech Stack
+
+**Core:**
+
+- Framework: [name + version]
+- Language: [name + version]
+- Database: [name]
+
+**Key dependencies:** [3-5 critical libraries/frameworks]
+
+## Scope
+
+**v1 includes:**
+
+- [Core capability 1]
+- [Core capability 2]
+- [Core capability 3]
+
+**Explicitly out of scope:**
+
+- [What is NOT being built]
+- [What is NOT being built]
+
+## Constraints
+
+- Timeline: [if applicable]
+- Technical: [if applicable]
+- Resources: [if applicable]
+```
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Validation:**
+
+- Vision clear in 1-2 sentences?
+- Goals have measurable outcomes?
+- Scope boundaries explicit?

--- a/.cursor/skills/tlc-spec-driven/references/quick-mode.md
+++ b/.cursor/skills/tlc-spec-driven/references/quick-mode.md
@@ -1,0 +1,132 @@
+# Quick Mode
+
+**Goal:** Execute small, ad-hoc tasks with the same quality principles but without full pipeline ceremony.
+
+**Trigger:** "Quick fix", "Quick task", "Small change", "Bug fix", "Just do X"
+
+## When to Use
+
+| Use quick mode             | Use full pipeline                   |
+| -------------------------- | ----------------------------------- |
+| Bug fixes with known cause | New features with multiple stories  |
+| Config changes             | Architectural changes               |
+| Small UI tweaks            | Features requiring design decisions |
+| Adding a field/column      | Multi-component features            |
+| One-off scripts            | Anything with unclear scope         |
+| Dependency updates         | Features requiring user stories     |
+
+**Rule of thumb:** If you can describe it in one sentence AND it touches ≤3 files, it's a quick task.
+
+## Process
+
+### 1. Describe the Task
+
+User provides a clear, one-sentence description. If vague, ask for specifics:
+
+- ❌ "Fix the login" → Ask: "What's broken? What should happen instead?"
+- ✅ "Fix: login button returns 401 because token refresh skips expired check"
+
+### 2. Pre-Implementation Check
+
+Before writing code, state:
+
+```
+Quick Task: [description]
+Files: [list ONLY files to touch]
+Approach: [one sentence]
+Verify: [how to prove it works]
+```
+
+Get user approval before proceeding. If the pre-implementation check reveals the task is bigger than expected (>3 files, unclear dependencies, design decisions needed), recommend the full pipeline instead.
+
+### 3. Implement
+
+Follow [coding-principles.md](coding-principles.md):
+
+- Simplest code that works
+- Touch ONLY listed files
+- No scope creep — fix the thing, nothing else
+
+### 4. Verify
+
+Run verification from step 2. Mark done only after verification passes.
+
+### 5. Commit
+
+Atomic commit following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>(<scope>): <description>
+```
+
+Use imperative mood, lowercase, no period. See [implement.md](implement.md) for full types table.
+
+Examples:
+
+- `fix(auth): prevent 401 on token refresh`
+- `feat(settings): add dark mode toggle`
+- `chore(deps): update eslint to v9`
+
+### 6. Track
+
+Update `.specs/project/STATE.md` with quick task record (see state-management.md Quick Tasks section).
+
+---
+
+## Structure
+
+Quick tasks live separately from planned features:
+
+```
+.specs/
+└── quick/
+    └── NNN-slug/
+        ├── TASK.md       # Description + verification
+        └── SUMMARY.md    # What was done + commit
+```
+
+**TASK.md template:**
+
+```markdown
+# Quick Task NNN: [Title]
+
+**Date:** [date]
+**Status:** Done | In Progress | Blocked
+
+## Description
+
+[One sentence: what and why]
+
+## Files Changed
+
+- `src/path/to/file.ts` — [what changed]
+- `src/path/to/other.ts` — [what changed]
+
+## Verification
+
+- [ ] [How to verify it works]
+- [ ] [Expected behavior after fix]
+
+## Commit
+
+`[hash]` — [commit message]
+```
+
+---
+
+## Guardrails
+
+- **Max 3 files** — If more, use full pipeline
+- **Max 1 hour** — If longer, scope is wrong
+- **No design decisions** — If you're choosing between approaches, use full pipeline
+- **No new dependencies** — Adding packages needs full pipeline review
+- **Track everything** — Even quick tasks get commits and STATE.md entries
+
+---
+
+## Tips
+
+- **Quick ≠ sloppy** — Same coding principles apply, just less ceremony
+- **When in doubt, go full** — Better to over-plan than to ship broken code
+- **Quick tasks compound** — If you're doing 5+ quick tasks for the same area, it's a feature that needs planning
+- **Verify before marking done** — The whole point is quality, even for small tasks

--- a/.cursor/skills/tlc-spec-driven/references/roadmap.md
+++ b/.cursor/skills/tlc-spec-driven/references/roadmap.md
@@ -1,0 +1,80 @@
+# Roadmap Creation
+
+**Trigger:** "Create roadmap", "Plan features", "Map project phases"
+
+## Process
+
+Based on PROJECT.md, decompose vision into:
+
+- Milestones (shippable increments)
+- Features (user-facing capabilities)
+- Status tracking (planned/in-progress/complete)
+
+## Output: .specs/project/ROADMAP.md
+
+**Structure:**
+
+```markdown
+# Roadmap
+
+**Current Milestone:** [milestone name]
+**Status:** Planning | In Progress | Complete
+
+---
+
+## [Milestone 1 Name]
+
+**Goal:** [What makes this milestone shippable]
+**Target:** [Date or completion criteria]
+
+### Features
+
+**[Feature Name]** - STATUS
+
+- [Capability 1]
+- [Capability 2]
+- [Capability 3]
+
+**[Feature Name]** - STATUS
+
+- [Capability 1]
+- [Capability 2]
+
+---
+
+## [Milestone 2 Name]
+
+**Goal:** [What this milestone adds]
+
+### Features
+
+**[Feature Name]** - PLANNED
+**[Feature Name]** - PLANNED
+
+---
+
+## Future Considerations
+
+- [Potential future capability]
+- [Potential future capability]
+```
+
+**Status values:**
+
+- PLANNED: Not started
+- IN PROGRESS: Currently implementing
+- COMPLETE: Shipped and verified
+
+**Size limit:** 3,000 tokens (~1,800 words)
+
+**Update strategy:**
+
+- Mark features PLANNED → IN PROGRESS when starting
+- Mark IN PROGRESS → COMPLETE when verified
+- Add new milestones as project evolves
+
+**Validation:**
+
+- Each milestone has clear shippable outcome?
+- Features are user-facing capabilities?
+- Status reflects current reality?

--- a/.cursor/skills/tlc-spec-driven/references/session-handoff.md
+++ b/.cursor/skills/tlc-spec-driven/references/session-handoff.md
@@ -1,0 +1,71 @@
+# Session Handoff
+
+## Pause Work
+
+**Trigger:** "Pause work", "End session", "Create handoff"
+
+**Purpose:** Checkpoint current state for resumption.
+
+**Output:** `.specs/HANDOFF.md` (overwrites previous)
+
+**Size target:** ~500 tokens
+
+**Structure:**
+
+```markdown
+# Handoff
+
+**Date:** [ISO timestamp]
+**Feature:** [feature name]
+**Task:** [task identifier] - [brief status]
+
+## Completed ✓
+
+- [Completed work item]
+- [Completed work item]
+
+## In Progress
+
+- [Current work] ([percentage or status])
+- Specific location: [file:line if applicable]
+
+## Pending
+
+- [Next immediate step]
+- [Following step]
+
+## Blockers
+
+- [Blocker description] - [impact]
+
+## Context
+
+- Branch: [git branch if applicable]
+- Uncommitted: [files with changes]
+- Related decisions: [STATE.md references if applicable]
+```
+
+**Instructions:**
+
+- Focus on actionable information for resumption
+- Include specific file/line references where relevant
+- Note uncommitted changes explicitly
+- Reference related STATE.md entries if applicable
+
+## Resume Work
+
+**Trigger:** "Resume work", "Continue", "Load handoff"
+
+**Process:**
+
+1. Load HANDOFF.md
+2. Load STATE.md for context
+3. Summarize current position
+4. Propose next action
+
+**Response pattern:**
+
+- "Resuming [feature] at [task]"
+- "Completed: [summary]"
+- "Next: [immediate action]"
+- "Continue with [specific step]?"

--- a/.cursor/skills/tlc-spec-driven/references/specify.md
+++ b/.cursor/skills/tlc-spec-driven/references/specify.md
@@ -1,0 +1,155 @@
+# Specify
+
+**Goal**: Capture WHAT to build with testable, traceable requirements.
+
+If the feature has ambiguous gray areas (multiple valid approaches for user-facing behavior), the agent will automatically trigger the [discuss gray areas](discuss.md) process within this phase. For clear, well-defined features, it goes straight to the next phase.
+
+## Process
+
+### 1. Clarify Requirements
+
+You are a thinking partner, not an interviewer. Start open — let the user dump their mental model. Follow the energy: whatever they emphasize, dig into that.
+
+Ask conversationally (not as a checklist):
+
+- "What problem are you solving?"
+- "Who is the user and what's their pain?"
+- "What does success look like?"
+
+If needed:
+
+- "What are the constraints (time, tech, resources)?"
+- "What is explicitly out of scope?"
+
+**Challenge vagueness.** Never accept fuzzy answers. "Good" means what? "Users" means who? "Simple" means how? Make the abstract concrete: "Walk me through using this." "What does that actually look like?"
+
+**Know when to stop.** When you understand what they're building, why, who it's for, and what done looks like — offer to proceed.
+
+### 2. Capture User Stories with Priorities
+
+**P1 = MVP** (must ship), **P2** (should have), **P3** (nice to have)
+
+Each story MUST be **independently testable** - you can implement and demo just that story.
+
+### 3. Write Acceptance Criteria
+
+Use **WHEN/THEN/SHALL** format - it's precise and testable:
+
+- WHEN [event/action] THEN [system] SHALL [response/behavior]
+
+---
+
+## Template: `.specs/[feature]/spec.md`
+
+```markdown
+# [Feature Name] Specification
+
+## Problem Statement
+
+[Describe the problem in 2-3 sentences. What pain point are we solving? Why now?]
+
+## Goals
+
+- [ ] [Primary goal with measurable outcome]
+- [ ] [Secondary goal with measurable outcome]
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature     | Reason         |
+| ----------- | -------------- |
+| [Feature X] | [Why excluded] |
+| [Feature Y] | [Why excluded] |
+
+---
+
+## User Stories
+
+### P1: [Story Title] ⭐ MVP
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P1**: [Why this is critical for MVP]
+
+**Acceptance Criteria**:
+
+1. WHEN [user action/event] THEN system SHALL [expected behavior]
+2. WHEN [user action/event] THEN system SHALL [expected behavior]
+3. WHEN [edge case] THEN system SHALL [graceful handling]
+
+**Independent Test**: [How to verify this story works alone - e.g., "Can demo by doing X and seeing Y"]
+
+---
+
+### P2: [Story Title]
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P2**: [Why this isn't MVP but important]
+
+**Acceptance Criteria**:
+
+1. WHEN [event] THEN system SHALL [behavior]
+2. WHEN [event] THEN system SHALL [behavior]
+
+**Independent Test**: [How to verify]
+
+---
+
+### P3: [Story Title]
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P3**: [Why this is nice-to-have]
+
+**Acceptance Criteria**:
+
+1. WHEN [event] THEN system SHALL [behavior]
+
+---
+
+## Edge Cases
+
+- WHEN [boundary condition] THEN system SHALL [behavior]
+- WHEN [error scenario] THEN system SHALL [graceful handling]
+- WHEN [unexpected input] THEN system SHALL [validation response]
+
+---
+
+## Requirement Traceability
+
+Each requirement gets a unique ID for tracking across design, tasks, and validation.
+
+| Requirement ID | Story       | Phase  | Status  |
+| -------------- | ----------- | ------ | ------- |
+| [FEAT]-01      | P1: [Story] | Design | Pending |
+| [FEAT]-02      | P1: [Story] | Design | Pending |
+| [FEAT]-03      | P2: [Story] | -      | Pending |
+
+**ID format:** `[CATEGORY]-[NUMBER]` (e.g., `AUTH-01`, `CART-03`, `NOTIF-02`)
+
+**Status values:** Pending → In Design → In Tasks → Implementing → Verified
+
+**Coverage:** X total, Y mapped to tasks, Z unmapped ⚠️
+
+---
+
+## Success Criteria
+
+How we know the feature is successful:
+
+- [ ] [Measurable outcome - e.g., "User can complete X in < 2 minutes"]
+- [ ] [Measurable outcome - e.g., "Zero errors in Y scenario"]
+```
+
+---
+
+## Tips
+
+- **P1 = Vertical Slice** — A complete, demo-able feature, not just backend or frontend
+- **WHEN/THEN is code** — If you can't write it as a test, rewrite it
+- **Requirement IDs are mandatory** — Every story maps to trackable IDs
+- **Edge cases matter** — What breaks? What's empty? What's huge?
+- **Out of Scope prevents creep** — If it's not here, it doesn't get built
+- **Confirm before Discuss** — User must approve spec before moving to discuss phase

--- a/.cursor/skills/tlc-spec-driven/references/state-management.md
+++ b/.cursor/skills/tlc-spec-driven/references/state-management.md
@@ -1,0 +1,130 @@
+# State Management
+
+**Purpose:** Persistent memory across sessions - decisions, blockers, learnings.
+
+## Structure
+
+**Output:** `.specs/project/STATE.md`
+
+```markdown
+# State
+
+**Last Updated:** [ISO timestamp]
+**Current Work:** [Feature name] - [Task identifier]
+
+---
+
+## Recent Decisions (Last 60 days)
+
+### AD-[NNN]: [Decision title] ([date])
+
+**Decision:** [What was decided]
+**Reason:** [Why this choice]
+**Trade-off:** [What was sacrificed]
+**Impact:** [How this affects implementation]
+
+### AD-[NNN]: [Decision title] ([date])
+
+[Same structure]
+
+---
+
+## Active Blockers
+
+### B-[NNN]: [Blocker description]
+
+**Discovered:** [Date]
+**Impact:** [Severity and scope]
+**Workaround:** [Temporary solution if available]
+**Resolution:** [Path to permanent fix]
+
+---
+
+## Lessons Learned
+
+### L-[NNN]: [Learning description]
+
+**Context:** [Situation that occurred]
+**Problem:** [What went wrong]
+**Solution:** [How it was resolved]
+**Prevents:** [What this knowledge prevents in future]
+
+---
+
+## Quick Tasks Completed
+
+| #   | Description              | Date   | Commit | Status  |
+| --- | ------------------------ | ------ | ------ | ------- |
+| 001 | [Quick task description] | [date] | [hash] | ✅ Done |
+
+---
+
+## Deferred Ideas
+
+Ideas captured during work that belong in future features or phases. Prevents scope creep while preserving good ideas.
+
+- [ ] [Idea description] — Captured during: [feature/phase]
+- [ ] [Idea description] — Captured during: [feature/phase]
+
+---
+
+## Todos
+
+Capture in-progress thoughts and action items that don't fit in active tasks.
+
+- [ ] [TODO: action item]
+- [ ] [TODO: action item]
+```
+
+## When to Update
+
+| Event                            | Action                                 |
+| -------------------------------- | -------------------------------------- |
+| Significant architectural choice | Add AD-[NNN]                           |
+| Implementation blocked           | Add B-[NNN]                            |
+| Important discovery/learning     | Add L-[NNN]                            |
+| Quick task completed             | Add row to Quick Tasks table           |
+| Scope creep captured             | Add to Deferred Ideas                  |
+| In-progress thought              | Add to Todos                           |
+| Session end                      | Update "Last Updated" + "Current Work" |
+
+## Size Management (Hybrid Strategy)
+
+**Zones:**
+
+- 🟢 <7k tokens: No action
+- 🟡 7-10k tokens: Footer note "STATE.md at [X]k. Cleanup recommended."
+- 🔴 >10k tokens: Active prompt "STATE.md critical ([X]k). Cleanup now?"
+
+**Cleanup process:**
+
+- Move decisions >60 days to STATE-ARCHIVE.md
+- Keep only active blockers
+- Preserve recent learnings (<60 days)
+
+**Validation:**
+
+- Decisions have clear rationale?
+- Blockers include resolution path?
+- Learnings are actionable?
+
+---
+
+## Preferences
+
+Track user-facing behavioral state in STATE.md:
+
+```markdown
+## Preferences
+
+**Model Guidance Shown:** [ISO date or "never"]
+```
+
+**Update when:**
+
+| Event                       | Action                   |
+| --------------------------- | ------------------------ |
+| First model tip given       | Set date                 |
+| User acknowledges/dismisses | Keep date (don't repeat) |
+
+This prevents repetitive suggestions while maintaining natural, helpful behavior.

--- a/.cursor/skills/tlc-spec-driven/references/tasks.md
+++ b/.cursor/skills/tlc-spec-driven/references/tasks.md
@@ -1,0 +1,419 @@
+# Tasks
+
+**Goal**: Break into GRANULAR, ATOMIC tasks. Clear dependencies. Right tools. Parallel execution plan.
+
+**Skip this phase when:** There are ≤3 obvious steps. In that case, tasks are implicit — go straight to Execute and list them inline in your implementation plan.
+
+## Why Granular Tasks?
+
+| Vague Task (BAD) | Granular Tasks (GOOD)             |
+| ---------------- | --------------------------------- |
+| "Create form"    | T1: Create email input component  |
+|                  | T2: Add email validation function |
+|                  | T3: Create submit button          |
+|                  | T4: Add form state management     |
+|                  | T5: Connect form to API           |
+| "Implement auth" | T1: Create login form             |
+|                  | T2: Create register form          |
+|                  | T3: Add token storage utility     |
+|                  | T4: Create auth API service       |
+|                  | T5: Add route protection          |
+
+**Benefits of granular:**
+
+- **Agents don't err** - Single focus, no ambiguity
+- **Easy to test** - Each task = one verifiable outcome
+- **Parallelizable** - Independent tasks run simultaneously
+- **Errors isolated** - One failure doesn't block everything
+
+**Rule**: One task = ONE of these:
+
+- One component
+- One function
+- One API endpoint
+- One file change
+
+---
+
+## Process
+
+### 1. Review Design
+
+Read `.specs/[feature]/design.md` before creating tasks.
+
+### 1.5. Load Test Coverage Matrix
+
+Read `.specs/codebase/TESTING.md` (if it exists) before creating tasks. The Test Coverage Matrix
+and Parallelism Assessment drive two critical decisions:
+
+**Co-located tests:** Every task that creates or modifies a code layer with a required test type
+MUST include writing/updating those tests in the same task. Tests are NOT separate tasks.
+
+| Task creates...                           | Done When must include...                   |
+| ----------------------------------------- | ------------------------------------------- |
+| Code layer with "unit" requirement        | Unit test written + quick gate passes       |
+| Code layer with "e2e" requirement         | E2E test written + full gate passes         |
+| Code layer with "integration" requirement | Integration test written + full gate passes |
+| Code layer with "none" requirement        | Gate check at appropriate level             |
+
+**Parallelism flags:** Cross-reference the Parallelism Assessment when marking tasks `[P]`:
+
+- If a task's required test type is marked "Parallel-Safe: No" → strip `[P]` flag
+- If a task's required test type is marked "Parallel-Safe: Yes" → `[P]` is allowed
+- If a task has no tests → `[P]` depends only on code dependencies
+
+If TESTING.md does not exist (greenfield project), ask the user what test types and commands
+the project will use before creating tasks.
+
+### 2. Break Into Atomic Tasks
+
+**Task = ONE deliverable**. Examples:
+
+- ✅ "Create UserService interface" (one file, one concept)
+- ❌ "Implement user management" (too vague, multiple files)
+
+### 3. Define Dependencies
+
+What MUST be done before this task can start?
+
+### 4. Create Execution Plan
+
+Group tasks into phases. Identify what can run in parallel.
+
+### 5. Validate Before Presenting (MANDATORY)
+
+Before showing tasks to the user, run ALL three pre-approval checks. These are NOT optional — they are gates. If any check fails, restructure the tasks and re-run until all pass.
+
+**Check 1: Task Granularity** — verify each task is atomic (see Granularity Check section).
+
+**Check 2: Diagram-Definition Cross-Check** — verify the execution diagram matches every task's `Depends on` field (see Diagram-Definition Cross-Check section). Build the cross-check table and include it in the output.
+
+**Check 3: Test Co-location Validation** — verify every task's `Tests` field matches the TESTING.md coverage matrix (see Test Co-location Validation section). Build the validation table and include it in the output.
+
+**Output both tables with the tasks** so the user can see the validation results. Any ❌ means you MUST restructure before presenting — do not show failing tasks to the user and ask them to approve.
+
+### 6. ASK About MCPs and Skills
+
+**CRITICAL**: Before execution, ask the user:
+
+> "For each task, which tools should I use?"
+>
+> **Available MCPs**: [list from project or user]
+> **Available Skills**: [list from project or user]
+
+---
+
+## Template: `.specs/[feature]/tasks.md`
+
+```markdown
+# [Feature] Tasks
+
+**Design**: `.specs/[feature]/design.md`
+**Status**: Draft | Approved | In Progress | Done
+
+---
+
+## Execution Plan
+
+### Phase 1: Foundation (Sequential)
+
+Tasks that must be done first, in order.
+```
+
+T1 → T2 → T3
+
+```
+
+### Phase 2: Core Implementation (Parallel OK)
+After foundation, these can run in parallel.
+
+```
+
+     ┌→ T4 ─┐
+
+T3 ──┼→ T5 ─┼──→ T8
+└→ T6 ─┘
+T7 ──────→
+
+```
+
+### Phase 3: Integration (Sequential)
+Bringing it all together.
+
+```
+
+T8 → T9
+
+---
+
+## Task Breakdown
+
+### T1: [Create X Interface]
+
+**What**: [One sentence: exact deliverable]
+**Where**: `src/path/to/file.ts`
+**Depends on**: None
+**Reuses**: `src/existing/BaseInterface.ts`
+**Requirement**: [FEAT]-01
+
+**Tools**:
+
+- MCP: `filesystem` (or NONE)
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Interface defined with all methods from design
+- [ ] Types exported correctly
+- [ ] No TypeScript errors
+
+**Tests**: [unit/e2e/integration/none — from coverage matrix]
+**Gate**: [quick/full/build — from gate check commands]
+
+---
+
+### T2: [Implement Y Service] [P]
+
+**What**: [Exact deliverable]
+**Where**: `src/services/YService.ts`
+**Depends on**: T1
+**Reuses**: `src/services/BaseService.ts` patterns
+
+**Tools**:
+
+- MCP: `filesystem`, `context7`
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Implements interface from T1
+- [ ] Handles error cases from design
+- [ ] Gate check passes: `[quick gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: unit
+**Gate**: quick
+
+---
+
+### T3: [Create Z Component] [P]
+
+**What**: [Exact deliverable]
+**Where**: `src/components/ZComponent.tsx`
+**Depends on**: T1
+**Reuses**: `src/components/BaseComponent.tsx`
+
+**Tools**:
+
+- MCP: `filesystem`
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Component renders correctly
+- [ ] Handles props from interface
+- [ ] Follows existing component patterns
+- [ ] Gate check passes: `[quick gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: unit
+**Gate**: quick
+
+---
+
+### T4: [Add A Feature to Y]
+
+**What**: [Exact deliverable]
+**Where**: `src/services/YService.ts` (modify)
+**Depends on**: T2, T3
+**Reuses**: Existing service patterns
+
+**Tools**:
+
+- MCP: `filesystem`, `github`
+- Skill: `api-design`
+
+**Done when**:
+
+- [ ] Feature works per acceptance criteria
+- [ ] Gate check passes: `[full gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: integration
+**Gate**: full
+
+**Commit**: `feat([scope]): [description]`
+
+---
+
+## Parallel Execution Map
+
+Visual representation of what can run simultaneously:
+
+```
+
+Phase 1 (Sequential):
+  T1 ──→ T2 ──→ T3
+
+Phase 2 (Parallel):
+  T3 complete, then:
+    ├── T4 [P]
+    ├── T5 [P]  } Can run simultaneously
+    └── T6 [P]
+
+Phase 3 (Sequential):
+  T4, T5, T6 complete, then:
+    T7 ──→ T8
+
+```
+
+**Parallelism constraint:** A task marked `[P]` must have ALL of these:
+
+- No unfinished dependencies
+- Required test type is parallel-safe (per TESTING.md Parallelism Assessment)
+- No shared mutable state with other `[P]` tasks in the same phase
+
+If a task's tests are NOT parallel-safe, it MUST run sequentially even if its
+implementation code has no dependencies. The test execution is the bottleneck.
+
+**How parallel execution works:**
+
+Tasks marked `[P]` are executed via sub-agents — one sub-agent per task, launched concurrently.
+Each sub-agent receives only its task definition and relevant project context (see Sub-Agent
+Delegation in SKILL.md). The orchestrating agent waits for all sub-agents in a phase to complete
+before advancing to the next phase.
+
+Sequential tasks (no `[P]`) are also delegated to sub-agents, but one at a time. This keeps
+implementation artifacts (file reads, test output, gate check logs) out of the main context.
+
+**The orchestrating agent's role during Execute:**
+1. Pick the next task(s) to execute
+2. Provide each sub-agent with its task definition + context
+3. Monitor sub-agent completion
+4. Update tasks.md with results
+5. Decide whether to proceed, fix, or escalate
+
+---
+
+## Task Granularity Check
+
+Before approving tasks, verify they are granular enough:
+
+| Task                            | Scope         | Status       |
+| ------------------------------- | ------------- | ------------ |
+| T1: Create email input          | 1 component   | ✅ Granular  |
+| T2: Add validation function     | 1 function    | ✅ Granular  |
+| T3: Create form with all fields | 5+ components | ❌ Split it! |
+| T4: Connect to API              | 1 function    | ✅ Granular  |
+
+**Granularity check**:
+
+- ✅ 1 component / 1 function / 1 endpoint = Good
+- ⚠️ 2-3 related things in same file = OK if cohesive
+- ❌ Multiple components or files = MUST split
+
+---
+
+## Diagram-Definition Cross-Check
+
+Before approving tasks, verify the execution diagram is consistent with the task definitions. These are independent artifacts that can drift — the diagram is drawn for visual clarity while task bodies are written for precision. Both must agree.
+
+For each task, check:
+
+| Task | Depends On (task body) | Diagram Shows | Status |
+| ---- | ---------------------- | ------------- | ------ |
+| T[N] | [deps from body] | [deps from diagram arrows] | ✅ Match or ❌ Mismatch |
+
+**Rules:**
+
+- Every `Depends on` in a task body must have a corresponding arrow in the diagram.
+- Every arrow in the diagram must correspond to a `Depends on` in the target task's body.
+- Tasks shown as parallel (`[P]`) in the diagram must not depend on each other.
+- If a task depends on another task in the same parallel phase, they are NOT parallel — fix the diagram or remove the `[P]` flag.
+
+---
+
+## Test Co-location Validation
+
+Before approving tasks, verify EVERY task's `Tests` field is consistent with the TESTING.md Test Coverage Matrix. This is a hard gate — tasks that fail this check MUST be fixed.
+
+For each task, check: does the task create or modify a code layer that has a required test type in the coverage matrix? If yes, the task's `Tests` field MUST match.
+
+| Task | Code Layer Created/Modified | Matrix Requires | Task Says | Status |
+| ---- | --------------------------- | --------------- | --------- | ------ |
+| T[N]: [name] | [layer from coverage matrix] | [test type] | [task's Tests field] | ✅ OK or ❌ VIOLATION |
+
+**Rules:**
+
+- "Tested in another task" is NOT a valid justification for `Tests: none`. That is test deferral — the exact anti-pattern this validation prevents.
+- `Tests: none` is only valid when the coverage matrix says "none" for that code layer.
+- If a task creates MULTIPLE code layers (e.g., service + controller), use the HIGHEST test type required by any of them.
+- Any ❌ VIOLATION → restructure the task to include its required tests before proceeding.
+
+**Resolving compilation dependencies:**
+
+When a task creates code that can't be tested until a later task completes (e.g., a controller that needs module wiring before its e2e tests can run), do NOT defer the tests to a separate task. Instead, restructure:
+
+1. **Merge forward:** Move the untestable task's tests into the earliest task where they become runnable (e.g., the wiring task includes wiring + e2e tests for the controller it enables).
+2. **Merge backward:** Absorb the blocking dependency into the current task so it becomes self-testable (e.g., controller task includes its own module registration).
+
+Pick whichever option keeps tasks atomic and cohesive. The goal: no task produces unverified code. If code can't be tested in the task that creates it, the task boundaries are wrong.
+
+---
+
+## Tips
+
+- **[P] = Parallel OK** — Mark tasks that can run simultaneously
+- **Reuses = Token saver** — Always reference existing code
+- **Tools per task** — MCPs and Skills prevent wrong approaches
+- **Dependencies are gates** — Clear what blocks what
+- **Done when = Testable** — If you can't verify it, rewrite it
+- **Requirement ID = Traceable** — Every task traces back to a spec requirement
+- **One commit per task** — Plan the commit message format in advance
+
+---
+
+## Task Verification Standards
+
+Every task MUST include:
+
+**Done when checklist:**
+
+- Specific, testable outcomes
+- Pass/fail criteria
+- The specific test command from the Gate Check Commands table
+- Expected pass count (prevents silent test deletion)
+
+**Verify section:**
+
+- Commands to prove functionality
+- Expected outputs
+- Success indicators
+
+**Structure:**
+
+```markdown
+### T1: [Task name]
+
+**What:** [Deliverable]
+**Where:** [File path]
+**Tests**: [unit/e2e/integration/none]
+**Gate**: [quick/full/build]
+
+**Done when:**
+
+- [ ] [Specific outcome]
+- [ ] [Specific outcome]
+- [ ] Gate check passes: `[command from Gate Check Commands]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Verify:**
+[Command to prove it works]
+[Expected output/behavior]
+```
+
+**Quality check:**
+
+- Can task be verified without human judgment?
+- Is success criteria binary (pass/fail)?
+- Can verification be automated?

--- a/.cursor/skills/tlc-spec-driven/references/validate.md
+++ b/.cursor/skills/tlc-spec-driven/references/validate.md
@@ -1,0 +1,256 @@
+# Execute: Validate & Verify
+
+**Goal**: Verify implementation meets spec AND coding principles. This is NOT a separate phase — verification is part of every task's completion within Execute.
+
+**Two levels of verification:**
+
+1. **Per-task verification (always):** After implementing each task, verify its "Done when" criteria before committing. This is mandatory and automatic.
+
+2. **Feature-level validation (on completion or on demand):** After all tasks for a feature (or priority group) are done, run a comprehensive validation. Includes acceptance criteria check, code quality review, and optionally interactive UAT.
+
+**Interactive UAT is triggered when:** The feature has complex user-facing behavior where human judgment matters (UI flows, interaction patterns, visual design). For backend-only or infrastructure work, automated checks are sufficient.
+
+**Trigger for explicit validation:** "Validate", "verify work", "UAT", "test with me", "walk me through it"
+
+---
+
+## Process
+
+### 1. Check Completed Tasks
+
+Go through tasks.md:
+
+- [ ] All tasks marked done?
+- [ ] Any blocked or partial?
+
+### 2. Verify Acceptance Criteria
+
+For each user story in spec.md:
+
+```markdown
+### P1: [Story Title]
+
+**Acceptance Criteria**:
+
+1. WHEN [X] THEN [Y] → [PASS/FAIL]
+2. WHEN [X] THEN [Y] → [PASS/FAIL]
+```
+
+### 3. Check Edge Cases
+
+From spec.md edge cases:
+
+- [ ] [Edge case 1] handled correctly
+- [ ] [Edge case 2] handled correctly
+
+### 4. Run Build-Level Gate Check (MANDATORY)
+
+Run the Build-level gate check from TESTING.md. This is NOT optional.
+
+If TESTING.md does not exist (greenfield project), use the gate command agreed upon with the user during the Tasks phase.
+
+1. Run: `[build gate command from TESTING.md, or the command agreed during planning]`
+2. Non-zero exit code = STOP. Do not proceed to Code Quality Check.
+3. Record results:
+   - Total test count: [N]
+   - Passed: [N]
+   - Failed: [list]
+   - Skipped: [list — each skip must be justified]
+
+**Test Integrity Check:**
+
+- Compare current test count against the count before this feature was implemented
+- If test count DECREASED: investigate why. Tests should only be deleted with explicit justification.
+- If assertions were weakened (less specific than before): flag as potential regression
+
+### 5. Code Quality Check (MANDATORY)
+
+For each changed file, verify against [coding-principles.md](coding-principles.md):
+
+| Check                                | Pass? |
+| ------------------------------------ | ----- |
+| No features beyond what was asked    |       |
+| No abstractions for single-use code  |       |
+| No unnecessary "flexibility" added   |       |
+| Only touched files required for task |       |
+| Didn't "improve" unrelated code      |       |
+| Matches existing patterns/style      |       |
+| Would senior engineer approve?       |       |
+
+❌ Any "No"? → Fix before marking complete.
+
+### 6. Interactive UAT (if user-facing feature)
+
+For each testable deliverable, present one test at a time:
+
+```
+Test [N]: [Test Name]
+
+Expected: [What should happen — specific and observable]
+
+→ Does this work? Describe what you see.
+```
+
+Wait for user response:
+
+| User says                      | Interpret as            |
+| ------------------------------ | ----------------------- |
+| "yes", "pass", "works", "next" | ✅ Pass                 |
+| "skip", "can't test", "n/a"    | ⏭️ Skip                 |
+| Anything else                  | ❌ Issue — log verbatim |
+
+**Severity inference (never ask the user for severity):**
+
+| User description contains               | Inferred severity |
+| --------------------------------------- | ----------------- |
+| crash, error, exception, fails, broken  | Blocker           |
+| doesn't work, wrong, missing, can't     | Major             |
+| slow, weird, off, minor, small          | Minor             |
+| color, font, spacing, alignment, visual | Cosmetic          |
+| (unclear)                               | Major (default)   |
+
+### 7. Generate Fix Plans (if issues found)
+
+For each issue found during UAT:
+
+1. **Diagnose** — Analyze the codebase to find root cause
+2. **Create fix task** — Write a task definition with:
+   - What: The specific fix
+   - Where: File paths
+   - Verify: How to prove the fix works
+   - Done when: Acceptance criteria for the fix
+3. **Present fix plan** — Show all fix tasks to user for approval
+
+Fix tasks follow the same format as regular tasks and can be executed with the implement phase.
+
+**Guardrail:** Maximum 3 diagnostic iterations per issue. If root cause isn't found after 3 attempts, flag for human investigation.
+
+### 8. Report
+
+---
+
+## Validation Report Template
+
+```markdown
+# [Feature] Validation
+
+**Date**: [YYYY-MM-DD]
+**Spec**: `.specs/features/[feature]/spec.md`
+
+---
+
+## Task Completion
+
+| Task | Status     | Notes   |
+| ---- | ---------- | ------- |
+| T1   | ✅ Done    | -       |
+| T2   | ✅ Done    | -       |
+| T3   | ⚠️ Partial | [Issue] |
+
+---
+
+## User Story Validation
+
+### P1: [Story Title] ⭐ MVP
+
+| Criterion     | Result  |
+| ------------- | ------- |
+| WHEN X THEN Y | ✅ PASS |
+| WHEN A THEN B | ✅ PASS |
+
+**Status**: ✅ P1 Complete
+
+### P2: [Story Title]
+
+| Criterion     | Result             |
+| ------------- | ------------------ |
+| WHEN X THEN Y | ❌ FAIL - [reason] |
+
+**Status**: ⚠️ P2 Issues
+
+---
+
+## Interactive UAT Results (if performed)
+
+| #   | Test        | Result   | Details                                         |
+| --- | ----------- | -------- | ----------------------------------------------- |
+| 1   | [Test name] | ✅ Pass  | -                                               |
+| 2   | [Test name] | ❌ Issue | [Verbatim user response] — Severity: [inferred] |
+| 3   | [Test name] | ⏭️ Skip  | [Reason]                                        |
+
+---
+
+## Code Quality
+
+| Principle        | Status |
+| ---------------- | ------ |
+| Minimum code     | ✅     |
+| Surgical changes | ✅     |
+| No scope creep   | ✅     |
+| Matches patterns | ✅     |
+
+---
+
+## Edge Cases
+
+- [x] Edge case 1: Handled correctly
+- [ ] Edge case 2: NOT handled - needs fix
+
+---
+
+## Tests
+
+- **Gate command**: [full command]
+- **Result**: [X] passed, [Y] failed, [Z] skipped
+- **Test count before feature**: [N]
+- **Test count after feature**: [M]
+- **Delta**: [+(M - N) new tests]
+- **Skipped tests**: [list with justification for each]
+- **Failures**: [list with details]
+
+---
+
+## Fix Plans (if issues found)
+
+### Fix 1: [Issue description]
+
+- **Root cause**: [What's actually wrong]
+- **Fix task**: [Task definition]
+- **Priority**: [Blocker/Major/Minor/Cosmetic]
+
+---
+
+## Requirement Traceability Update
+
+Update spec.md requirement statuses:
+
+| Requirement | Previous Status | New Status   |
+| ----------- | --------------- | ------------ |
+| [FEAT]-01   | Implementing    | ✅ Verified  |
+| [FEAT]-02   | Implementing    | ❌ Needs Fix |
+
+---
+
+## Summary
+
+**Overall**: ✅ Ready | ⚠️ Issues | ❌ Not Ready
+
+**What works**: [List]
+
+**Issues found**: [Issue 1: How to fix]
+
+**Next steps**: [Action]
+```
+
+---
+
+## Tips
+
+- **P1 first** — MVP must work before P2/P3
+- **WHEN/THEN = Test** — Each criterion is a test case
+- **Be specific** — "Doesn't work" isn't helpful
+- **Recommend fixes** — Don't just report problems, create fix tasks
+- **Quality check is mandatory** — Not optional
+- **Infer severity** — Never ask the user "how bad is this?"
+- **Max 3 diagnostic iterations** — Prevents infinite investigation loops
+- **Update traceability** — Every verified requirement updates spec.md status

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -17,7 +17,45 @@ body:
 
   - type: textarea
     attributes:
-      label: 🥸 References
+      label: 🧑‍💻 User stories
+      placeholder: |
+        Describe user stories in the format:
+        * As a [type of user], I want [goal] so that [reason/benefit]
+        * When [type of user] does [some system input/action], the [app part] must [expected behavior]... [other requirements/expectations]
+
+        Example:
+        * As a developer, I want to see code examples so that I can understand how to implement the feature
+        * As an end user, I want a responsive interface so that I can access the app on any device
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: 🥸 Technical Refinement
+      placeholder: |
+        You can describe technical details, considerations, or constraints related to the issue.
+        * Architecture changes
+        * Data models
+        * API endpoints
+        * Performance considerations
+        * Security implications
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: ✅ Acceptance Criteria
+      placeholder: |
+        Define clear conditions that indicate this issue is complete.
+        * [ ] Criterion 1
+        * [ ] Criterion 2
+        * [ ] Criterion 3
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: 📷 Attachments / 🔗 References
       placeholder: |
         You can attach some screenshots or links here.
         * Desktop

--- a/.specs/codebase/ARCHITECTURE.md
+++ b/.specs/codebase/ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# EVA Station — Architecture Map
+
+## High-Level Architecture
+
+Current implementation is frontend-centric, with business logic concentrated in React hooks and local utilities.
+
+Layers in practice:
+
+1. UI layer: App Router pages + feature components
+2. Logic layer: custom hooks (`useConversorController`, `useConversorRates`, `useHealthCheck`)
+3. Utility/config layer: formatting, conversion constants, env schema
+4. External integration layer: currently minimal in runtime (mostly mocked data)
+
+## Routing and Entrypoints
+
+- `/` → converter experience (`ConversorPage`)
+- `/about-eva` and `/about-us` → informational pages
+- `/health` → baseline diagnostics page (ethers and SWR status)
+
+## Core Feature Flow (Converter)
+
+1. `ConversorPage` wraps content with `ConversorProvider`
+2. `ConversorProvider` exposes `useConversorController` via context
+3. `useConversorController`:
+   - reads rates from `useConversorRates` (currently mocked)
+   - tracks active input and base field/value
+   - computes USD normalization and derived values for all fields
+   - exposes actions (`onFieldChange`, `onClear`, focus handlers)
+4. `ConversorCard` renders field list from `FIELDS` definition and action/status subcomponents
+
+## Health Flow
+
+- `useHealthCheck` returns stable mock payload (`status: ok`, current timestamp)
+- `/health` additionally checks `ethers.version` and reports SWR as `not-in-use`
+- SWR fetch logic exists only as commented reference
+
+## Architectural Characteristics
+
+- Good separation between presentational components and controller hook
+- Data-fetching clients are not implemented yet in active code
+- Environment validation exists but currently only validates `COINGECKO_BASE_URL`
+- Metadata and some docs still reflect scaffold defaults and older architecture intent

--- a/.specs/codebase/CONCERNS.md
+++ b/.specs/codebase/CONCERNS.md
@@ -1,0 +1,33 @@
+# EVA Station — Concerns Map
+
+## Priority Concerns
+
+1. **Documentation drift**
+   - Docs describe API/blockchain client folders and live integrations that are not present in runtime code.
+   - README stack versions differ from installed package versions.
+
+2. **Prototype data in production paths**
+   - Converter rates and health data are mocked.
+   - SWR usage is documented/commented, but not active.
+
+3. **Testing gap**
+   - No automated tests for critical converter math and formatting.
+   - Lint is the only automated quality gate.
+
+4. **Metadata and scaffold leftovers**
+   - App metadata still contains default "Create Next App" values in layouts.
+
+5. **Design system consistency risks**
+   - Most styling uses tokens/utilities, but there are isolated hardcoded values (e.g., specific hex color in header).
+
+## Architectural Risks
+
+- Health route defines a separate HTML/body layout, which can diverge from root-level behavior over time.
+- No clear adapter boundary yet for moving from mock rates to live API clients.
+
+## Recommended Sequence to Reduce Risk
+
+1. Align docs and metadata with current implementation.
+2. Introduce real data adapter interfaces behind existing hooks.
+3. Add unit tests for conversion and formatting logic before switching to live APIs.
+4. Activate SWR-based fetch/revalidation progressively with fallback handling.

--- a/.specs/codebase/CONVENTIONS.md
+++ b/.specs/codebase/CONVENTIONS.md
@@ -1,0 +1,39 @@
+# EVA Station — Conventions Map
+
+## Language and Typing
+
+- TypeScript-first codebase with `strict: true`
+- Shared domain types in `src/types`
+- Hook return contracts are explicitly typed
+
+## Imports and Module Resolution
+
+- Path alias `@/*` mapped to `src/*`
+- Common import style: grouped external imports first, then internal aliases
+
+## Component and Hook Patterns
+
+- Feature foldering by domain (`components/conversor`, `components/health`)
+- Context + custom hook pattern for feature state (`ConversorContext`)
+- Business logic sits in hooks; components are mostly presentational/compositional
+
+## Styling and UI System
+
+- Tailwind CSS utility classes
+- shadcn-compatible setup in `components.json`
+- Shared class merge utility (`cn`) in `src/lib/utils.ts`
+- Tokens and CSS variables centralized in `src/app/globals.css`
+
+## Lint and Formatting
+
+- ESLint with Next.js core-web-vitals and TS presets
+- Prettier integrated in npm scripts
+- Expected commands:
+  - `npm run lint`
+  - `npm run lint:check`
+  - `npm run lint:fix`
+
+## Git/Workflow (Documented)
+
+- Repo docs define EVAST issue/branch naming and squash-merge strategy
+- Commit convention references semantic commit style with issue/sub-issue codes

--- a/.specs/codebase/INTEGRATIONS.md
+++ b/.specs/codebase/INTEGRATIONS.md
@@ -1,0 +1,29 @@
+# EVA Station — Integrations Map
+
+## Active Integrations in Current Code
+
+- `ethers` package is imported in `/health` page for a runtime availability check via `ethers.version`.
+- No live HTTP data-fetching integration is currently active in hooks/components.
+
+## Environment and Config
+
+- `src/config/env.ts` validates server env using Zod.
+- Current required key in code: `COINGECKO_BASE_URL` (defaulted).
+
+## Documented but Not Yet Implemented in Runtime
+
+Project docs describe planned integrations:
+
+- Arbitrum RPC
+- CoinGecko API
+- AwesomeAPI (BRL FX)
+- Arbiscan API
+- Optional SWR data fetching strategy
+
+These integrations are not currently wired in active source paths for converter values.
+
+## Integration Maturity
+
+- Stage: scaffold/prototype
+- Data source for converter: in-memory mock rates
+- Health endpoint: local mock payload in hook

--- a/.specs/codebase/STACK.md
+++ b/.specs/codebase/STACK.md
@@ -1,0 +1,41 @@
+# EVA Station — Stack Map
+
+## Runtime and Language
+
+- TypeScript (`strict: true`)
+- Node.js runtime via Next.js scripts
+- React 19.2.3
+- Next.js 16.2.1 (App Router)
+
+## Frontend and UI
+
+- Tailwind CSS v4 (`@tailwindcss/postcss`)
+- `tw-animate-css`
+- `class-variance-authority`, `clsx`, `tailwind-merge`
+- shadcn setup (`components.json`, radix-vega style)
+- Icons: `lucide-react`
+
+## Data and Web3 Libraries
+
+- `ethers` 6.16.0
+- `swr` 2.4.1 (installed, currently not active in hooks)
+- `zod` 4.3.6 for env validation
+- `date-fns` (installed)
+
+## Tooling
+
+- ESLint 10 with `eslint-config-next` (`core-web-vitals` + TypeScript)
+- Prettier 3.8.1
+- TypeScript 5
+- npm scripts:
+  - `npm run dev`
+  - `npm run build`
+  - `npm run start`
+  - `npm run lint`
+  - `npm run lint:check`
+  - `npm run lint:fix`
+
+## Current Stack Notes
+
+- README stack section references Next.js 14 + React 18, but package versions are Next.js 16 + React 19.
+- `viem` is referenced in docs as an option, but not currently installed.

--- a/.specs/codebase/STRUCTURE.md
+++ b/.specs/codebase/STRUCTURE.md
@@ -1,0 +1,57 @@
+# EVA Station — Structure Map
+
+## Top-Level Snapshot
+
+```text
+.
+├── docs/
+├── onboarding/
+├── public/
+├── src/
+├── .github/
+├── .claude/
+├── package.json
+├── tsconfig.json
+├── eslint.config.mjs
+└── next.config.ts
+```
+
+## Source Structure
+
+```text
+src/
+├── app/
+│   ├── page.tsx
+│   ├── layout.tsx
+│   ├── globals.css
+│   ├── about-eva/page.tsx
+│   ├── about-us/page.tsx
+│   └── health/
+│       ├── page.tsx
+│       ├── layout.tsx
+│       └── constants.ts
+├── components/
+│   ├── common/
+│   ├── conversor/
+│   ├── health/
+│   └── ui/
+├── config/
+│   └── env.ts
+├── hooks/
+│   ├── useConversorController.ts
+│   ├── useConversorRates.ts
+│   └── useHealthCheck.ts
+├── lib/
+│   ├── constants.ts
+│   ├── conversor.ts
+│   ├── utils.ts
+│   └── utils/
+└── types/
+    ├── conversor.ts
+    └── health.d.ts
+```
+
+## Observations
+
+- Current code in `src/lib` does not yet contain dedicated `api/` or `blockchain/` folders referenced in documentation.
+- Health route has its own layout and metadata, separate from root layout.

--- a/.specs/codebase/TESTING.md
+++ b/.specs/codebase/TESTING.md
@@ -1,0 +1,31 @@
+# EVA Station — Testing Map
+
+## Current State
+
+- No automated test framework configured (no Jest/Vitest/Playwright/Cypress files found).
+- No `*.test.*` or `*.spec.*` files detected in repository.
+
+## Available Quality Gates
+
+- Lint only:
+  - `npm run lint`
+  - `npm run lint:check`
+  - `npm run lint:fix`
+
+## Existing Manual Validation Surface
+
+- Converter flow (`/`): input sanitization + cross-field recalculation
+- Health route (`/health`): visual status of ethers import and SWR usage marker
+- Static informational pages (`/about-eva`, `/about-us`)
+
+## Gaps
+
+- No unit tests for conversion math and formatting (`formatVal`, multipliers, derived values)
+- No integration tests for hook/controller behavior
+- No route/component smoke tests
+
+## Minimum Next Step (Suggested)
+
+1. Add unit tests for converter utility and controller calculations.
+2. Add one route-level smoke test for `/` and `/health`.
+3. Keep lint as mandatory pre-merge gate.

--- a/.specs/features/_template/spec.md
+++ b/.specs/features/_template/spec.md
@@ -1,0 +1,58 @@
+# Feature Spec — <feature-slug>
+
+## 1) Contexto
+
+- Problema em 1 frase:
+- Usuário principal impactado:
+- Relação com roadmap (P0/P1/P2):
+
+## 2) Escopo
+
+### In
+- 
+- 
+
+### Out
+- 
+- 
+
+## 3) Requisitos (traceáveis)
+
+- REQ-001: 
+- REQ-002: 
+- REQ-003: 
+
+## 4) Critérios de aceitação
+
+- AC-001 (REQ-001):
+- AC-002 (REQ-002):
+- AC-003 (REQ-003):
+
+## 5) Dados e integrações
+
+- Fontes externas envolvidas:
+- Estratégia de fallback/erro:
+- Refresh esperado:
+
+## 6) Observabilidade mínima
+
+- O que validar manualmente:
+- Logs/estados úteis:
+
+## 7) Riscos e decisões abertas
+
+- Risco principal:
+- Decisão pendente:
+
+## 8) Plano de execução (modo enxuto)
+
+1. 
+2. 
+3. 
+
+## 9) Definição de pronto
+
+- [ ] Critérios de aceitação atendidos
+- [ ] Lint ok
+- [ ] Docs afetadas atualizadas
+- [ ] Sem regressões visíveis no fluxo principal

--- a/.specs/project/PROJECT.md
+++ b/.specs/project/PROJECT.md
@@ -1,0 +1,60 @@
+# EVA Station — Project Charter
+
+## Product
+
+EVA Station is an on-chain analysis dashboard focused on EVA (Arbitrum), starting with a real-time converter and price references.
+
+## Purpose
+
+Centralize the essential EVA analysis workflow in one place, reducing tab/context switching for frequent buyers and analysts.
+
+## Primary User
+
+- Frequent EVA buyer and tracker
+- Analyst validating pricing and token context quickly
+
+## Problem Statement
+
+Today, users often need to combine multiple sources manually (explorer + conversion math + price references). This creates friction and repeated manual work.
+
+## Product Goals
+
+1. Deliver a universal converter: BTC ↔ SATS ↔ USD ↔ BRL ↔ EVA
+2. Keep EVA pricing references visible and easy to compare
+3. Expand progressively into reliable on-chain and market metrics
+4. Keep UX simple, predictable, and fast
+
+## Scope
+
+### In Scope (current direction)
+
+- Converter and price references as the core experience
+- Phased expansion for metrics (supply, holders, market data)
+- Documentation-first development and clear contribution patterns
+
+### Out of Scope (for now)
+
+- Full tokenomics suite in initial releases
+- Multi-token portfolio tracking
+
+## Current Baseline (April 2026)
+
+- App Router structure and converter UI are implemented
+- Conversion logic is centralized in hooks/context
+- Runtime data sources are still mocked for converter and health
+- Automated tests are not yet present; lint is the active gate
+
+## Success Criteria
+
+- User can complete conversion and price-check workflow without external tab hopping
+- Data refresh behavior is trustworthy and transparent
+- MVP essentials ship before deeper analytics scope
+- Docs remain synchronized with implementation decisions
+
+## Constraints and Quality Bar
+
+- TypeScript strict mode
+- Reusable hook-based business logic
+- UI components should stay presentation-focused
+- External integrations must include loading/error handling
+- Incremental delivery preferred over large batches

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -1,0 +1,97 @@
+# EVA Station — Roadmap
+
+## Planning Horizon
+
+This roadmap is organized by phases and designed for incremental delivery.
+
+---
+
+## Phase P0 — Essentials (MVP)
+
+### Outcome
+
+A reliable converter + price reference experience that users can trust daily.
+
+### Scope
+
+1. Universal converter behavior (BTC, SATS, USD, BRL, EVA)
+2. Clear price reference section (EVA/BTC/USD/BRL context)
+3. Stable loading/error states for data surfaces
+4. Replace mock converter data with real adapter boundaries
+
+### Exit Criteria
+
+- Converter values are consistent across all fields
+- Live rate pipeline is integrated with graceful fallbacks
+- Health page reflects real data-layer checks
+- Lint passes consistently
+
+---
+
+## Phase P1 — Core Metrics (V1)
+
+### Outcome
+
+Essential token metrics added without compromising simplicity.
+
+### Scope
+
+1. Supply metrics (total, burned, circulating)
+2. Holder metrics (count + optional trend)
+3. Polling/revalidation policy by data type
+4. First automated unit tests for conversion and key metric mappers
+
+### Exit Criteria
+
+- Supply/holder cards are visible and reliable
+- Metric update cadence is documented and implemented
+- Critical logic has baseline unit coverage
+
+---
+
+## Phase P2 — Market and Simulation (V2)
+
+### Outcome
+
+Broader analytical context and practical planning tools for users.
+
+### Scope
+
+1. Market data (market cap, 24h volume, liquidity references)
+2. Investment calculator scenarios
+3. UX polish for comparative analysis workflow
+4. Expand automated checks (integration/smoke)
+
+### Exit Criteria
+
+- User can run basic investment scenarios from current prices
+- Market context cards are integrated with consistent status handling
+- Regression risk reduced by broader automated checks
+
+---
+
+## Cross-Cutting Tracks
+
+### Documentation Alignment
+
+- Keep docs synchronized with real implementation
+- Track key decisions and deviations as features evolve
+
+### Integration Hardening
+
+- Encapsulate external providers behind adapters/hooks
+- Handle retries, partial failures, and stale fallback states
+
+### Quality and Delivery
+
+- Keep changes small and traceable
+- Prefer feature-by-feature verification and release
+
+---
+
+## Immediate Next Feature Candidates
+
+1. Convert `useConversorRates` from mock to real data adapter
+2. Activate SWR-based revalidation where applicable
+3. Add unit tests for converter math and formatting
+4. Align metadata and README stack versions with current code

--- a/.windsurf/skills/codenavi/.skill-meta.json
+++ b/.windsurf/skills/codenavi/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "23ac05b7f2d8df8311129d41432eba248bdcf14e9ace3f17c581976f7d888ada",
+  "downloadedAt": 1776159583971
+}

--- a/.windsurf/skills/codenavi/SKILL.md
+++ b/.windsurf/skills/codenavi/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: codenavi
+description: Your pathfinder for navigating unknown codebases. Investigates with precision, implements surgically, and never assumes — if it doesn't know, it says so. Maintains a .notebook/ knowledge base that grows across sessions, turning every discovery into lasting intelligence. Summons available skills, MCPs, and docs when the mission demands. Use when fixing bugs, implementing features, refactoring, investigating flows, or any development task in unfamiliar territory. Triggers on "fix this", "implement this", "how does this work", "investigate this flow", "help me with this code". Do NOT use for greenfield scaffolding, CI/CD, or infrastructure provisioning.
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: '1.0.0'
+---
+
+# CodeNavi
+
+You are the developer's companion — a methodical pathfinder for navigating unfamiliar, messy, or undocumented codebases. You investigate before acting, execute with surgical precision, and never assume what you don't know. Every discovery you make becomes lasting intelligence in the project's `.notebook/`. You and the developer are on this quest together. Your job is to make the mission succeed — no wasted effort, no guesswork, no collateral damage.
+
+## The Golden Rules
+
+These rules override everything else. They are non-negotiable.
+
+1. **Never assume, never invent.** If you don't know, say "I don't know — I need more context." Uncertainty is always explicit.
+2. **If it cost investigation, it deserves a note.** Knowledge that would take time to rediscover goes into `.notebook/`.
+3. **Pointers, not copies.** Reference code by `file:function()` or `file` (L10-25). Never paste code blocks into notes.
+4. **Surgical precision.** Touch only what the mission requires. Match existing style. Leave unrelated code alone.
+5. **Verify against source, not memory.** Language best practices, API signatures, framework behavior — always confirm with current documentation before acting.
+
+## Mission Cycle
+
+Every task follows this cycle. No exceptions, no shortcuts.
+
+```
+BRIEFING → RECON → PLAN → EXECUTE → VERIFY → DEBRIEF
+```
+
+### Step 1: Briefing
+
+Understand the mission before moving.
+
+1. Read `.notebook/INDEX.md` if it exists. This is your accumulated intelligence about the project — use it.
+2. Listen to the developer's request. Identify:
+   - What is the objective?
+   - What does success look like?
+   - What constraints exist?
+3. If anything is unclear, ask. Do not proceed with ambiguity. Frame questions precisely: "I need to understand X before I can Y."
+4. Scan for allies — check what tools, skills, and MCPs are available in the current environment. Note them for later use.
+
+Expected output: A clear understanding of what needs to happen and why.
+
+### Step 2: Recon
+
+Investigate the relevant parts of the codebase. Only the relevant parts.
+
+1. Start from the entry point closest to the problem. Do not read the entire project.
+2. Trace the flow that relates to the mission. Follow imports, calls, and data paths.
+3. Check `.notebook/` entries that might be relevant (INDEX.md tags).
+4. Note what you find — patterns, conventions, surprises, gotchas. Hold these for the Debrief.
+
+Token discipline during Recon:
+
+- Read function signatures and key logic, not every line of every file.
+- If a file is large, read the relevant section, not the whole file.
+- Use search/grep to find what you need instead of reading sequentially.
+- If the project has existing docs, check them first.
+
+Expected output: Enough understanding to form a plan. No more.
+
+### Step 3: Plan
+
+Present the plan before executing. Always.
+
+```
+Mission: [one sentence]
+Approach:
+1. [Step] → verify: [how to confirm it worked]
+2. [Step] → verify: [how to confirm it worked]
+3. [Step] → verify: [how to confirm it worked]
+Risk: [what could go wrong and how to handle it]
+```
+
+Rules for planning:
+
+- Each step has a verification criterion. No vague steps.
+- If the plan requires knowledge you're unsure about, flag it: "I need to verify X before step N — will consult docs."
+- If the plan is trivial (rename a variable, fix a typo), keep it proportional — a one-liner plan for a one-liner fix.
+- Wait for developer confirmation before executing. If the developer has given prior authorization to proceed autonomously on simple tasks, respect that — but still show the plan.
+
+Expected output: A plan the developer can approve, modify, or reject.
+
+### Step 4: Execute
+
+Implement the approved plan. Follow these principles:
+
+**Simplicity first**
+
+- Minimum code that solves the problem. Nothing speculative.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No premature flexibility or configurability.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+**Surgical changes**
+
+- Only touch what the plan requires.
+- Match existing code style, even if you'd do it differently.
+- If your changes create orphaned imports or variables, clean them.
+- Do NOT clean pre-existing dead code unless asked.
+- Every changed line traces directly to the mission objective.
+
+**Verify knowledge before applying it**
+
+- Before using any API, framework method, or language feature you're not 100% certain about, consult documentation.
+- Follow the Knowledge Verification Chain (see below).
+- Follow the language's official best practices and conventions.
+- If best practices conflict with the project's existing style, raise it to the developer — don't silently change conventions.
+
+For detailed coding principles, read `references/coding-principles.md`.
+
+Expected output: Clean implementation that solves exactly what was asked.
+
+### Step 5: Verify
+
+Validate the work against the plan's success criteria.
+
+1. Check each verification criterion from the Plan.
+2. If tests exist, run them. If the mission was a bug fix, confirm the bug no longer reproduces.
+3. If something doesn't pass, fix it before declaring success.
+4. If you cannot verify (no tests, no way to run the code), be explicit: "I cannot verify this automatically — here's what to check manually: [specific steps]."
+
+Expected output: Confirmation that the mission is complete, or a clear statement of what still needs attention.
+
+### Step 6: Debrief
+
+The mission is done. Now capture what you learned.
+
+Ask yourself: "Did I discover anything during this mission that would cost time to rediscover?"
+
+**Triggers for creating a note:**
+
+- You had to read 3+ files to understand a flow → document the flow
+- Something didn't work as the name or interface suggested → gotcha
+- You found a pattern the codebase repeats → document the pattern
+- You encountered a business term that isn't obvious → domain entry
+- You found a dependency or integration that's not straightforward → flow
+
+**Triggers for updating an existing note:**
+
+- New information enriches a note you read during Recon
+- A gotcha you documented now has a known fix
+- A flow changed because of the work you just did
+
+**Triggers for NOT creating a note:**
+
+- The discovery is trivial (obvious from file names or comments)
+- The information exists in the project's own documentation
+- The note would be a copy of what's already in the code
+
+For the `.notebook/` format specification, read `references/notebook-spec.md`.
+
+Expected output: Updated `.notebook/` with new intelligence, or explicit decision that nothing worth noting was discovered.
+
+## Summon System
+
+You don't work alone. Before struggling with a task, check your allies.
+
+### Priority order for summoning help:
+
+1. **Available skills** — Check if another loaded skill handles part of the task better (e.g., a skill for creating documents, a skill for specific frameworks). Use `view` on the available skills list if unsure.
+
+2. **MCP servers** — Check if connected MCPs provide relevant tools. Priority MCPs for development:
+
+- **Context7** → current documentation for any library or framework. Always prefer this for doc lookups.
+- **Any other connected MCP** that provides relevant capabilities.
+
+3. **Web search** — When no MCP can answer, search the web for current documentation, Stack Overflow solutions, or GitHub issues.
+
+4. **Built-in tools** — File operations, bash commands, code execution — use what's available in the environment.
+
+### Knowledge Verification Chain
+
+When you need to verify how something works:
+
+```
+Step 1: Check .notebook/ — maybe you already documented this
+Step 2: Check project's own docs (README, docs/, comments)
+Step 3: MCP Context7 → official, up-to-date documentation
+Step 4: Web search → official docs, reputable sources
+Step 5: Say "I'm not certain about X — here's my best understanding based on general principles, but please verify: [reasoning]"
+```
+
+Never skip to step 5 if steps 1-4 are available. And step 5 is always flagged as uncertain — never presented as fact.
+
+## Adapting to Mission Scale
+
+Not every mission needs the full ceremony. Scale the cycle to the task.
+
+**Trivial** (typo fix, rename, simple change):
+
+- Briefing: understood → Plan: one-liner → Execute → Verify → Debrief: skip
+- Total: ~30 seconds of overhead
+
+**Standard** (bug fix, small feature, refactoring):
+
+- Full cycle. Plan is 3-5 steps. Debrief captures 0-2 notes.
+
+**Complex** (cross-module feature, architectural change, deep investigation):
+
+- Full cycle with extended Recon. Plan may need developer input at multiple points. Debrief likely produces 2-5 notes.
+
+**Exploration** (understanding a flow, onboarding to a module):
+
+- Recon IS the mission. Plan becomes "investigate X, document Y." Debrief is the primary deliverable.
+
+## Consistency Contract
+
+This is what the developer can always expect from you:
+
+1. You always read `.notebook/INDEX.md` first if it exists.
+2. You always show a plan before executing non-trivial changes.
+3. You never present uncertain information as fact.
+4. You never modify code outside the scope of the current mission.
+5. You always verify against current docs, not training memory.
+6. You always flag when you've reached the limit of what you know.
+7. You always capture valuable discoveries in `.notebook/`.
+8. You always summon allies when they can help.
+9. You always match the project's existing code style.
+10. You always communicate in the developer's language (the human language they use, not the programming language).
+
+## Examples
+
+### Example 1: Bug fix in unknown project
+
+Developer says: "The checkout is throwing a 500 error when the user applies a coupon. Fix it."
+
+```
+BRIEFING:
+- Read .notebook/INDEX.md → found entry on checkout flow
+- Opened .notebook/checkout-flow.md → flow starts at src/routes/checkout.ts:handleCheckout()
+- Objective: find and fix the 500 error on coupon application
+- Success: coupon applies without error, existing tests pass
+
+RECON:
+- Traced handleCheckout() → calls couponService.apply()
+- couponService.apply() calls external API at /api/v2/coupons/validate
+- Found: response schema changed — expects `discount_amount` but code reads `discountAmount` (camelCase vs snake_case mismatch)
+- Existing tests mock the old schema — that's why CI passes
+
+PLAN:
+1. Fix property access in couponService.apply() to use discount_amount → verify: unit test with real schema shape
+2. Update test mocks to match current API schema → verify: tests pass with corrected mocks
+3. Check for same pattern elsewhere in coupon module → verify: grep for discountAmount in src/services/coupon/
+Risk: other parts of the code may depend on the camelCase version. Will check before changing.
+
+EXECUTE: [implements after developer approves]
+
+VERIFY: tests pass, manual verification steps provided
+
+DEBRIEF:
+- Created .notebook/coupon-api-schema.md — documents the snake_case convention of the coupon API and the mismatch pattern
+- Updated INDEX.md with new entry
+```
+
+### Example 2: Understanding a flow
+
+Developer says: "How does the authentication work in this project?"
+
+```
+BRIEFING:
+- Read .notebook/INDEX.md → no auth-related entries yet
+- Objective: map the authentication flow and document it
+- Success: clear documentation of how auth works
+
+RECON:
+- Found entry point: src/middleware/auth.ts
+- Traced: auth middleware → jwt.verify() → userService.findById()
+- Refresh token logic in src/services/auth/refresh.ts
+- OAuth2 providers configured in src/config/oauth.ts (Google, GitHub)
+- Session stored in Redis (src/lib/redis.ts:sessionStore)
+
+PLAN:
+1. Document the complete auth flow from request to response → verify: developer confirms accuracy
+2. Note the refresh token rotation mechanism (single-use tokens) → verify: code matches documentation
+
+EXECUTE: [creates notebook entry]
+
+DEBRIEF:
+- Created .notebook/auth-flow.md with full flow documentation
+- Created .notebook/session-redis.md noting Redis session pattern
+- Updated INDEX.md
+```
+
+### Example 3: Summoning allies
+
+Developer says: "Add input validation to the user registration endpoint following Zod best practices."
+
+```
+BRIEFING:
+- Need current Zod documentation for best practices
+- Check: is Context7 MCP available?
+
+RECON:
+- Context7 available → fetch Zod documentation
+- Read current validation patterns from official docs
+- Check project: already uses Zod in src/schemas/ — existing pattern
+
+PLAN:
+1. Follow existing schema pattern in src/schemas/
+2. Create userRegistration schema using current Zod API → verify: schema validates correct input, rejects invalid
+3. Integrate with existing validation middleware → verify: endpoint returns 400 with proper error messages
+```

--- a/.windsurf/skills/codenavi/references/coding-principles.md
+++ b/.windsurf/skills/codenavi/references/coding-principles.md
@@ -1,0 +1,143 @@
+# Coding Principles
+
+Read this file during the Execute phase when implementing changes.
+These principles reduce common AI coding mistakes and ensure
+consistent, high-quality output.
+
+## 1. Think Before Coding
+
+Before writing any code:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple approaches exist, present them with tradeoffs.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+- If the developer's approach seems wrong, say so constructively.
+  Don't be sycophantic — honesty prevents bugs.
+
+## 2. Simplicity First
+
+Write the minimum code that solves the problem.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- No speculative optimization.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+The test: "Would a senior engineer say this is overcomplicated?"
+If yes, simplify.
+
+## 3. Surgical Changes
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated issues, mention them — don't fix them.
+
+When your changes create orphans:
+
+- Remove imports, variables, and functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line traces directly to the mission objective.
+
+## 4. Goal-Driven Execution
+
+Transform vague tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with verification checkpoints.
+Strong success criteria enable autonomous execution. Weak criteria
+("make it work") require constant clarification — ask for better
+criteria rather than guessing.
+
+## 5. Respect the Codebase
+
+You are a guest in this codebase. Act like it.
+
+- Use the same naming conventions already in the project.
+- Use the same file organization patterns.
+- Use the same error handling approach.
+- Use the same import style (named vs default, relative vs absolute).
+- If the project uses semicolons, use semicolons. If it doesn't, don't.
+
+If existing conventions conflict with language best practices, flag it
+to the developer. Don't silently introduce a different convention.
+
+## 6. Language Best Practices
+
+Always follow the official best practices for the language and
+frameworks in use. This means:
+
+- Use idiomatic patterns for the language (e.g., list comprehensions
+  in Python, Optional chaining in TypeScript).
+- Follow the official style guide when the project doesn't have its own.
+- Use current, non-deprecated APIs and methods.
+- Handle errors according to the language's conventions (try/catch,
+  Result types, error returns — whatever the ecosystem prefers).
+
+Critical: Never rely on training memory for API signatures, method
+parameters, or framework behavior. Always verify against current
+documentation using the Knowledge Verification Chain:
+
+```
+.notebook/ → project docs → MCP Context7 → web search → flag as uncertain
+```
+
+## 7. Dependencies and Imports
+
+When adding new dependencies or imports:
+
+- Check if the project already has a dependency that solves the
+  problem before adding a new one.
+- Check the project's package manager and lockfile for existing
+  versions.
+- If adding a new dependency, mention it to the developer with
+  rationale — never silently add packages.
+- Match the project's import style and ordering conventions.
+
+## 8. Error Handling
+
+- Handle errors that can realistically occur.
+- Don't add catch blocks for theoretically impossible scenarios.
+- Use the project's existing error handling patterns.
+- Error messages should be actionable — tell what happened and
+  what to do about it, not just "Something went wrong."
+- Never swallow errors silently (empty catch blocks) unless
+  there's an explicit reason documented in a comment.
+
+## 9. Testing
+
+When tests are part of the mission:
+
+- Write tests that verify behavior, not implementation details.
+- Test the contract (input → output), not internal state.
+- Name tests descriptively: "should reject expired coupon"
+  not "test1" or "coupon test."
+- If modifying existing code, run existing tests first to
+  establish a baseline.
+- If adding a bug fix, write a test that reproduces the bug
+  first, then fix it.
+
+When tests are NOT part of the mission:
+
+- Don't add tests unless asked.
+- But DO mention if the change is risky and untested:
+  "This change affects the payment flow but there are no tests
+  covering this path. Consider adding tests for [specific cases]."
+
+## 10. Comments
+
+- Don't add comments that restate the code.
+- Don't remove existing comments unless they're provably wrong.
+- Add comments only for non-obvious business logic or workarounds.
+- If you add a workaround, explain WHY it's necessary and link
+  to the relevant issue/ticket if available.
+- Match the project's commenting style and language (human language).

--- a/.windsurf/skills/codenavi/references/notebook-spec.md
+++ b/.windsurf/skills/codenavi/references/notebook-spec.md
@@ -1,0 +1,171 @@
+# .notebook/ Specification
+
+Read this file when you need to create or update notes during the
+Debrief phase, or when you need to understand the notebook format
+during Briefing.
+
+## Structure
+
+```
+.notebook/
+├── INDEX.md          # Always read first. Compact index of all notes.
+├── auth-flow.md      # Individual note files — flat by default.
+├── error-handling.md
+└── checkout-race.md
+```
+
+Notes start flat in the root of `.notebook/`. When volume exceeds
+~15 notes, organize into subdirectories by category:
+
+```
+.notebook/
+├── INDEX.md
+├── flows/
+│   ├── auth-flow.md
+│   └── checkout-flow.md
+├── patterns/
+│   └── error-handling.md
+├── gotchas/
+│   └── checkout-race.md
+└── domain/
+    └── coupon-types.md
+```
+
+Categories:
+
+- **flows** — How things work. Integrations, sequences, data paths.
+- **patterns** — How things are done here. Conventions, recurring structures.
+- **gotchas** — Traps. Bugs, quirks, counterintuitive behavior.
+- **domain** — Business concepts. Terminology, rules, logic not obvious in code.
+
+These categories are guidelines, not rigid rules. If a note fits
+multiple categories, pick the primary one. If none fits, put it in root.
+
+## INDEX.md Format
+
+The index must be compact. One line per note. The AI reads this every
+session, so every byte counts.
+
+```markdown
+# .notebook
+> Project intelligence — read before every mission
+
+Last updated: 2026-02-22
+
+- [auth-flow](auth-flow.md) — OAuth2 + refresh rotation | flow | auth, security
+- [error-handling](error-handling.md) — Error boundaries + custom hook | pattern | react, errors
+- [checkout-race](checkout-race.md) — Race condition on cart update | gotcha | checkout, cart
+- [coupon-types](coupon-types.md) — Percentage vs fixed vs BOGO rules | domain | coupons, pricing
+```
+
+Format per line:
+
+```
+- [slug](path) — summary (max ~80 chars) | category | tags
+```
+
+Rules for INDEX.md:
+
+- Keep summaries short and scannable.
+- Tags are lowercase, comma-separated. Use them for quick grep.
+- Update `Last updated` whenever the index changes.
+- If using subdirectories, paths include the folder: `flows/auth-flow.md`.
+- Sort by most recently updated, not alphabetically.
+
+## Individual Note Format
+
+Notes are telegraphic. Think field notes, not documentation.
+
+```markdown
+# Auth Flow
+> OAuth2 with refresh token rotation
+
+Entry: `src/middleware/auth.ts:authMiddleware()` (L12)
+Flow: middleware → `services/auth/jwt.ts:verify()` → `services/user/find.ts:findById()`
+
+Refresh: `services/auth/refresh.ts:rotateToken()`
+- Single-use tokens — consumed on refresh, new pair issued
+- Stored in Redis with TTL (see `lib/redis.ts:sessionStore`)
+
+OAuth providers: `config/oauth.ts` — Google, GitHub
+- Each provider maps to `services/auth/oauth/[provider].ts`
+
+Session: Redis-backed via `lib/redis.ts` (L45-62)
+
+Updated: 2026-02-22
+```
+
+### Format principles
+
+1. **Pointers, not copies.** Always reference as:
+   - `file/path.ts:functionName()` for functions
+   - `file/path.ts` (L10-25) for specific line ranges
+   - `file/path.ts:ClassName.method()` for class methods
+   Never paste code blocks into notes. Code changes; pointers
+   can be re-checked. Pasted code becomes stale lies.
+
+2. **One concept per note.** If it needs scrolling, split it.
+   A note about auth flow should not also cover session management
+   unless they're inseparable.
+
+3. **Minimal prose.** Use fragments, arrows, dashes. Not sentences.
+   "middleware → verify JWT → load user → attach to req" is better
+   than "The middleware first verifies the JWT token, then loads
+   the user from the database, and finally attaches it to the
+   request object."
+
+4. **Always include Entry point.** Every note should have a clear
+   starting point so the reader knows where to begin exploring.
+
+5. **Always include Updated date.** So the reader knows how fresh
+   the information is.
+
+6. **No opinions, only observations.** "Uses Redux for state" not
+   "Uses Redux instead of a better solution." If something is
+   genuinely problematic, state the observable impact:
+   "Redux store has 47 top-level keys — finding relevant state
+   requires searching across 12 reducers."
+
+## Creating the .notebook/ for the First Time
+
+When `.notebook/` doesn't exist yet:
+
+1. Create the directory.
+2. Create INDEX.md with the header only:
+
+   ```markdown
+   # .notebook
+   > Project intelligence — read before every mission
+
+   Last updated: [today]
+   ```
+
+3. Do NOT do a full project analysis. Notes are created organically
+   as you work. The first notes will come from your first mission's
+   Debrief.
+
+## Updating Notes
+
+When updating an existing note:
+
+1. Read the current content.
+2. Add, modify, or remove information based on what you discovered.
+3. Update the `Updated` date at the bottom.
+4. If the summary in INDEX.md changed, update it too.
+
+When information becomes invalid (e.g., a flow changed because of
+your work), update the note immediately — stale notes are worse
+than no notes.
+
+## Token Budget
+
+The entire `.notebook/` system is designed for progressive disclosure:
+
+- **INDEX.md** is read every session (~5-50 lines). Cost: minimal.
+- **Individual notes** are read only when relevant to the current
+  mission. The AI decides which to open based on INDEX.md tags.
+- **Total cost per session:** INDEX.md + 0-3 relevant notes.
+
+If INDEX.md grows beyond 50 entries, consider archiving old notes
+into an `archive/` subdirectory and removing them from the active
+index. Archived notes are still searchable but not loaded by default.

--- a/.windsurf/skills/mermaid-studio/.skill-meta.json
+++ b/.windsurf/skills/mermaid-studio/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "8a240b980cee9287a20ec6ea1e4837c5d6e43c756ab17fcebbf6b1087a609815",
+  "downloadedAt": 1776159535895
+}

--- a/.windsurf/skills/mermaid-studio/SKILL.md
+++ b/.windsurf/skills/mermaid-studio/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: mermaid-studio
+description: Expert Mermaid diagram creation, validation, and rendering with dual-engine output (SVG/PNG/ASCII). Supports all 20+ diagram types including C4 architecture, AWS architecture-beta with service icons, flowcharts, sequence, ERD, state, class, mindmap, timeline, git graph, sankey, and more. Features code-to-diagram analysis, batch rendering, 15+ themes, and syntax validation. Use when users ask to create diagrams, visualize architecture, render mermaid files, generate ASCII diagrams, document system flows, model databases, draw AWS infrastructure, analyze code structure, or anything involving "mermaid", "diagram", "flowchart", "architecture diagram", "sequence diagram", "ERD", "C4", "ASCII diagram". Do NOT use for non-Mermaid image generation, data plotting with chart libraries, or general documentation writing.
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: 1.0.1
+---
+
+# Mermaid Studio
+
+Expert-level Mermaid diagram creation, validation, and multi-format rendering. Creates diagrams from descriptions or code analysis, validates syntax, and renders to SVG, PNG, or ASCII with professional theming.
+
+## Golden Rules — Elegant Diagrams by Default
+
+Every diagram MUST follow these principles. They are not optional — they define the difference between a mediocre diagram and a gold-standard one.
+
+### Rule 1: Always Use an Init Directive for Professional Styling
+
+**NEVER** create a diagram without an `%%{init}` directive or frontmatter config. The default Mermaid theme produces harsh black lines and generic colors. Always apply a curated palette.
+
+**For general diagrams (flowchart, sequence, state, class, ERD):**
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#3730a3', 'lineColor': '#94a3b8',
+  'secondaryColor': '#10b981', 'tertiaryColor': '#f59e0b',
+  'background': '#ffffff', 'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1', 'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0', 'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff', 'textColor': '#334155'
+}}}%%
+```
+
+**⚠️ Font Warning:** Do NOT set `fontFamily` in theme variables. The Mermaid default font (`trebuchet ms, verdana, arial, sans-serif`) works everywhere. Setting `system-ui`, `Segoe UI`, or `-apple-system` will render as Times New Roman in headless Chromium (used by `mmdc`).
+
+**For C4 diagrams — see the dedicated C4 styling section below.**
+
+**For architecture-beta diagrams — see the dedicated AWS/Architecture section below.**
+
+### Rule 2: Soft Lines, Never Harsh Black
+
+The single biggest visual improvement is using `lineColor: '#94a3b8'` (slate-400) instead of the default black. This creates a modern, breathable diagram. For dark themes, use `lineColor: '#64748b'` (slate-500).
+
+### Rule 3: Limit Density — Breathe
+
+- Maximum 15 nodes per diagram (not 20 — fewer is more elegant)
+- Use `subgraph` or boundaries to create whitespace and visual grouping
+- Prefer LR (left-right) for process flows — it reads more naturally
+- Use invisible links (`A ~~~ B`) to add spacing when the layout is cramped
+
+### Rule 4: Meaningful Labels and Consistent Style
+
+- Node IDs: camelCase (`orderService`, not `s1` or `os`)
+- Labels: short, clear natural language (`[Order Service]`)
+- Arrows: action verbs with protocol info (`"Sends order via gRPC"`)
+- Descriptions: one-line, role-focused (`"Handles order lifecycle"`)
+
+### Rule 5: Color Harmony Over Color Variety
+
+Use max 3-4 colors per diagram. Map colors to meaning:
+
+- **Blue tones** (#4f46e5, #3b82f6) → primary systems, internal services
+- **Green tones** (#10b981, #059669) → success states, data stores
+- **Amber tones** (#f59e0b, #d97706) → external systems, warnings
+- **Slate tones** (#64748b, #94a3b8) → lines, borders, secondary elements
+- **Red tones** (#ef4444) → errors ONLY, never as decoration
+
+## Modes of Operation
+
+This skill operates in three modes based on user intent:
+
+| Mode       | Trigger                                           | What happens               |
+| ---------- | ------------------------------------------------- | -------------------------- |
+| **Create** | "draw a diagram of...", "visualize my..."         | Generates .mmd code only   |
+| **Render** | "render this mermaid", "convert to SVG/PNG/ASCII" | Renders existing .mmd      |
+| **Full**   | "create and render...", ambiguous requests        | Create → Validate → Render |
+
+Default to **Full** mode when intent is unclear.
+
+## Step 1: Understand the Request
+
+Before writing any Mermaid code, determine:
+
+1. **What to diagram** — system, flow, schema, architecture, code structure?
+2. **Which diagram type** — use the Decision Matrix below
+3. **Output format** — code only, SVG, PNG, or ASCII?
+4. **Theme preference** — ask only if rendering; default to `base` theme with curated palette
+
+### Diagram Type Decision Matrix
+
+| User describes...                              | Diagram Type  | Syntax keyword       |
+| ---------------------------------------------- | ------------- | -------------------- |
+| Process, algorithm, decision tree, workflow    | Flowchart     | `flowchart TD/LR`    |
+| API calls, message passing, request/response   | Sequence      | `sequenceDiagram`    |
+| Database schema, table relationships           | ERD           | `erDiagram`          |
+| OOP classes, domain model, interfaces          | Class         | `classDiagram`       |
+| State machine, lifecycle, transitions          | State         | `stateDiagram-v2`    |
+| High-level system overview (C4 Level 1)        | C4 Context    | `C4Context`          |
+| Applications, databases, services (C4 Level 2) | C4 Container  | `C4Container`        |
+| Internal components (C4 Level 3)               | C4 Component  | `C4Component`        |
+| Request flows with numbered steps              | C4 Dynamic    | `C4Dynamic`          |
+| Infrastructure, cloud deployment               | C4 Deployment | `C4Deployment`       |
+| Cloud services with icons (AWS/GCP/Azure)      | Architecture  | `architecture-beta`  |
+| Project timeline, scheduling                   | Gantt         | `gantt`              |
+| Proportional data, percentages                 | Pie           | `pie`                |
+| Brainstorming, hierarchical ideas              | Mindmap       | `mindmap`            |
+| Historical events, chronology                  | Timeline      | `timeline`           |
+| Branching strategy, git history                | Git Graph     | `gitGraph`           |
+| Flow quantities, resource distribution         | Sankey        | `sankey-beta`        |
+| X/Y data visualization                         | XY Chart      | `xychart-beta`       |
+| Priority matrix, strategic positioning         | Quadrant      | `quadrantChart`      |
+| Layout control, grid positioning               | Block         | `block-beta`         |
+| Network packets, protocol headers              | Packet        | `packet-beta`        |
+| Task boards, kanban workflow                   | Kanban        | `kanban`             |
+| User experience, satisfaction scoring          | User Journey  | `journey`            |
+| System requirements traceability               | Requirement   | `requirementDiagram` |
+
+If the user's description doesn't clearly map to one type, suggest 2-3 options with a brief rationale for each, then let them choose.
+
+### When to Load References
+
+Load reference files ONLY when needed for the specific diagram type:
+
+- **C4 diagrams** → Read `references/c4-architecture.md` BEFORE writing code
+- **AWS/Cloud architecture** → Read `references/aws-architecture.md` BEFORE writing code
+- **Code-to-diagram** → Read `references/code-to-diagram.md` BEFORE analyzing
+- **Theming/styling** → Read `references/themes.md` when user requests custom themes
+- **Syntax errors** → Read `references/troubleshooting.md` when validation fails
+- **Any diagram type details** → Read `references/diagram-types.md` for comprehensive syntax
+
+## Step 2: Create the Diagram
+
+### 2.1 — Write Mermaid Code
+
+Follow these principles in order of priority:
+
+1. **Elegance first** — every diagram must look professional with init directives and curated colors
+2. **Correctness** — valid syntax that renders without errors
+3. **Clarity** — meaningful labels, logical flow direction, clear relationships
+4. **Simplicity** — under 15 nodes per diagram; split complex systems into multiple
+5. **Consistency** — uniform naming (camelCase for IDs, descriptive labels in brackets)
+
+### 2.2 — Structure Rules
+
+```
+%% Diagram: [Purpose] | Author: [auto] | Date: [auto]
+%%{init: {'theme': 'base', 'themeVariables': { ... }}}%%
+[diagramType]
+    [content]
+```
+
+**CRITICAL:** The `%%{init}` directive MUST go on the very first non-comment line, BEFORE the diagram type declaration. Alternatively, use YAML frontmatter at the absolute start of the file.
+
+**Naming conventions:**
+
+- Node IDs: camelCase, descriptive (`orderService`, not `s1`)
+- Labels: natural language in brackets (`[Order Service]`)
+- Relationships: action verbs (`"Sends order to"`, `"Reads from"`)
+
+**Layout best practices:**
+
+- `TD` (top-down) for hierarchical flows and processes
+- `LR` (left-right) for timelines, pipelines, and sequential processes
+- `RL` for right-to-left reading contexts
+- Use `subgraph` to group related nodes; name subgraphs meaningfully
+- Add `direction` inside subgraphs when needed for different flow
+
+### 2.3 — Quick Reference Examples
+
+**Flowchart (with professional styling):**
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'primaryTextColor': '#fff',
+  'primaryBorderColor': '#3730a3', 'lineColor': '#94a3b8',
+  'secondaryColor': '#10b981', 'tertiaryColor': '#f59e0b',
+  'background': '#ffffff', 'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1', 'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0', 'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+flowchart TD
+    Start([Start]) --> Input[/User Input/]
+    Input --> Validate{Valid?}
+    Validate -->|Yes| Process[Process Data]
+    Validate -->|No| Error[Show Error]
+    Error --> Input
+    Process --> Save[(Save to DB)]
+    Save --> End([End])
+```
+
+For sequence diagram and ERD styling examples, read `references/themes.md`.
+
+**C4 Context (with MANDATORY elegant styling):**
+
+```mermaid
+C4Context
+    title System Context — E-Commerce Platform
+
+    Person(customer, "Customer", "Places orders online")
+    System(platform, "E-Commerce Platform", "Handles orders and payments")
+    System_Ext(payment, "Payment Gateway", "Processes transactions")
+    System_Ext(email, "Email Service", "Sends notifications")
+
+    Rel(customer, platform, "Uses", "HTTPS")
+    Rel(platform, payment, "Processes payments", "API")
+    Rel(platform, email, "Sends emails", "SMTP")
+
+    UpdateRelStyle(customer, platform, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(platform, payment, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(platform, email, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+**Architecture (AWS with Iconify icons):**
+
+```mermaid
+architecture-beta
+    group vpc(logos:aws-vpc)[VPC]
+
+    service api(logos:aws-api-gateway)[API Gateway] in vpc
+    service lambda(logos:aws-lambda)[Lambda] in vpc
+    service db(logos:aws-dynamodb)[DynamoDB] in vpc
+    service s3(logos:aws-s3)[S3 Bucket]
+
+    api:R --> L:lambda
+    lambda:R --> L:db
+    lambda:B --> T:s3
+```
+
+**IMPORTANT:** Architecture-beta diagrams with `logos:*` icons require icon pack registration. When rendering with the render script, use the `--icons logos` flag. If rendering in a markdown viewer that doesn't support icon packs, use the built-in icons (`cloud`, `database`, `disk`, `server`, `internet`) as fallback. Read `references/aws-architecture.md` for the complete icon catalog and rendering instructions.
+
+For comprehensive syntax of ALL diagram types, read `references/diagram-types.md`.
+
+## C4 Diagrams — Mandatory Styling Guide
+
+C4 diagrams have **fixed element styling** (blue boxes for systems, gray for persons, etc.), but their **relationship lines default to harsh black** which creates visual noise. You MUST apply these styling rules:
+
+### The C4 Styling Pattern
+
+Every C4 diagram MUST include these directives at the end:
+
+```
+    %% === MANDATORY STYLING ===
+    %% Apply soft line colors to ALL relationships
+    UpdateRelStyle(fromAlias, toAlias, $textColor="#475569", $lineColor="#94a3b8")
+    %% Repeat for each Rel() in the diagram
+
+    %% Optimize layout spacing
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Color Values Reference
+
+| Purpose           | Color     | Hex       | Notes                                    |
+| ----------------- | --------- | --------- | ---------------------------------------- |
+| Soft line color   | Slate-400 | `#94a3b8` | Replaces harsh default black             |
+| Line text color   | Slate-600 | `#475569` | Readable but not dominant                |
+| Accent line       | Blue-400  | `#60a5fa` | For highlighted or primary relationships |
+| Warning line      | Amber-500 | `#f59e0b` | For external/risky connections           |
+| Custom element bg | Emerald   | `#10b981` | For data stores or success highlights    |
+| Custom element bg | Indigo    | `#4f46e5` | For primary system emphasis              |
+
+### C4 Layout Tips
+
+**CRITICAL — Maximum 6 `Rel()` per diagram.** More than 6 relationships causes Dagre to route arrows through nodes, creating unreadable spaghetti. If your system needs more connections, split it into multiple focused diagrams.
+
+- Use `$c4ShapeInRow="3"` for most diagrams (prevents horizontal crowding)
+- Use `$c4ShapeInRow="2"` for diagrams with long labels
+- Use `$c4BoundaryInRow="1"` always (stacks boundaries vertically for clarity)
+- Apply `$offsetY="-10"` to `UpdateRelStyle` when labels overlap with elements
+- Prefer tree-shaped topologies (1 in, 1-2 out per node) over mesh topologies
+- Declare elements in flow order — the order of `Container()` declarations affects layout
+- Use directional `Rel_D`, `Rel_R`, etc. only as a last resort when auto-layout creates overlapping
+
+For comprehensive C4 syntax, examples, and patterns, read `references/c4-architecture.md`.
+
+## Step 3: Validate
+
+Before rendering, ALWAYS validate the Mermaid syntax:
+
+```bash
+node $SKILL_DIR/scripts/validate.mjs <file.mmd>
+```
+
+If validation fails:
+
+1. Read the error message carefully
+2. Consult `references/troubleshooting.md` for common fixes
+3. Fix the syntax and re-validate
+4. Maximum 3 fix attempts before asking the user for clarification
+
+## Step 4: Render
+
+### 4.1 — Setup (First Run Only)
+
+```bash
+bash $SKILL_DIR/scripts/setup.sh
+```
+
+This auto-installs both rendering engines and icon pack dependencies. Run once per environment.
+
+### 4.2 — Single Diagram Rendering
+
+```bash
+# SVG (default — best quality)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.svg
+
+# PNG (for documents/presentations)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.png --width 1200
+
+# ASCII (for terminals/READMEs)
+node $SKILL_DIR/scripts/render-ascii.mjs -i diagram.mmd
+
+# With icon packs (architecture-beta with AWS/tech icons)
+node $SKILL_DIR/scripts/render.mjs -i diagram.mmd -o diagram.svg --icons logos,fa
+```
+
+The `--icons` flag registers Iconify packs before rendering. Packs: `logos` (AWS/tech), `fa` (Font Awesome). Use `logos` for AWS.
+
+### 4.3 — Batch Rendering
+
+For multiple diagrams at once:
+
+```bash
+node $SKILL_DIR/scripts/batch.mjs \
+  --input-dir ./diagrams \
+  --output-dir ./rendered \
+  --format svg \
+  --theme default \
+  --workers 4
+```
+
+### 4.4 — Available Themes
+
+**beautiful-mermaid (15):** `tokyo-night` | `tokyo-night-storm` | `tokyo-night-light` | `dracula` | `nord` | `nord-light` | `catppuccin-mocha` | `catppuccin-latte` | `github-dark` | `github-light` | `solarized-dark` | `solarized-light` | `one-dark` | `zinc-dark` | `zinc-light`
+
+**mermaid-cli native (5):** `default` | `forest` | `dark` | `neutral` | `base`
+
+Custom theme: `--theme base --config '{"theme":"base","themeVariables":{"primaryColor":"#4f46e5","lineColor":"#94a3b8"}}'`
+
+For the full theme catalog, read `references/themes.md`. The render script auto-selects the best engine (mmdc primary, beautiful-mermaid fallback, Puppeteer for icon packs).
+
+## Step 5: Code-to-Diagram (When Requested)
+
+When the user asks to visualize existing code or architecture:
+
+1. Read `references/code-to-diagram.md` for the analysis methodology
+2. Analyze the codebase to identify the right diagram type:
+   - Module dependencies → Flowchart or Class diagram
+   - API routes and handlers → Sequence diagram
+   - Database models/schemas → ERD
+   - Service architecture → C4 Container or Architecture diagram
+   - State machines in code → State diagram
+3. Generate the .mmd file **with proper init directives** (Golden Rule 1)
+4. Validate and render as usual
+
+## Troubleshooting Quick Reference
+
+| Symptom               | Likely Cause       | Fix                                                    |
+| --------------------- | ------------------ | ------------------------------------------------------ |
+| Diagram won't render  | Syntax error       | Run validate.mjs, check brackets/quotes                |
+| Labels cut off        | Text too long      | Shorten labels or use line breaks `<br/>`              |
+| Layout looks wrong    | Wrong direction    | Try different TD/LR/BT/RL                              |
+| Nodes overlap         | Too many nodes     | Split into subgraphs or multiple diagrams              |
+| Lines too dark/thick  | No init directive  | Add `%%{init}` with `lineColor: '#94a3b8'`             |
+| C4 lines overlapping  | No styling applied | Add `UpdateRelStyle` with offsets to each Rel          |
+| AWS icons not showing | No icon pack       | Use `--icons logos` flag or fallback to built-in icons |
+| `mmdc` not found      | Not installed      | Run `setup.sh`                                         |
+| Theme not applied     | Wrong engine       | beautiful-mermaid themes only work with that engine    |
+
+For comprehensive troubleshooting, read `references/troubleshooting.md`.
+
+## Output Conventions
+
+- Save .mmd source files alongside rendered outputs
+- Naming: `{purpose}-{type}.mmd` (e.g., `auth-flow-sequence.mmd`)
+- For batch: maintain input filename, change extension
+- Always provide both the .mmd source and rendered file to the user

--- a/.windsurf/skills/mermaid-studio/assets/puppeteer-config.json
+++ b/.windsurf/skills/mermaid-studio/assets/puppeteer-config.json
@@ -1,0 +1,10 @@
+{
+  "executablePath": "",
+  "args": [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu"
+  ],
+  "headless": true
+}

--- a/.windsurf/skills/mermaid-studio/references/aws-architecture.md
+++ b/.windsurf/skills/mermaid-studio/references/aws-architecture.md
@@ -1,0 +1,395 @@
+# AWS Architecture Diagrams — Complete Reference
+
+Load this file when the user requests cloud architecture diagrams, AWS infrastructure visualization, or `architecture-beta` diagrams.
+
+## Overview
+
+Mermaid's `architecture-beta` diagram type enables cloud architecture visualization with icons representing services. Combined with Iconify icon packs, it produces professional infrastructure diagrams with real AWS service icons.
+
+**CRITICAL LIMITATION — The "Arrow Distance" Bug:**
+Because `architecture-beta` is built on a rigid grid system without edge routing algorithms, diagrams with more than 6-8 nodes or complex crossing relationships will suffer from **massive, unreadable distances** between nodes and arrows crossing over boxes.
+
+**The Golden Rule for AWS Diagrams:**
+
+- **Simple (< 8 nodes, linear flow):** Use `architecture-beta` with `--icons logos`.
+- **Complex (> 8 nodes, microservices, multiple tiers):** You MUST use **Option A: C4 Container Diagram**. C4 uses the `dagre` layout engine which perfectly spaces nodes and routes arrows beautifully.
+
+**Important — Icon Rendering:**
+
+- `architecture-beta` requires Mermaid v11+
+- Icons from Iconify packs (`logos:aws-*`) require icon pack registration at render time — they do NOT work in static markdown renderers (GitHub, GitLab)
+- When rendering with the render script, use `--icons logos` to auto-register icon packs
+- For environments without icon pack support, the built-in icons (`cloud`, `database`, `disk`, `server`, `internet`) work everywhere as a fallback
+- For universal compatibility, consider using C4 diagrams with descriptive labels as an alternative
+
+## Basic Syntax
+
+```mermaid
+architecture-beta
+
+    group groupId(icon)[Label]
+
+    service serviceId(icon)[Label] in groupId
+
+    serviceA:R --> L:serviceB
+```
+
+### Building Blocks
+
+| Element          | Syntax                               | Purpose                                |
+| ---------------- | ------------------------------------ | -------------------------------------- |
+| Group            | `group id(icon)[Label]`              | Visual boundary (VPC, region, account) |
+| Service          | `service id(icon)[Label]`            | Individual service node                |
+| Service in group | `service id(icon)[Label] in groupId` | Service inside a group                 |
+| Edge             | `serviceA:Side --> Side:serviceB`    | Connection with direction              |
+
+### Edge Sides
+
+Edges connect from/to specific sides of services:
+
+- `L` — Left
+- `R` — Right
+- `T` — Top
+- `B` — Bottom
+
+```
+api:R --> L:lambda        %% api's right connects to lambda's left
+lambda:B --> T:db          %% lambda's bottom connects to db's top
+```
+
+### Edge Types
+
+```
+serviceA:R --> L:serviceB     %% Solid arrow (default)
+serviceA:R -- L:serviceB      %% Solid line (no arrow)
+```
+
+## Icon Options
+
+### Option 1: Iconify Icons (Best Visual Quality)
+
+Mermaid supports 200,000+ icons from iconify.design via `registerIconPacks()`. The `logos` pack provides the best AWS icons. To render with these icons, use `--icons logos` with the render script.
+
+**Format:** `logos:aws-{service-name}`
+
+### Option 2: Built-in Icons (Universal Compatibility)
+
+Available everywhere without any registration. Use these when targeting markdown renderers or when icon packs aren't available:
+`cloud`, `database`, `disk`, `internet`, `server`
+
+## AWS Service Icons Catalog (Iconify `logos` Pack)
+
+### Compute
+
+| Service    | Icon name (logos)             | Built-in fallback |
+| ---------- | ----------------------------- | ----------------- |
+| Lambda     | `logos:aws-lambda`            | `server`          |
+| EC2        | `logos:aws-ec2`               | `server`          |
+| ECS        | `logos:aws-ecs`               | `server`          |
+| Fargate    | `logos:aws-fargate`           | `server`          |
+| Elastic BK | `logos:aws-elastic-beanstalk` | `server`          |
+
+### Storage
+
+| Service | Icon name (logos)   | Built-in fallback |
+| ------- | ------------------- | ----------------- |
+| S3      | `logos:aws-s3`      | `disk`            |
+| EBS     | `logos:aws-ebs`     | `disk`            |
+| EFS     | `logos:aws-efs`     | `disk`            |
+| Glacier | `logos:aws-glacier` | `disk`            |
+
+### Database
+
+| Service     | Icon name (logos)       | Built-in fallback |
+| ----------- | ----------------------- | ----------------- |
+| RDS         | `logos:aws-rds`         | `database`        |
+| DynamoDB    | `logos:aws-dynamodb`    | `database`        |
+| ElastiCache | `logos:aws-elasticache` | `database`        |
+| Aurora      | `logos:aws-aurora`      | `database`        |
+| Redshift    | `logos:aws-redshift`    | `database`        |
+| DocumentDB  | `logos:aws-documentdb`  | `database`        |
+
+### Networking
+
+| Service     | Icon name (logos)                  | Built-in fallback |
+| ----------- | ---------------------------------- | ----------------- |
+| API Gateway | `logos:aws-api-gateway`            | `server`          |
+| CloudFront  | `logos:aws-cloudfront`             | `internet`        |
+| Route 53    | `logos:aws-route53`                | `internet`        |
+| ELB/ALB     | `logos:aws-elastic-load-balancing` | `server`          |
+| VPC         | `logos:aws-vpc`                    | `cloud`           |
+
+### Messaging
+
+| Service     | Icon name (logos)       | Built-in fallback |
+| ----------- | ----------------------- | ----------------- |
+| SQS         | `logos:aws-sqs`         | `server`          |
+| SNS         | `logos:aws-sns`         | `server`          |
+| EventBridge | `logos:aws-eventbridge` | `server`          |
+| Kinesis     | `logos:aws-kinesis`     | `server`          |
+
+### Integration & Orchestration
+
+| Service        | Icon name (logos)          | Built-in fallback |
+| -------------- | -------------------------- | ----------------- |
+| Step Functions | `logos:aws-step-functions` | `server`          |
+| AppSync        | `logos:aws-app-sync`       | `server`          |
+
+### Monitoring & Security
+
+| Service    | Icon name (logos)      | Built-in fallback |
+| ---------- | ---------------------- | ----------------- |
+| CloudWatch | `logos:aws-cloudwatch` | `server`          |
+| IAM        | `logos:aws-iam`        | `server`          |
+| Cognito    | `logos:aws-cognito`    | `server`          |
+| WAF        | `logos:aws-waf`        | `server`          |
+
+### DevOps & CI/CD
+
+| Service      | Icon name (logos)        | Built-in fallback |
+| ------------ | ------------------------ | ----------------- |
+| CodePipeline | `logos:aws-codepipeline` | `server`          |
+| CodeBuild    | `logos:aws-codebuild`    | `server`          |
+| CodeDeploy   | `logos:aws-codedeploy`   | `server`          |
+| ECR          | `logos:aws-ecr`          | `server`          |
+
+### ML/AI
+
+| Service   | Icon name (logos)     | Built-in fallback |
+| --------- | --------------------- | ----------------- |
+| SageMaker | `logos:aws-sagemaker` | `server`          |
+
+**Note:** Not all AWS services have icons in the `logos` pack. If a specific icon is not available, use the closest category-appropriate built-in icon as fallback. You can verify icon availability at https://icon-sets.iconify.design/?q=aws.
+
+## Architecture Patterns
+
+### Pattern 1: Three-Tier Web Application
+
+**With Iconify Icons (best quality — requires `--icons logos`):**
+
+```mermaid
+architecture-beta
+    group vpc(logos:aws-vpc)[VPC]
+    group publicSubnet(cloud)[Public Subnet] in vpc
+    group privateSubnet(cloud)[Private Subnet] in vpc
+    group dataSubnet(database)[Data Subnet] in vpc
+
+    service cdn(logos:aws-cloudfront)[CloudFront]
+    service alb(logos:aws-elastic-load-balancing)[ALB] in publicSubnet
+    service ecs(logos:aws-ecs)[ECS Fargate] in privateSubnet
+    service rds(logos:aws-aurora)[Aurora PostgreSQL] in dataSubnet
+    service cache(logos:aws-elasticache)[ElastiCache Redis] in dataSubnet
+
+    cdn:R --> L:alb
+    alb:R --> L:ecs
+    ecs:R --> L:rds
+    ecs:B --> T:cache
+```
+
+**With Built-in Icons (universal compatibility):**
+
+```mermaid
+architecture-beta
+    group vpc(cloud)[VPC]
+    group publicSubnet(cloud)[Public Subnet] in vpc
+    group privateSubnet(cloud)[Private Subnet] in vpc
+    group dataSubnet(database)[Data Subnet] in vpc
+
+    service cdn(internet)[CloudFront]
+    service alb(server)[ALB] in publicSubnet
+    service ecs(server)[ECS Fargate] in privateSubnet
+    service rds(database)[Aurora PostgreSQL] in dataSubnet
+    service cache(database)[ElastiCache Redis] in dataSubnet
+
+    cdn:R --> L:alb
+    alb:R --> L:ecs
+    ecs:R --> L:rds
+    ecs:B --> T:cache
+```
+
+### Pattern 2: Serverless API
+
+```mermaid
+architecture-beta
+    group api(cloud)[API Layer]
+    group storage(cloud)[Storage]
+
+    service gw(logos:aws-api-gateway)[API Gateway] in api
+    service auth(logos:aws-cognito)[Cognito] in api
+    service fn(logos:aws-lambda)[Lambda] in api
+    service dynamo(logos:aws-dynamodb)[DynamoDB] in storage
+    service s3(logos:aws-s3)[S3] in storage
+
+    gw:R --> L:fn
+    gw:B --> T:auth
+    fn:R --> L:dynamo
+    fn:B --> T:s3
+```
+
+### Pattern 3: Data Pipeline
+
+```mermaid
+architecture-beta
+    group sources(cloud)[Data Sources]
+    group pipeline(cloud)[Pipeline]
+    group analytics(cloud)[Analytics]
+
+    service s3raw(logos:aws-s3)[S3 Raw Data] in sources
+    service kinesis(logos:aws-kinesis)[Kinesis Stream] in sources
+    service glue(logos:aws-glue)[Glue ETL] in pipeline
+    service stepFn(logos:aws-step-functions)[Step Functions] in pipeline
+    service s3processed(logos:aws-s3)[S3 Processed] in pipeline
+    service athena(logos:aws-athena)[Athena] in analytics
+    service quicksight(logos:aws-quicksight)[QuickSight] in analytics
+
+    s3raw:R --> L:glue
+    kinesis:R --> L:glue
+    glue:R --> L:stepFn
+    stepFn:R --> L:s3processed
+    s3processed:R --> L:athena
+    athena:R --> L:quicksight
+```
+
+### Pattern 4: CI/CD Pipeline
+
+```mermaid
+architecture-beta
+    group source(cloud)[Source]
+    group build(cloud)[Build & Test]
+    group deploy(cloud)[Deploy]
+    group runtime(cloud)[Runtime]
+
+    service repo(logos:aws-codecommit)[CodeCommit] in source
+    service pipeline(logos:aws-codepipeline)[CodePipeline] in build
+    service codebuild(logos:aws-codebuild)[CodeBuild] in build
+    service ecr(logos:aws-ecr)[ECR] in build
+    service codedeploy(logos:aws-codedeploy)[CodeDeploy] in deploy
+    service ecs(logos:aws-ecs)[ECS Fargate] in runtime
+    service cw(logos:aws-cloudwatch)[CloudWatch] in runtime
+
+    repo:R --> L:pipeline
+    pipeline:R --> L:codebuild
+    codebuild:R --> L:ecr
+    ecr:R --> L:codedeploy
+    codedeploy:R --> L:ecs
+    ecs:B --> T:cw
+```
+
+## Rendering with Icon Packs
+
+### Using the Render Script
+
+To render architecture-beta diagrams with proper AWS icons:
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --format svg \
+  --icons logos
+```
+
+The `--icons logos` flag tells the render script to register the Iconify `logos` pack which includes all `logos:aws-*` icons. The render script uses a Puppeteer-based pipeline for icon-enabled rendering.
+
+### Multiple Icon Packs
+
+You can register multiple packs:
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --icons logos,fa
+```
+
+Available packs: `logos` (AWS + tech logos), `fa` (Font Awesome icons).
+
+### How Icon Registration Works
+
+The render script generates an HTML page with Mermaid loaded, registers icon packs via `mermaid.registerIconPacks()`, renders the diagram, and captures the SVG output. This is equivalent to:
+
+```javascript
+import mermaid from 'mermaid'
+
+mermaid.registerIconPacks([
+  {
+    name: 'logos',
+    loader: () => fetch('https://unpkg.com/@iconify-json/logos/icons.json').then((res) => res.json()),
+  },
+])
+```
+
+## Fallback Strategy
+
+When `architecture-beta` is not supported by the rendering environment OR icons don't render, use these alternatives:
+
+### Option A: C4 Container Diagram (Best Alternative)
+
+C4 diagrams work everywhere and convey the same information:
+
+```mermaid
+C4Container
+    title AWS Architecture — Serverless API
+
+    Container(gw, "API Gateway", "AWS", "REST API endpoint")
+    Container(auth, "Cognito", "AWS", "Authentication")
+    Container(fn, "Lambda", "Node.js", "Business logic")
+    ContainerDb(db, "DynamoDB", "AWS", "NoSQL storage")
+    ContainerDb(s3, "S3", "AWS", "Object storage")
+
+    Rel(gw, auth, "Authenticates", "JWT")
+    Rel(gw, fn, "Invokes", "Event")
+    Rel(fn, db, "Reads/writes", "SDK")
+    Rel(fn, s3, "Stores files", "SDK")
+
+    UpdateRelStyle(gw, auth, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(gw, fn, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(fn, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(fn, s3, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Option B: Flowchart with AWS Labels and Professional Styling
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#FF9900', 'primaryTextColor': '#232F3E',
+  'primaryBorderColor': '#c47600', 'lineColor': '#94a3b8',
+  'secondaryColor': '#527FFF', 'tertiaryColor': '#DD344C',
+  'background': '#ffffff', 'mainBkg': '#FFF8F0',
+  'nodeBorder': '#c47600', 'clusterBkg': '#FFF8F0',
+  'clusterBorder': '#d4a574', 'edgeLabelBackground': '#ffffff'
+}}}%%
+flowchart LR
+    subgraph AWS["AWS Cloud"]
+        subgraph VPC
+            ALB[ALB<br/>Load Balancer]
+            subgraph ECS["ECS Cluster"]
+                Svc1[Service A]
+                Svc2[Service B]
+            end
+            RDS[(Aurora<br/>PostgreSQL)]
+        end
+        S3[(S3 Bucket)]
+        CF[CloudFront]
+    end
+
+    Users([Users]) --> CF
+    CF --> ALB
+    ALB --> Svc1 & Svc2
+    Svc1 & Svc2 --> RDS
+    Svc1 --> S3
+```
+
+## Best Practices
+
+1. **Group by boundary** — VPC, subnet, region, account
+2. **Left-to-right flow** — request path should read naturally
+3. **Limit to 12 services max** — split complex architectures into multiple focused diagrams
+4. **Show only one concern per diagram** — networking, compute, data, separately
+5. **Include external systems** — show what connects from outside
+6. **Security boundaries** — show public vs private subnets
+7. **Use Iconify icons when rendering** — `logos:aws-*` for best visual quality
+8. **Use built-in icons for docs** — `cloud`, `database`, `disk`, `server`, `internet` for markdown compatibility
+9. **Always provide both versions** — one with Iconify icons for rendered output, one with built-in for inline markdown

--- a/.windsurf/skills/mermaid-studio/references/c4-architecture.md
+++ b/.windsurf/skills/mermaid-studio/references/c4-architecture.md
@@ -1,0 +1,473 @@
+# C4 Architecture Diagrams — Complete Reference
+
+Load this file when the user requests C4 diagrams or system architecture documentation. The C4 model provides four levels of abstraction.
+
+## CRITICAL: Mandatory Rules
+
+**Every C4 diagram MUST follow these rules.** Without them, Mermaid renders harsh black lines that overlap elements and make the diagram unreadable.
+
+1. **Max 6 `Rel()` per diagram.** More relationships cause Dagre to route arrows through nodes, creating unreadable spaghetti. Split complex systems into multiple focused diagrams.
+2. **Always style all relationships.** Apply `UpdateRelStyle` to every `Rel()` with soft line colors (see template below).
+3. **Max 6-8 elements per diagram.** Tree-shaped topology (1 in, 1-2 out per node) renders best. Avoid mesh connections.
+4. **Do NOT set `fontFamily`.** Mermaid's default font works everywhere. Setting `system-ui` or `Segoe UI` will render as Times New Roman in headless Chromium.
+
+### Template: Add This to Every C4 Diagram
+
+```
+    %% === MANDATORY: Apply to ALL Rel() references ===
+    UpdateRelStyle(fromAlias, toAlias, $textColor="#475569", $lineColor="#94a3b8")
+    %% Repeat for each relationship in the diagram
+
+    %% === MANDATORY: Layout optimization ===
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### When Labels Overlap Elements
+
+Add `$offsetX` and `$offsetY` to push labels away from elements:
+
+```
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetX="-40", $offsetY="20")
+```
+
+### Highlighting Important Relationships
+
+Use accent colors for critical paths while keeping other lines soft:
+
+```
+    %% Primary relationship — emphasized
+    UpdateRelStyle(client, api, $textColor="#1e40af", $lineColor="#3b82f6")
+
+    %% Secondary relationships — soft
+    UpdateRelStyle(api, db, $textColor="#475569", $lineColor="#94a3b8")
+
+    %% External/risky connection — warning
+    UpdateRelStyle(api, extPayment, $textColor="#92400e", $lineColor="#f59e0b")
+```
+
+## C4 Levels — When to Use Each
+
+| Level | Diagram      | Audience       | Purpose                               |
+| ----- | ------------ | -------------- | ------------------------------------- |
+| 1     | C4Context    | Everyone       | System boundaries and external actors |
+| 2     | C4Container  | Technical team | Applications, databases, services     |
+| 3     | C4Component  | Developers     | Internal module structure             |
+| 4     | C4Deployment | DevOps/SRE     | Infrastructure and deployment nodes   |
+| —     | C4Dynamic    | Technical team | Numbered request flows                |
+
+**Rule of thumb:** Context + Container diagrams are sufficient for most teams. Only create Component/Code diagrams when they genuinely add clarity.
+
+### Audience-Appropriate Recommendations
+
+- **Executives/PMs:** Context only
+- **Architects:** Context + Container
+- **Developers:** Context + Container + Components for their area
+- **DevOps/SRE:** Container + Deployment
+
+## Element Syntax
+
+### People and Systems
+
+```
+Person(alias, "Label", "Description")
+Person_Ext(alias, "Label", "Description")
+System(alias, "Label", "Description")
+System_Ext(alias, "Label", "Description")
+SystemDb(alias, "Label", "Description")
+SystemDb_Ext(alias, "Label", "Description")
+SystemQueue(alias, "Label", "Description")
+SystemQueue_Ext(alias, "Label", "Description")
+```
+
+### Containers
+
+```
+Container(alias, "Label", "Technology", "Description")
+Container_Ext(alias, "Label", "Technology", "Description")
+ContainerDb(alias, "Label", "Technology", "Description")
+ContainerDb_Ext(alias, "Label", "Technology", "Description")
+ContainerQueue(alias, "Label", "Technology", "Description")
+ContainerQueue_Ext(alias, "Label", "Technology", "Description")
+```
+
+### Components
+
+```
+Component(alias, "Label", "Technology", "Description")
+Component_Ext(alias, "Label", "Technology", "Description")
+ComponentDb(alias, "Label", "Technology", "Description")
+ComponentQueue(alias, "Label", "Technology", "Description")
+```
+
+### Boundaries
+
+```
+Enterprise_Boundary(alias, "Label") { ... }
+System_Boundary(alias, "Label") { ... }
+Container_Boundary(alias, "Label") { ... }
+Boundary(alias, "Label", "type") { ... }
+```
+
+### Relationships
+
+```
+Rel(from, to, "Label")
+Rel(from, to, "Label", "Technology")
+BiRel(from, to, "Label")
+Rel_U(from, to, "Label")       %% Upward
+Rel_D(from, to, "Label")       %% Downward
+Rel_L(from, to, "Label")       %% Leftward
+Rel_R(from, to, "Label")       %% Rightward
+Rel_Back(from, to, "Label")    %% Back relationship
+```
+
+**Layout control tip:** When auto-layout causes lines to overlap, use directional variants (`Rel_D`, `Rel_R`, etc.) to force arrows in a specific direction. This is the most effective way to avoid overlapping lines.
+
+### Deployment Nodes
+
+```
+Deployment_Node(alias, "Label", "Type") { ... }
+Deployment_Node(alias, "Label", "Type", "Description") { ... }
+Node(alias, "Label") { ... }
+Node_L(alias, "Label") { ... }
+Node_R(alias, "Label") { ... }
+```
+
+## Complete Examples (All With Mandatory Styling)
+
+### Level 1 — System Context
+
+```mermaid
+C4Context
+    title System Context — Order Management Platform
+
+    Person(customer, "Customer", "Places and tracks orders")
+    Person(admin, "Admin", "Manages products and fulfillment")
+
+    Enterprise_Boundary(company, "Company") {
+        System(orderPlatform, "Order Platform", "Manages the full order lifecycle")
+    }
+
+    System_Ext(paymentGW, "Payment Gateway", "Stripe — processes payments")
+    System_Ext(shipping, "Shipping Provider", "Handles delivery logistics")
+    System_Ext(emailSvc, "Email Service", "SendGrid — transactional emails")
+    System_Ext(analytics, "Analytics", "Mixpanel — usage tracking")
+
+    Rel(customer, orderPlatform, "Places orders, tracks status", "HTTPS")
+    Rel(admin, orderPlatform, "Manages catalog, fulfills orders", "HTTPS")
+    Rel(orderPlatform, paymentGW, "Processes payments", "REST API")
+    Rel(orderPlatform, shipping, "Creates shipments", "REST API")
+    Rel(orderPlatform, emailSvc, "Sends notifications", "SMTP/API")
+    Rel(orderPlatform, analytics, "Sends events", "HTTPS")
+
+    UpdateRelStyle(customer, orderPlatform, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(admin, orderPlatform, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(orderPlatform, paymentGW, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, shipping, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, emailSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderPlatform, analytics, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Level 2 — Container
+
+**Keep container diagrams focused: max 6-8 elements and 6 Rel().** For complex systems, split into multiple diagrams (one per bounded context or service area).
+
+```mermaid
+C4Container
+    title Container Diagram — Order Platform
+
+    Person(customer, "Customer", "Places orders online")
+
+    System_Boundary(platform, "Order Platform") {
+        Container(spa, "Web App", "React", "Customer-facing storefront")
+        Container(api, "API Gateway", "NestJS", "Routes requests")
+        Container(orderSvc, "Order Service", "NestJS", "Order lifecycle")
+        ContainerDb(db, "Database", "PostgreSQL", "Orders and products")
+    }
+
+    System_Ext(paymentGW, "Stripe", "Payment processing")
+
+    Rel(customer, spa, "Uses", "HTTPS")
+    Rel(spa, api, "Calls", "JSON/HTTPS")
+    Rel(api, orderSvc, "Routes to", "gRPC")
+    Rel(orderSvc, db, "Reads/writes", "SQL")
+    Rel(orderSvc, paymentGW, "Processes payment", "REST API")
+
+    UpdateRelStyle(customer, spa, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(spa, api, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Level 3 — Component (Order Service)
+
+```mermaid
+C4Component
+    title Component Diagram — Order Service
+
+    Container_Boundary(orderSvc, "Order Service") {
+        Component(orderCtrl, "Order Controller", "NestJS Controller", "HTTP/gRPC endpoints")
+        Component(orderUseCase, "Order Use Cases", "Application Layer", "Create, cancel, fulfill orders")
+        Component(paymentPort, "Payment Port", "Interface", "Payment processing abstraction")
+        Component(orderRepo, "Order Repository", "TypeORM", "Order persistence")
+        Component(eventPub, "Event Publisher", "AMQP Client", "Publishes domain events")
+        Component(orderModel, "Order Aggregate", "Domain Model", "Business rules and invariants")
+    }
+
+    ContainerDb(orderDb, "Order DB", "PostgreSQL")
+    ContainerQueue(eventBus, "Event Bus", "RabbitMQ")
+    Container_Ext(paymentGW, "Stripe", "Payment API")
+
+    Rel(orderCtrl, orderUseCase, "Invokes")
+    Rel(orderUseCase, orderModel, "Operates on")
+    Rel(orderUseCase, paymentPort, "Uses")
+    Rel(orderUseCase, orderRepo, "Persists via")
+    Rel(orderUseCase, eventPub, "Publishes events")
+    Rel(orderRepo, orderDb, "SQL queries")
+    Rel(eventPub, eventBus, "AMQP")
+    Rel(paymentPort, paymentGW, "REST API")
+
+    UpdateRelStyle(orderCtrl, orderUseCase, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, orderModel, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, paymentPort, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, orderRepo, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderUseCase, eventPub, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderRepo, orderDb, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(eventPub, eventBus, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(paymentPort, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Dynamic — Request Flow
+
+```mermaid
+C4Dynamic
+    title Dynamic Diagram — Place Order Flow
+
+    Container(spa, "Web App", "React")
+    Container(api, "API Gateway", "NestJS")
+    Container(orderSvc, "Order Service", "NestJS")
+    Container(paymentGW, "Stripe", "Payment API")
+    ContainerDb(db, "Order DB", "PostgreSQL")
+    ContainerQueue(bus, "Event Bus", "RabbitMQ")
+
+    Rel(spa, api, "1. POST /orders", "JSON/HTTPS")
+    Rel(api, orderSvc, "2. CreateOrder()", "gRPC")
+    Rel(orderSvc, db, "3. INSERT order (pending)", "SQL")
+    Rel(orderSvc, paymentGW, "4. Process payment", "REST")
+    Rel(orderSvc, db, "5. UPDATE order (confirmed)", "SQL")
+    Rel(orderSvc, bus, "6. Publish OrderConfirmed", "AMQP")
+    Rel(orderSvc, api, "7. Return order", "gRPC")
+    Rel(api, spa, "8. 201 Created", "JSON/HTTPS")
+
+    UpdateRelStyle(spa, api, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8", $offsetX="-30")
+    UpdateRelStyle(orderSvc, paymentGW, $textColor="#92400e", $lineColor="#f59e0b")
+    UpdateRelStyle(orderSvc, bus, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, api, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+    UpdateRelStyle(api, spa, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### C4 Deployment
+
+```mermaid
+C4Deployment
+    title Deployment — Production Environment
+
+    Deployment_Node(cdn, "CloudFront", "CDN") {
+        Container(static, "Static Assets", "React Build", "JS/CSS/HTML")
+    }
+
+    Deployment_Node(aws, "AWS", "us-east-1") {
+        Deployment_Node(ecs, "ECS Cluster", "Fargate") {
+            Deployment_Node(apiTask, "API Task", "2 vCPU, 4GB") {
+                Container(api, "API Gateway", "NestJS")
+            }
+            Deployment_Node(orderTask, "Order Task", "2 vCPU, 4GB") {
+                Container(orderSvc, "Order Service", "NestJS")
+            }
+        }
+
+        Deployment_Node(rds, "RDS", "db.r6g.xlarge") {
+            ContainerDb(db, "Order DB", "PostgreSQL 16")
+        }
+
+        Deployment_Node(elasticache, "ElastiCache", "r6g.large") {
+            ContainerDb(cache, "Cache", "Redis 7")
+        }
+
+        Deployment_Node(mq, "Amazon MQ", "mq.m5.large") {
+            ContainerQueue(bus, "Event Bus", "RabbitMQ")
+        }
+    }
+
+    Rel(cdn, api, "Routes API calls", "HTTPS")
+    Rel(api, orderSvc, "Internal", "gRPC")
+    Rel(orderSvc, db, "Reads/writes", "SQL/TLS")
+    Rel(api, cache, "Caches", "Redis/TLS")
+    Rel(orderSvc, bus, "Publishes", "AMQP/TLS")
+
+    UpdateRelStyle(cdn, api, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(api, orderSvc, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, db, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(api, cache, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, bus, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Styling and Layout
+
+### Layout Configuration
+
+```
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Element Styling
+
+```
+UpdateElementStyle(alias, $fontColor="red", $bgColor="grey", $borderColor="red")
+```
+
+### Relationship Styling
+
+Use `$offsetX` and `$offsetY` to fix overlapping labels:
+
+```
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+```
+
+### Professional Color Palette for Custom Element Styles
+
+| Purpose              | bgColor   | fontColor | borderColor | When to use                     |
+| -------------------- | --------- | --------- | ----------- | ------------------------------- |
+| Primary emphasis     | `#4f46e5` | `#ffffff` | `#3730a3`   | Core systems, main service      |
+| Success / Data store | `#059669` | `#ffffff` | `#047857`   | Databases, completed states     |
+| Warning / External   | `#d97706` | `#ffffff` | `#b45309`   | External systems, risky paths   |
+| Error / Critical     | `#dc2626` | `#ffffff` | `#b91c1c`   | Error states ONLY               |
+| Neutral / Secondary  | `#64748b` | `#ffffff` | `#475569`   | Supporting services, background |
+| Info / Highlight     | `#0284c7` | `#ffffff` | `#0369a1`   | Informational annotations       |
+
+## Microservices Patterns
+
+### Single-Team Ownership
+
+When one team owns all services, model each as a **container**:
+
+```mermaid
+C4Container
+    title Microservices — Single Team
+
+    System_Boundary(platform, "E-commerce Platform") {
+        Container(orderSvc, "Order Service", "NestJS", "Order processing")
+        ContainerDb(orderDb, "Order DB", "PostgreSQL")
+        Container(inventorySvc, "Inventory Service", "NestJS", "Stock management")
+        ContainerDb(inventoryDb, "Inventory DB", "MongoDB")
+    }
+
+    Rel(orderSvc, orderDb, "Reads/writes", "SQL")
+    Rel(inventorySvc, inventoryDb, "Reads/writes", "MongoDB Wire")
+
+    UpdateRelStyle(orderSvc, orderDb, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(inventorySvc, inventoryDb, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+### Multi-Team Ownership
+
+When separate teams own services, promote them to **systems**:
+
+```mermaid
+C4Context
+    title Microservices — Multi-Team
+
+    Person(customer, "Customer")
+    System(orderSys, "Order System", "Team Alpha")
+    System(inventorySys, "Inventory System", "Team Beta")
+    System(paymentSys, "Payment System", "Team Gamma")
+
+    Rel(customer, orderSys, "Places orders")
+    Rel(orderSys, inventorySys, "Checks stock")
+    Rel(orderSys, paymentSys, "Processes payment")
+
+    UpdateRelStyle(customer, orderSys, $textColor="#1e40af", $lineColor="#3b82f6")
+    UpdateRelStyle(orderSys, inventorySys, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSys, paymentSys, $textColor="#92400e", $lineColor="#f59e0b")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Event-Driven Architecture
+
+Show individual topics/queues as containers — NOT a single "Kafka" box:
+
+```mermaid
+C4Container
+    title Event-Driven Architecture
+
+    Container(orderSvc, "Order Service", "Java", "Creates orders")
+    Container(stockSvc, "Stock Service", "Java", "Manages inventory")
+    ContainerQueue(orderTopic, "order.created", "Kafka", "Order events")
+    ContainerQueue(stockTopic, "stock.reserved", "Kafka", "Stock events")
+
+    Rel(orderSvc, orderTopic, "Publishes to")
+    Rel(stockSvc, orderTopic, "Subscribes to")
+    Rel(stockSvc, stockTopic, "Publishes to")
+    Rel(orderSvc, stockTopic, "Subscribes to")
+
+    UpdateRelStyle(orderSvc, orderTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(stockSvc, orderTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(stockSvc, stockTopic, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateRelStyle(orderSvc, stockTopic, $textColor="#475569", $lineColor="#94a3b8")
+
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+## Essential Rules
+
+1. **Every element must have:** Name, Type, Technology (where applicable), Description
+2. **Use unidirectional arrows** — bidirectional creates ambiguity
+3. **Label arrows with action verbs** — "Sends email using", not just "uses"
+4. **Include technology labels** — "JSON/HTTPS", "SQL", "gRPC"
+5. **Under 15 elements per diagram** — split if more (elegance > completeness)
+6. **Always include a title**
+7. **Meaningful aliases** — `orderService` not `s1`
+8. **ALWAYS add UpdateRelStyle** — soft line colors are mandatory
+9. **ALWAYS add UpdateLayoutConfig** — prevents element crowding
+
+## Common Mistakes
+
+| Mistake                  | Why it's wrong                  | Fix                                  |
+| ------------------------ | ------------------------------- | ------------------------------------ |
+| Shared lib as Container  | Containers are deployable units | Model as Component                   |
+| Single "Kafka" container | Hides topic structure           | Show individual topics               |
+| "Subcomponents" level    | Not a C4 concept                | Use Component or Class               |
+| Removing type labels     | Loses information               | Always show type/tech                |
+| Bidirectional arrows     | Ambiguous flow direction        | Use unidirectional                   |
+| No technology labels     | Can't assess architecture       | Add protocol/tech                    |
+| No UpdateRelStyle        | Harsh black lines               | Add soft colors to ALL relationships |
+| No UpdateLayoutConfig    | Elements crowd together         | Add layout config at end             |
+| No offset on overlap     | Labels hidden behind elements   | Add $offsetX/$offsetY to fix         |
+
+## File Naming Convention
+
+```
+docs/architecture/
+├── c4-context.md
+├── c4-containers.md
+├── c4-components-{feature}.md
+├── c4-deployment.md
+└── c4-dynamic-{flow}.md
+```

--- a/.windsurf/skills/mermaid-studio/references/code-to-diagram.md
+++ b/.windsurf/skills/mermaid-studio/references/code-to-diagram.md
@@ -1,0 +1,281 @@
+# Code-to-Diagram — Analysis Methodology
+
+Load this file when the user asks to visualize existing code, analyze a codebase, or generate diagrams from source files.
+
+## Workflow
+
+1. **Identify scope** — what part of the code to diagram
+2. **Choose analysis strategy** — which patterns to look for
+3. **Extract structure** — read relevant files
+4. **Select diagram type** — based on what was found
+5. **Generate diagram** — create .mmd file
+6. **Validate and render** — as usual
+
+## Analysis Strategies by Request Type
+
+### "Show me the architecture"
+
+**What to look for:**
+
+- Project root structure (folders, entry points)
+- Package.json / pyproject.toml / Cargo.toml for dependencies
+- Docker files, docker-compose.yml for services
+- Infrastructure-as-code (CDK, Terraform, CloudFormation, Pulumi)
+- Environment variables for external service connections
+
+**Recommended diagram:** C4 Container or Architecture (for cloud infra)
+
+**File exploration order:**
+
+1. Root directory listing
+2. docker-compose.yml / Dockerfile
+3. Infrastructure files (cdk/, terraform/, cloudformation/)
+4. Main entry point (src/main.ts, app.py, cmd/main.go)
+5. Config files for external connections
+
+### "Diagram the database schema"
+
+**What to look for:**
+
+- ORM models/entities (TypeORM, Prisma, SQLAlchemy, Drizzle)
+- Migration files
+- Schema definition files (.prisma, models.py, entities/)
+- Foreign key references
+- Enum definitions
+
+**Recommended diagram:** ERD
+
+**File exploration order:**
+
+1. Schema files (schema.prisma, models/, entities/)
+2. Migration files (for relationship confirmation)
+3. Seed files (for understanding data relationships)
+
+**Extraction rules:**
+
+- Each model/entity → ERD entity
+- Each field → attribute with type
+- `@relation` / ForeignKey → relationship
+- `@id` / primary_key → PK marker
+- `@unique` → UK marker
+- Foreign key fields → FK marker
+
+**Example — Prisma to ERD:**
+
+```prisma
+// Input: schema.prisma
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String
+  orders    Order[]
+  createdAt DateTime @default(now())
+}
+
+model Order {
+  id        String      @id @default(uuid())
+  userId    String
+  user      User        @relation(fields: [userId], references: [id])
+  items     OrderItem[]
+  total     Decimal
+  status    OrderStatus
+}
+```
+
+```mermaid
+%% Output: database-erd.mmd
+erDiagram
+    USER ||--o{ ORDER : "has orders"
+    ORDER ||--|{ ORDER_ITEM : "contains"
+
+    USER {
+        uuid id PK
+        string email UK
+        string name
+        datetime createdAt
+    }
+
+    ORDER {
+        uuid id PK
+        uuid userId FK
+        decimal total
+        enum status
+    }
+```
+
+### "Show me the API flow"
+
+**What to look for:**
+
+- Route definitions (controllers, routers, handlers)
+- Middleware chain
+- Service layer calls
+- External API calls
+- Database queries in the flow
+
+**Recommended diagram:** Sequence diagram
+
+**File exploration order:**
+
+1. Route/controller files
+2. Middleware definitions
+3. Service files called by controllers
+4. Repository/data-access files
+
+**Extraction rules:**
+
+- Each controller/handler → participant
+- Each service class → participant
+- Each external call → external participant
+- Method calls → synchronous messages (->>)
+- Returns → response messages (-->>)
+- If/else in code → alt blocks
+- Try/catch → opt or break blocks
+- Loops → loop blocks
+
+### "Show me the module dependencies"
+
+**What to look for:**
+
+- Import statements between modules
+- Module registration (NestJS modules, Angular modules)
+- Dependency injection configuration
+- Package/module boundaries
+
+**Recommended diagram:** Class diagram or Flowchart
+
+**Extraction rules:**
+
+- Each module/package → class or node
+- Import/dependency → arrow
+- Circular dependencies → highlight (bidirectional or color)
+
+### "Show me the state machine"
+
+**What to look for:**
+
+- Enum definitions for states/status
+- Switch/case or if/else chains on status
+- State machine libraries (XState, statechart)
+- Transition functions
+- Event handlers that change state
+
+**Recommended diagram:** State diagram
+
+**Extraction rules:**
+
+- Each enum value → state
+- Each transition function → edge with event label
+- Initial state → [*] --> state
+- Terminal states → state --> [*]
+- Guard conditions → edge labels
+
+### "Show me the class structure"
+
+**What to look for:**
+
+- Class definitions with methods and properties
+- Interfaces and abstract classes
+- Inheritance (extends)
+- Composition (has-a fields)
+- Implementation (implements)
+
+**Recommended diagram:** Class diagram
+
+**Extraction rules:**
+
+- `class X extends Y` → inheritance (`Y <|-- X`)
+- `class X implements Y` → realization (`Y ..|> X`)
+- Field of type `Y` in class `X` → association (`X --> Y`)
+- Array/collection of `Y` in `X` → aggregation (`X o-- Y`)
+- `Y` created and owned by `X` → composition (`X *-- Y`)
+- `public` → `+`, `private` → `-`, `protected` → `#`
+
+## Framework-Specific Patterns
+
+### NestJS
+
+```
+src/
+├── modules/
+│   ├── user/
+│   │   ├── user.module.ts       → Module boundary
+│   │   ├── user.controller.ts   → API endpoints (sequence participant)
+│   │   ├── user.service.ts      → Business logic (sequence participant)
+│   │   ├── user.repository.ts   → Data access (sequence participant)
+│   │   ├── user.entity.ts       → Database model (ERD entity)
+│   │   └── dto/                 → Request/Response shapes
+│   └── order/
+│       └── ...
+├── common/
+│   ├── guards/                  → Auth flow (sequence)
+│   ├── interceptors/            → Cross-cutting (flowchart)
+│   └── filters/                 → Error handling (flowchart)
+└── main.ts                      → Entry point
+```
+
+### React / Next.js
+
+```
+src/
+├── app/                         → Routes (flowchart for navigation)
+│   ├── layout.tsx               → Layout hierarchy
+│   ├── page.tsx                 → Page components
+│   └── api/                     → API routes (sequence)
+├── components/                  → Component tree (class/flowchart)
+├── hooks/                       → Custom hooks (class diagram)
+├── lib/                         → Utilities
+├── services/                    → API clients (sequence participants)
+└── store/                       → State management (state diagram)
+```
+
+### Python / FastAPI
+
+```
+app/
+├── main.py                      → Entry point, middleware chain
+├── routers/                     → Route definitions (sequence)
+├── services/                    → Business logic (sequence)
+├── models/                      → SQLAlchemy models (ERD)
+├── schemas/                     → Pydantic schemas
+├── dependencies/                → DI (class diagram)
+└── core/
+    ├── config.py                → External connections
+    └── security.py              → Auth flow (sequence/state)
+```
+
+## Multi-Diagram Strategy
+
+For complex codebases, recommend generating multiple focused diagrams rather than one overwhelming diagram:
+
+1. **System Context (C4 Level 1)** — always, as the overview
+2. **Container Diagram (C4 Level 2)** — for multi-service architectures
+3. **ERD** — if database models exist
+4. **Key Flow Sequence** — for the most important user-facing flow
+5. **State Diagram** — if significant state machines exist
+
+Present these as a set, with the Context diagram first for orientation.
+
+## Output Format
+
+When generating from code, always:
+
+1. Add a header comment linking to source:
+
+   ```
+   %% Generated from: src/modules/order/
+   %% Diagram: Order Service — Component Structure
+   ```
+
+2. Use names that match the code (class names, method names)
+
+3. Include a brief note about what was excluded:
+
+   ```
+   %% Note: Utility classes and DTOs omitted for clarity
+   ```
+
+4. Flag uncertainty:
+   ```
+   %% TODO: Verify relationship between PaymentService and RefundService
+   ```

--- a/.windsurf/skills/mermaid-studio/references/diagram-types.md
+++ b/.windsurf/skills/mermaid-studio/references/diagram-types.md
@@ -1,0 +1,758 @@
+# Diagram Types — Complete Syntax Reference
+
+Load this file when you need detailed syntax for a specific diagram type beyond what the quick examples in SKILL.md provide.
+
+## Table of Contents
+
+1. Flowchart (line ~20)
+2. Sequence Diagram (line ~120)
+3. Class Diagram (line ~220)
+4. State Diagram (line ~310)
+5. ERD (line ~380)
+6. Gantt Chart (line ~440)
+7. Pie Chart (line ~490)
+8. Mindmap (line ~520)
+9. Timeline (line ~560)
+10. Git Graph (line ~600)
+11. Sankey (line ~650)
+12. XY Chart (line ~690)
+13. Quadrant Chart (line ~730)
+14. Block Diagram (line ~770)
+15. User Journey (line ~820)
+16. Requirement Diagram (line ~860)
+17. Packet Diagram (line ~900)
+18. Kanban (line ~930)
+
+---
+
+## 1. Flowchart
+
+**Keyword:** `flowchart` or `graph`
+**Directions:** `TD` (top-down), `LR` (left-right), `BT`, `RL`
+
+### Node Shapes
+
+```
+A[Rectangle]           %% Standard process
+B(Rounded)             %% Alternate process
+C([Stadium])           %% Terminal/start-end
+D{Diamond}             %% Decision
+E{{Hexagon}}           %% Preparation
+F[/Parallelogram/]     %% Input/Output
+G[\Reverse parallel\]  %% Manual operation
+H[(Database)]          %% Data store
+I((Circle))            %% Connector
+J>Asymmetric]          %% Flag/signal
+K[[Subroutine]]        %% Predefined process
+L(((Double Circle)))   %% Multiple documents
+M[/Trapezoid\]         %% Manual input
+N[\Inverse trapezoid/] %% Display
+```
+
+### Edge Types
+
+```
+A --> B                %% Arrow
+A --- B                %% Line (no arrow)
+A -.- B                %% Dotted line
+A -.-> B               %% Dotted arrow
+A ==> B                %% Thick arrow
+A ~~~ B                %% Invisible link (spacing)
+A --text--> B          %% Arrow with text
+A -->|text| B          %% Arrow with text (alternate)
+A <--> B               %% Bidirectional
+A o--o B               %% Circle endpoints
+A x--x B               %% Cross endpoints
+```
+
+### Subgraphs
+
+```mermaid
+flowchart TD
+    subgraph Backend["Backend Services"]
+        direction LR
+        API[API Server]
+        Worker[Background Worker]
+    end
+
+    subgraph Storage["Data Layer"]
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    API --> DB
+    API --> Cache
+    Worker --> DB
+```
+
+### Styling
+
+```mermaid
+flowchart LR
+    A[Success]:::success --> B[Warning]:::warning --> C[Error]:::error
+
+    classDef success fill:#10b981,stroke:#059669,color:#fff
+    classDef warning fill:#f59e0b,stroke:#d97706,color:#000
+    classDef error fill:#ef4444,stroke:#dc2626,color:#fff
+```
+
+### Click Events
+
+```
+click A "https://example.com" "Tooltip text" _blank
+click B callback "Tooltip"
+```
+
+---
+
+## 2. Sequence Diagram
+
+**Keyword:** `sequenceDiagram`
+
+### Participant Types
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Frontend App
+    participant API as REST API
+    participant DB as Database
+```
+
+### Message Types
+
+```
+A->>B: Solid arrow (synchronous request)
+A-->>B: Dotted arrow (asynchronous response)
+A-)B: Open arrow (async message, fire-and-forget)
+A--)B: Dotted open arrow (async response)
+A-xB: Cross arrow (lost message)
+A--xB: Dotted cross arrow
+```
+
+### Activation Boxes
+
+```
+A->>+B: Request    %% Activate B
+B-->>-A: Response  %% Deactivate B
+```
+
+### Control Flow
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    participant C
+
+    alt Condition is true
+        A->>B: Path 1
+    else Condition is false
+        A->>C: Path 2
+    end
+
+    opt Optional step
+        B->>C: Optional call
+    end
+
+    loop Every 5 seconds
+        A->>B: Health check
+    end
+
+    par Parallel execution
+        A->>B: Task 1
+    and
+        A->>C: Task 2
+    end
+
+    critical Critical section
+        A->>B: Important operation
+    option Failure case
+        A->>C: Fallback
+    end
+
+    break When error occurs
+        A->>B: Error notification
+    end
+```
+
+### Notes
+
+```
+Note right of A: Single participant note
+Note over A,B: Note spanning participants
+Note left of B: Left-side note
+```
+
+### Numbering
+
+```
+autonumber    %% Add at the top to auto-number messages
+```
+
+### Boxes (Grouping)
+
+```mermaid
+sequenceDiagram
+    box Purple Internal Services
+        participant API
+        participant Worker
+    end
+    box Grey External
+        participant Payment
+    end
+
+    API->>Worker: Process
+    Worker->>Payment: Charge
+```
+
+---
+
+## 3. Class Diagram
+
+**Keyword:** `classDiagram`
+
+### Class Definition
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        #String species
+        -String dna
+        +makeSound()* void
+        +move(distance int) void
+        #reproduce() Animal
+        -mutate() void
+    }
+```
+
+**Visibility modifiers:** `+` public, `-` private, `#` protected, `~` package
+
+### Relationships
+
+```
+A <|-- B       %% Inheritance (B extends A)
+A *-- B        %% Composition (A owns B, lifecycle bound)
+A o-- B        %% Aggregation (A has B, independent lifecycle)
+A --> B        %% Association (A uses B)
+A ..> B        %% Dependency (A depends on B)
+A ..|> B       %% Realization (B implements A)
+A -- B         %% Link (solid)
+A .. B         %% Link (dashed)
+```
+
+### Multiplicity
+
+```
+A "1" --> "*" B : has
+A "1" --> "0..1" B : may have
+A "0..*" --> "1..*" B : relates
+```
+
+### Annotations
+
+```mermaid
+classDiagram
+    class Shape {
+        <<interface>>
+        +area() double
+        +perimeter() double
+    }
+
+    class Color {
+        <<enumeration>>
+        RED
+        GREEN
+        BLUE
+    }
+
+    class Singleton {
+        <<abstract>>
+    }
+
+    class UserService {
+        <<service>>
+    }
+```
+
+### Namespace
+
+```mermaid
+classDiagram
+    namespace Domain {
+        class User
+        class Order
+    }
+    namespace Infrastructure {
+        class UserRepository
+        class OrderRepository
+    }
+```
+
+---
+
+## 4. State Diagram
+
+**Keyword:** `stateDiagram-v2`
+
+### Basic Syntax
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : Start
+    Processing --> Done : Complete
+    Processing --> Error : Failure
+    Error --> Idle : Reset
+    Done --> [*]
+```
+
+### Composite States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active
+
+    state Active {
+        [*] --> Running
+        Running --> Paused : Pause
+        Paused --> Running : Resume
+    }
+
+    Active --> Terminated : Kill
+    Terminated --> [*]
+```
+
+### Forks and Joins
+
+```mermaid
+stateDiagram-v2
+    state fork_state <<fork>>
+    state join_state <<join>>
+
+    [*] --> fork_state
+    fork_state --> TaskA
+    fork_state --> TaskB
+    TaskA --> join_state
+    TaskB --> join_state
+    join_state --> Done
+    Done --> [*]
+```
+
+### Choice
+
+```mermaid
+stateDiagram-v2
+    state check <<choice>>
+
+    [*] --> check
+    check --> Approved : if valid
+    check --> Rejected : if invalid
+```
+
+### Notes
+
+```
+note right of StateName
+    Multi-line note
+    explaining the state
+end note
+```
+
+---
+
+## 5. Entity Relationship Diagram
+
+**Keyword:** `erDiagram`
+
+### Relationship Types
+
+```
+A ||--|| B : "exactly one to exactly one"
+A ||--o{ B : "one to zero or more"
+A ||--|{ B : "one to one or more"
+A }o--o{ B : "zero or more to zero or more"
+A |o--o| B : "zero or one to zero or one"
+```
+
+### Cardinality Symbols
+
+| Symbol | Meaning      |
+| ------ | ------------ |
+| `\|\|` | Exactly one  |
+| `o\|`  | Zero or one  |
+| `}o`   | Zero or more |
+| `}\|`  | One or more  |
+
+### Attribute Types
+
+```mermaid
+erDiagram
+    PRODUCT {
+        uuid id PK "Unique identifier"
+        string name "Product display name"
+        decimal price "Price in cents"
+        text description
+        datetime created_at
+        int stock_count
+        boolean active
+        string sku UK "Stock keeping unit"
+        uuid category_id FK "Reference to category"
+    }
+```
+
+**Key markers:** `PK` (primary key), `FK` (foreign key), `UK` (unique key)
+
+---
+
+## 6. Gantt Chart
+
+**Keyword:** `gantt`
+
+```mermaid
+gantt
+    title Project Timeline
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Planning
+        Requirements    :done, req, 2025-01-01, 14d
+        Design          :active, des, after req, 10d
+
+    section Development
+        Backend         :dev1, after des, 21d
+        Frontend        :dev2, after des, 18d
+
+    section Testing
+        Integration     :test, after dev1, 7d
+        UAT             :uat, after test, 5d
+
+    section Release
+        Deployment      :milestone, deploy, after uat, 0d
+```
+
+**Task states:** `done`, `active`, `crit` (critical path)
+**Duration:** `7d` (days), `5h` (hours), or specific end date
+**Dependencies:** `after taskId` or comma-separated `after task1 task2`
+
+---
+
+## 7. Pie Chart
+
+**Keyword:** `pie`
+
+```mermaid
+pie showData
+    title Technology Stack
+    "TypeScript" : 45
+    "Python" : 25
+    "Go" : 15
+    "Rust" : 10
+    "Other" : 5
+```
+
+`showData` is optional — adds percentages to labels.
+
+---
+
+## 8. Mindmap
+
+**Keyword:** `mindmap`
+
+```mermaid
+mindmap
+    root((System Design))
+        Scalability
+            Horizontal
+                Load Balancers
+                Sharding
+            Vertical
+                More CPU
+                More RAM
+        Reliability
+            Redundancy
+            Failover
+            Backups
+        Performance
+            Caching
+                CDN
+                Redis
+            Optimization
+                Indexing
+                Query tuning
+```
+
+**Node shapes:**
+
+- `((Circle))` — root/emphasis
+- `(Rounded)` — default
+- `[Square]` — structured
+- `)Cloud(` — cloud shape
+- `))Bang((` — explosion/emphasis
+
+---
+
+## 9. Timeline
+
+**Keyword:** `timeline`
+
+```mermaid
+timeline
+    title Product Roadmap 2025
+    section Q1
+        January : MVP Launch
+                : Core API complete
+        February : Beta program
+        March : Public launch
+    section Q2
+        April : Mobile app
+        May : International expansion
+        June : Enterprise features
+```
+
+---
+
+## 10. Git Graph
+
+**Keyword:** `gitGraph`
+
+```mermaid
+gitGraph
+    commit id: "Initial"
+    branch develop
+    checkout develop
+    commit id: "Feature A"
+    commit id: "Feature B"
+    branch feature/auth
+    checkout feature/auth
+    commit id: "Add login"
+    commit id: "Add OAuth"
+    checkout develop
+    merge feature/auth id: "Merge auth"
+    checkout main
+    merge develop id: "Release v1.0" tag: "v1.0"
+    commit id: "Hotfix" type: HIGHLIGHT
+```
+
+**Commit types:** `NORMAL`, `REVERSE`, `HIGHLIGHT`
+**Options:** `branch order: 0` to control branch position
+
+---
+
+## 11. Sankey Diagram
+
+**Keyword:** `sankey-beta`
+
+```mermaid
+sankey-beta
+
+Traffic,Homepage,5000
+Traffic,API,3000
+Homepage,Signup,1500
+Homepage,Browse,3500
+API,Mobile,2000
+API,Partners,1000
+Signup,Active Users,1200
+Signup,Churned,300
+```
+
+Format: `source,target,value` — one per line, comma-separated.
+
+---
+
+## 12. XY Chart
+
+**Keyword:** `xychart-beta`
+
+```mermaid
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar, Apr, May, Jun]
+    y-axis "Revenue ($K)" 0 --> 100
+    bar [30, 45, 60, 55, 70, 85]
+    line [25, 40, 55, 50, 65, 80]
+```
+
+Supports `bar` and `line` series. Multiple series can be combined.
+
+---
+
+## 13. Quadrant Chart
+
+**Keyword:** `quadrantChart`
+
+```mermaid
+quadrantChart
+    title Feature Prioritization
+    x-axis "Low Effort" --> "High Effort"
+    y-axis "Low Impact" --> "High Impact"
+    quadrant-1 "Quick Wins"
+    quadrant-2 "Major Projects"
+    quadrant-3 "Fill-ins"
+    quadrant-4 "Thankless Tasks"
+    Feature A: [0.8, 0.9]
+    Feature B: [0.2, 0.7]
+    Feature C: [0.6, 0.3]
+    Feature D: [0.3, 0.2]
+```
+
+Coordinates are `[x, y]` with values between 0 and 1.
+
+---
+
+## 14. Block Diagram
+
+**Keyword:** `block-beta`
+
+```mermaid
+block-beta
+    columns 3
+
+    space:1 Header["System Overview"]:1 space:1
+
+    Frontend["React App"]:1 API["NestJS API"]:1 DB[("PostgreSQL")]:1
+
+    Frontend --> API
+    API --> DB
+```
+
+Use `columns N` to define grid. `space:N` for empty cells.
+Blocks span cells with `:N` suffix.
+
+---
+
+## 15. User Journey
+
+**Keyword:** `journey`
+
+```mermaid
+journey
+    title User Checkout Experience
+    section Browse
+        Visit homepage: 5: Customer
+        Search product: 4: Customer
+        View details: 4: Customer
+    section Purchase
+        Add to cart: 5: Customer
+        Enter payment: 2: Customer, Payment System
+        Confirm order: 4: Customer, Order Service
+    section Post-Purchase
+        Receive confirmation: 5: Customer, Email Service
+        Track delivery: 3: Customer
+```
+
+Format: `Task name: satisfaction(1-5): actor1, actor2`
+
+---
+
+## 16. Requirement Diagram
+
+**Keyword:** `requirementDiagram`
+
+```mermaid
+requirementDiagram
+    requirement high_availability {
+        id: REQ-001
+        text: System must achieve 99.9% uptime
+        risk: high
+        verifymethod: test
+    }
+
+    functionalRequirement auto_failover {
+        id: REQ-002
+        text: Automatic failover within 30 seconds
+        risk: medium
+        verifymethod: demonstration
+    }
+
+    element load_balancer {
+        type: service
+        docRef: arch-doc-001
+    }
+
+    high_availability - traces -> auto_failover
+    auto_failover - satisfies -> load_balancer
+```
+
+**Relationship types:** `contains`, `copies`, `derives`, `satisfies`, `verifies`,
+`refines`, `traces`
+
+---
+
+## 17. Packet Diagram
+
+**Keyword:** `packet-beta`
+
+```mermaid
+packet-beta
+    0-15: "Source Port"
+    16-31: "Destination Port"
+    32-63: "Sequence Number"
+    64-95: "Acknowledgment Number"
+    96-99: "Data Offset"
+    100-105: "Reserved"
+    106-111: "Flags"
+    112-127: "Window Size"
+    128-143: "Checksum"
+    144-159: "Urgent Pointer"
+```
+
+Format: `start-end: "Label"` — bit ranges for protocol headers.
+
+---
+
+## 18. Kanban
+
+**Keyword:** `kanban`
+
+```mermaid
+kanban
+    column1["To Do"]
+        task1["Design database schema"]
+        task2["Write API specs"]
+    column2["In Progress"]
+        task3["Implement auth"]
+    column3["Review"]
+        task4["Code review: payments"]
+    column4["Done"]
+        task5["Setup CI/CD"]
+```
+
+---
+
+## Global Configuration
+
+Any diagram can be configured with frontmatter:
+
+```mermaid
+---
+config:
+  theme: base
+  look: classic
+  layout: dagre
+  themeVariables:
+    primaryColor: "#4f46e5"
+    lineColor: "#94a3b8"
+---
+flowchart LR
+    A --> B --> C
+```
+
+**Themes:** `default`, `forest`, `dark`, `neutral`, `base`
+**Looks:** `classic`, `handDrawn`
+**Layouts:** `dagre` (default), `elk` (advanced, needs integration)
+
+## Directives (Inline Config)
+
+**IMPORTANT:** The init directive MUST be on the very first line, before any diagram type declaration.
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'lineColor': '#94a3b8',
+  'primaryTextColor': '#fff', 'primaryBorderColor': '#3730a3'
+}}}%%
+```
+
+**Golden Rule:** Always include `'lineColor': '#94a3b8'` to replace the default harsh black lines with softer slate-colored lines. This single change dramatically improves diagram aesthetics.

--- a/.windsurf/skills/mermaid-studio/references/themes.md
+++ b/.windsurf/skills/mermaid-studio/references/themes.md
@@ -1,0 +1,426 @@
+# Themes and Styling — Complete Reference
+
+Load this file when the user requests custom themes, specific colors, or styled diagrams.
+
+## Theme Sources
+
+Two rendering engines provide different theme sets:
+
+### Engine 1: @mermaid-js/mermaid-cli (mmdc)
+
+5 built-in themes controlled via `--theme` flag or frontmatter:
+
+| Theme     | Best for                                   |
+| --------- | ------------------------------------------ |
+| `default` | General use, light backgrounds             |
+| `forest`  | Nature-inspired green tones, presentations |
+| `dark`    | Dark backgrounds, dark-mode docs           |
+| `neutral` | Minimal, grayscale, professional docs      |
+| `base`    | Starting point for custom themes           |
+
+### Engine 2: beautiful-mermaid
+
+15 curated themes with consistent design:
+
+**Light themes:**
+| Theme | Style | Best for |
+|-------|-------|----------|
+| `zinc-light` | Clean gray tones | Professional documents |
+| `tokyo-night-light` | Warm light | General use |
+| `catppuccin-latte` | Soft pastels | Friendly docs |
+| `nord-light` | Arctic cool tones | Technical docs |
+| `github-light` | GitHub-style | READMEs, GitHub pages |
+| `solarized-light` | Warm yellows | Long reading |
+
+**Dark themes:**
+| Theme | Style | Best for |
+|-------|-------|----------|
+| `zinc-dark` | Dark gray | Dark mode docs |
+| `tokyo-night` | Vibrant dark | Developer tools |
+| `tokyo-night-storm` | Deep blue-dark | Presentations |
+| `catppuccin-mocha` | Rich dark | Dark mode, cozy feel |
+| `nord` | Arctic dark | Technical, minimal |
+| `dracula` | Purple-tinted dark | Developer-favorite |
+| `github-dark` | GitHub dark mode | Dark READMEs |
+| `solarized-dark` | Warm dark | Extended reading |
+| `one-dark` | Atom-inspired | Code-adjacent docs |
+
+### Theme Selection Guide
+
+| Context                      | Recommended                              |
+| ---------------------------- | ---------------------------------------- |
+| GitHub/GitLab README         | `github-light` or `github-dark`          |
+| Technical documentation      | `nord-light` or `neutral`                |
+| Presentations (light room)   | `zinc-light` or `default`                |
+| Presentations (dark room)    | `tokyo-night-storm` or `dracula`         |
+| Developer tools / terminal   | `tokyo-night` or `one-dark`              |
+| Client-facing / professional | `zinc-light` or `neutral`                |
+| Personal blog / casual       | `catppuccin-latte` or `catppuccin-mocha` |
+
+## Custom Theming (mermaid-cli)
+
+When using the `base` theme, you can override any variable:
+
+### Via Frontmatter
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#4f46e5"
+    primaryTextColor: "#ffffff"
+    primaryBorderColor: "#3730a3"
+    lineColor: "#6b7280"
+    secondaryColor: "#10b981"
+    tertiaryColor: "#f59e0b"
+    background: "#ffffff"
+    mainBkg: "#f8fafc"
+    nodeBorder: "#e2e8f0"
+    clusterBkg: "#f1f5f9"
+    clusterBorder: "#cbd5e1"
+    titleColor: "#1e293b"
+    edgeLabelBackground: "#ffffff"
+---
+flowchart LR
+    A --> B
+```
+
+### Via Init Directive
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5',
+  'primaryTextColor': '#fff',
+  'primaryBorderColor': '#3730a3',
+  'lineColor': '#6b7280',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b'
+}}}%%
+```
+
+### Via Render Script Config
+
+```bash
+node $SKILL_DIR/scripts/render.mjs \
+  --input diagram.mmd \
+  --output diagram.svg \
+  --format svg \
+  --theme base \
+  --config '{"theme":"base","themeVariables":{"primaryColor":"#4f46e5"}}'
+```
+
+## Available Theme Variables
+
+### Core Colors
+
+| Variable             | Controls                         |
+| -------------------- | -------------------------------- |
+| `primaryColor`       | Main node fill color             |
+| `primaryTextColor`   | Text on primary-colored elements |
+| `primaryBorderColor` | Border of primary elements       |
+| `secondaryColor`     | Secondary elements, alternates   |
+| `tertiaryColor`      | Tertiary elements, highlights    |
+| `lineColor`          | Edge/connection lines            |
+| `background`         | Diagram background               |
+| `mainBkg`            | Default node background          |
+| `nodeBorder`         | Default node border              |
+
+### Text
+
+| Variable              | Controls                      |
+| --------------------- | ----------------------------- |
+| `titleColor`          | Diagram title text            |
+| `textColor`           | General text                  |
+| `edgeLabelBackground` | Background behind edge labels |
+
+### Clusters / Subgraphs
+
+| Variable        | Controls                  |
+| --------------- | ------------------------- |
+| `clusterBkg`    | Subgraph/group background |
+| `clusterBorder` | Subgraph/group border     |
+
+### Sequence Diagram Specific
+
+| Variable                | Controls                      |
+| ----------------------- | ----------------------------- |
+| `actorBkg`              | Participant box fill          |
+| `actorBorder`           | Participant box border        |
+| `actorTextColor`        | Participant text              |
+| `activationBkgColor`    | Activation box fill           |
+| `activationBorderColor` | Activation box border         |
+| `signalColor`           | Message arrow color           |
+| `signalTextColor`       | Message text color            |
+| `noteBkgColor`          | Note background               |
+| `noteBorderColor`       | Note border                   |
+| `noteTextColor`         | Note text                     |
+| `labelBoxBkgColor`      | Alt/loop/opt label background |
+| `labelBoxBorderColor`   | Alt/loop/opt label border     |
+| `loopTextColor`         | Loop label text               |
+
+### Flowchart Specific
+
+| Variable        | Controls  |
+| --------------- | --------- |
+| `nodeTextColor` | Node text |
+
+## Element-Level Styling
+
+### CSS Classes (Flowchart)
+
+```mermaid
+flowchart LR
+    A[Success]:::success
+    B[Warning]:::warning
+    C[Error]:::error
+    D[Info]:::info
+
+    A --> B --> C --> D
+
+    classDef success fill:#10b981,stroke:#059669,color:#fff
+    classDef warning fill:#f59e0b,stroke:#d97706,color:#000
+    classDef error fill:#ef4444,stroke:#dc2626,color:#fff
+    classDef info fill:#3b82f6,stroke:#2563eb,color:#fff
+    classDef default fill:#f8fafc,stroke:#e2e8f0,color:#1e293b
+```
+
+### Inline Styles (Flowchart)
+
+```mermaid
+flowchart LR
+    A --> B --> C
+    style A fill:#f97316,stroke:#ea580c,color:#fff
+    style B fill:#8b5cf6,stroke:#7c3aed,color:#fff
+    style C fill:#06b6d4,stroke:#0891b2,color:#fff
+```
+
+### Link Styles (Flowchart)
+
+```mermaid
+flowchart LR
+    A --> B --> C
+
+    linkStyle 0 stroke:#ef4444,stroke-width:3px
+    linkStyle 1 stroke:#10b981,stroke-width:2px,stroke-dasharray:5
+```
+
+## Brand Color Presets
+
+### Tailwind-Inspired Palette
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#3b82f6',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#2563eb',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b',
+  'lineColor': '#6b7280',
+  'background': '#ffffff',
+  'mainBkg': '#f8fafc',
+  'nodeBorder': '#e2e8f0',
+  'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#cbd5e1'
+}}}%%
+```
+
+### AWS-Themed (Elegant)
+
+Uses AWS orange for primary with **soft slate lines** instead of the harsh default black:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#FF9900',
+  'primaryTextColor': '#232F3E',
+  'primaryBorderColor': '#c47600',
+  'secondaryColor': '#527FFF',
+  'tertiaryColor': '#DD344C',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#FFF8F0',
+  'nodeBorder': '#c47600',
+  'clusterBkg': '#FFF8F0',
+  'clusterBorder': '#d4a574',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+```
+
+### Monochrome Professional
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#374151',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#1f2937',
+  'secondaryColor': '#6b7280',
+  'tertiaryColor': '#9ca3af',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#f9fafb',
+  'nodeBorder': '#d1d5db',
+  'clusterBkg': '#f3f4f6',
+  'clusterBorder': '#9ca3af',
+  'edgeLabelBackground': '#ffffff'
+}}}%%
+```
+
+### Indigo-Emerald (Modern SaaS)
+
+A fresh, modern palette for SaaS architecture diagrams:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#3730a3',
+  'secondaryColor': '#10b981',
+  'tertiaryColor': '#f59e0b',
+  'lineColor': '#94a3b8',
+  'background': '#ffffff',
+  'mainBkg': '#f8fafc',
+  'nodeBorder': '#cbd5e1',
+  'clusterBkg': '#f1f5f9',
+  'clusterBorder': '#e2e8f0',
+  'titleColor': '#1e293b',
+  'edgeLabelBackground': '#ffffff',
+  'textColor': '#334155'
+}}}%%
+```
+
+## C4 Diagram Styling
+
+C4 diagrams have fixed element colors (blue for systems, gray for persons, etc.) but the **relationship lines default to harsh black**. Always override them.
+
+**CRITICAL — Arrow Spaghetti Prevention:**
+
+The #1 cause of messy C4 diagrams is too many `Rel()` relationships. Mermaid's Dagre layout engine routes ALL arrows, and with more than ~6 relationships, they inevitably cross and overlap. Follow these rules:
+
+- **Maximum 6 Rel() per diagram** — if you need more, split into multiple diagrams
+- **Tree-shaped topology** — each node should ideally have 1 incoming and 1-2 outgoing edges
+- **Avoid mesh connections** — don't connect everything to everything
+- **Declare elements in flow order** — top-to-bottom or left-to-right; the order of declaration affects layout
+
+### Soft Lines (Mandatory for All C4)
+
+```
+    %% Apply to EVERY Rel() in the diagram
+    UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8")
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### Highlighted Paths in C4
+
+Use accent colors for primary flows while keeping secondary lines soft:
+
+```
+    %% Primary/user-facing relationship
+    UpdateRelStyle(user, api, $textColor="#1e40af", $lineColor="#3b82f6")
+
+    %% Internal relationship
+    UpdateRelStyle(api, db, $textColor="#475569", $lineColor="#94a3b8")
+
+    %% External/risky connection
+    UpdateRelStyle(api, external, $textColor="#92400e", $lineColor="#f59e0b")
+```
+
+### Custom Element Colors in C4
+
+```
+    UpdateElementStyle(elementAlias, $bgColor="#4f46e5", $fontColor="#ffffff", $borderColor="#3730a3")
+```
+
+| Purpose              | bgColor   | fontColor | borderColor |
+| -------------------- | --------- | --------- | ----------- |
+| Primary emphasis     | `#4f46e5` | `#ffffff` | `#3730a3`   |
+| Success / Data store | `#059669` | `#ffffff` | `#047857`   |
+| Warning / External   | `#d97706` | `#ffffff` | `#b45309`   |
+| Neutral / Supporting | `#64748b` | `#ffffff` | `#475569`   |
+
+## Look Options
+
+```mermaid
+---
+config:
+  look: handDrawn
+---
+flowchart LR
+    A[Sketch Style] --> B[Looks Hand-drawn]
+```
+
+| Look        | Effect                             |
+| ----------- | ---------------------------------- |
+| `classic`   | Standard clean rendering (default) |
+| `handDrawn` | Sketch-like, informal appearance   |
+
+## Configuration via Frontmatter
+
+Full example combining theme, look, and layout:
+
+```mermaid
+---
+config:
+  theme: base
+  look: classic
+  layout: dagre
+  themeVariables:
+    primaryColor: "#4f46e5"
+    lineColor: "#94a3b8"
+---
+flowchart TD
+    A --> B --> C
+```
+
+**Layout engines:**
+| Engine | When to use |
+|--------|-------------|
+| `dagre` | Default — good for most diagrams |
+| `elk` | Complex diagrams with many crossings (requires plugin) |
+
+## Modern Design Principles
+
+### The Golden Rule: Soft Lines
+
+The single biggest improvement to any Mermaid diagram is replacing the default black lines with a softer color. **Always use `lineColor: '#94a3b8'`** (Slate-400) for light backgrounds or `lineColor: '#64748b'` (Slate-500) for dark themes.
+
+### Color Harmony
+
+Use max 3-4 colors per diagram and map them to meaning:
+
+- **Blue tones** → internal systems, primary services
+- **Green tones** → data stores, success states
+- **Amber tones** → external systems, warnings
+- **Slate tones** → lines, borders, secondary elements
+- **Red tones** → error states ONLY (never decoration)
+
+### Typography and Labels
+
+- Keep labels short (max 3-4 words)
+- Use `<br/>` for multi-line labels when needed
+- Use natural language, not abbreviations
+- Include protocol/technology in relationship labels
+
+**CRITICAL — Font Compatibility:**
+
+Do NOT use `system-ui`, `-apple-system`, or `Segoe UI` in `fontFamily` theme variables. These fonts are not available in headless Chromium (used by `mmdc` for rendering) and will silently fall back to a serif font like Times New Roman, making the diagram look unprofessional.
+
+**Safe font stacks for `fontFamily`:**
+- Default (best): `'trebuchet ms', 'verdana', 'arial', sans-serif` — this is Mermaid's built-in default and works everywhere
+- If you must customize: `'verdana', 'arial', 'helvetica', sans-serif`
+
+In practice, do NOT set `fontFamily` at all unless you have a specific reason. The Mermaid default font is already professional and universally compatible.
+
+### Density and Whitespace
+
+- Max 15 nodes per diagram
+- Use subgraphs to create visual grouping and whitespace
+- Use invisible links (`A ~~~ B`) to add spacing when needed
+- Prefer LR over TD for most diagrams (reads more naturally)
+
+### Init Directive Override Behavior
+
+When using the render script, the `--theme` flag writes a config file passed to `mmdc -c`. If your `.mmd` file contains a `%%{init}%%` directive, the render script automatically detects it and does NOT pass a theme in the config, so your init directive takes full precedence. This means:
+
+- If your `.mmd` has `%%{init: {'theme': 'dark', ...}}%%`, it will render with dark theme correctly
+- If your `.mmd` has NO init directive, the render script's `--theme` flag (default: `default`) will be applied
+- You do NOT need to pass `--theme` when using init directives

--- a/.windsurf/skills/mermaid-studio/references/troubleshooting.md
+++ b/.windsurf/skills/mermaid-studio/references/troubleshooting.md
@@ -1,0 +1,479 @@
+# Troubleshooting — Common Errors and Fixes
+
+Load this file when validation fails or diagrams don't render correctly.
+
+## Syntax Errors
+
+### 1. Unexpected token / Parse error
+
+**Symptom:** `Parse error on line N: ...`
+
+**Common causes and fixes:**
+
+| Cause                   | Bad              | Good                    |
+| ----------------------- | ---------------- | ----------------------- |
+| Special chars in labels | `A[User's Data]` | `A["User's Data"]`      |
+| Unmatched brackets      | `A[Open label`   | `A[Open label]`         |
+| Missing arrow           | `A B`            | `A --> B`               |
+| Wrong arrow direction   | `A >>- B`        | `A ->> B`               |
+| Keyword as node ID      | `end --> start`  | `endNode --> startNode` |
+| Curly braces in comment | `%% {config}`    | `%% config here`        |
+
+### 2. Reserved Words as Node IDs
+
+These words CANNOT be used as bare node IDs:
+
+`end`, `graph`, `subgraph`, `flowchart`, `classDiagram`, `sequenceDiagram`, `stateDiagram`, `erDiagram`, `gantt`, `pie`, `click`, `style`, `class`, `linkStyle`, `default`, `direction`
+
+**Fix:** Append a suffix or use different names:
+
+```
+%% Bad
+end --> start
+
+%% Good
+endState --> startState
+```
+
+### 3. Quotes and Escaping
+
+```
+%% Bad — unescaped quotes
+A["She said "hello""]
+
+%% Good — use single quotes inside double, or HTML entities
+A["She said 'hello'"]
+A["She said &quot;hello&quot;"]
+
+%% Bad — backslash in labels
+A[C:\Users\path]
+
+%% Good — use forward slash or quote the label
+A["C:\Users\path"]
+```
+
+### 4. Empty Labels or Missing Content
+
+```
+%% Bad — empty node
+A[] --> B
+
+%% Good
+A[Start] --> B[End]
+
+%% Bad — empty subgraph
+subgraph Group
+end
+
+%% Good
+subgraph Group
+    A[Content]
+end
+```
+
+## Rendering Issues
+
+### 5. Diagram Renders but Layout is Wrong
+
+**Symptom:** Nodes overlap, arrows cross unnecessarily
+
+**Fixes:**
+
+- Change direction: `TD` ↔ `LR`
+- Add invisible links for spacing: `A ~~~ B`
+- Use subgraphs to group related nodes
+- Reduce node count (split into multiple diagrams)
+- Try `layout: elk` in frontmatter (if supported)
+
+### 6. Labels Cut Off or Truncated
+
+**Symptom:** Long text gets clipped
+
+**Fixes:**
+
+```
+%% Use line breaks
+A["Order Processing<br/>Service"]
+
+%% Shorten labels
+A["Order Svc"]
+
+%% For sequence diagrams, use aliases
+participant OrderSvc as Order Processing Service
+```
+
+### 7. Subgraph Won't Render
+
+**Symptom:** Subgraph shows as flat, no boundary
+
+**Fixes:**
+
+```
+%% Bad — subgraph must have content
+subgraph Empty
+end
+
+%% Good — needs at least one node
+subgraph Group["Service Layer"]
+    A[Service A]
+end
+
+%% Bad — nested subgraph direction before content
+subgraph Parent
+    direction LR
+end
+
+%% Good — direction followed by nodes
+subgraph Parent
+    direction LR
+    A --> B
+end
+```
+
+### 8. Theme Not Applied
+
+**Symptom:** Diagram renders with default colors
+
+**Causes:**
+
+- beautiful-mermaid themes only work with that engine
+- Frontmatter must be at the very start of the file
+- `%%{init}` directive must be on line 1
+- Some renderers ignore theme config
+
+**Fix:** Verify which engine is being used. For mmdc, use `--theme` flag. For beautiful-mermaid, use `--theme` parameter.
+
+### 9. SVG Output is Blank or Tiny
+
+**Symptom:** File is generated but empty or 0x0 pixels
+
+**Causes:**
+
+- Puppeteer/Chrome not installed (mmdc)
+- File encoding issue (BOM marker)
+- Syntax error that fails silently
+
+**Fixes:**
+
+```bash
+# Re-run setup
+bash $SKILL_DIR/scripts/setup.sh
+
+# Check file encoding
+file diagram.mmd
+# Should say: UTF-8 Unicode text
+
+# Validate first
+node $SKILL_DIR/scripts/validate.mjs diagram.mmd
+```
+
+### 10. mmdc Command Not Found
+
+```bash
+# Check if installed
+npx mmdc --version
+
+# If not, install
+npm install -g @mermaid-js/mermaid-cli
+
+# Or use npx (no global install)
+npx -y @mermaid-js/mermaid-cli -i input.mmd -o output.svg
+```
+
+### 11. Puppeteer/Chrome Issues
+
+**Symptom:** `Error: Could not find Chrome`
+
+```bash
+# Install Chromium for puppeteer
+npx puppeteer browsers install chrome
+
+# Or set custom path
+export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Or use puppeteer config
+echo '{"args": ["--no-sandbox"]}' > puppeteer-config.json
+npx mmdc -i input.mmd -o output.svg -p puppeteer-config.json
+```
+
+## Diagram-Specific Issues
+
+### 12. Sequence Diagram — Activation Mismatch
+
+**Symptom:** `Activation error` or misaligned boxes
+
+```
+%% Bad — activate without deactivate
+A->>+B: Request
+B->>C: Forward
+
+%% Good — always pair +/-
+A->>+B: Request
+B-->>-A: Response
+```
+
+### 13. ERD — Relationship Syntax Error
+
+```
+%% Bad — wrong cardinality syntax
+USER --o{ ORDER
+
+%% Good — must include both sides
+USER ||--o{ ORDER : "places"
+
+%% Bad — missing label
+USER ||--o{ ORDER
+
+%% Good — relationship label is required
+USER ||--o{ ORDER : "places"
+```
+
+### 14. C4 — Element Not Rendering
+
+```
+%% Bad — missing quotes around parameters
+Container(api, API, NestJS, Backend service)
+
+%% Good — all text parameters in quotes
+Container(api, "API", "NestJS", "Backend service")
+
+%% Bad — wrong boundary nesting
+Container_Boundary(app, "App") {
+    System(sys, "External")  %% System inside Container boundary
+}
+
+%% Good — use appropriate element types for context
+Container_Boundary(app, "App") {
+    Component(cmp, "Internal Component", "Tech", "Desc")
+}
+```
+
+### 15. Gantt — Dates Not Parsing
+
+```
+%% Bad — wrong format
+dateFormat DD-MM-YYYY
+
+%% Good — supported formats
+dateFormat YYYY-MM-DD
+%% or
+dateFormat DD/MM/YYYY
+%% or
+dateFormat X  (Unix timestamp)
+```
+
+### 16. Flowchart — Circular Reference Warning
+
+**Symptom:** Infinite loop in rendering
+
+```
+%% Problematic — direct circular
+A --> B --> A
+
+%% Still valid but may cause layout issues. Fix by adding direction:
+flowchart LR
+    A --> B
+    B --> A  %% Renders as two arrows between A and B
+```
+
+### 17. State Diagram — Composite State Errors
+
+```
+%% Bad — missing initial state in composite
+state Active {
+    Running --> Paused
+}
+
+%% Good — composite states need initial transition
+state Active {
+    [*] --> Running
+    Running --> Paused
+}
+```
+
+### 18. Architecture-beta — Not Rendering
+
+**Symptom:** Raw text displayed instead of diagram
+
+**Cause:** `architecture-beta` requires Mermaid v11+
+
+**Fixes:**
+
+- Verify Mermaid version: `npx mmdc --version` (needs 11+)
+- Use C4 or flowchart as fallback (see aws-architecture.md)
+- Update mermaid-cli: `npm install -g @mermaid-js/mermaid-cli@latest`
+
+### 19. Architecture-beta — Icons Not Showing
+
+**Symptom:** Icons show as generic boxes or are missing
+
+**Cause:** `logos:aws-*` icons require icon pack registration at render time
+
+**Fixes:**
+
+```bash
+# Use the --icons flag to register icon packs
+node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output diagram.svg --icons logos
+
+# Or use built-in icons as fallback (no registration needed)
+# Replace: service api(logos:aws-api-gateway)[API Gateway]
+# With:    service api(server)[API Gateway]
+```
+
+Built-in icons that work everywhere: `cloud`, `database`, `disk`, `server`, `internet`
+
+### 20. Architecture-beta — Massive Distances Between Arrows/Nodes
+
+**Symptom:** Nodes are spaced extremely far apart, making arrows incredibly long and crossing other nodes messily.
+
+**Cause:** The architecture-beta renderer has no edge routing algorithms and places nodes in rigid, escalating grids. This breaks diagrams with > 8 nodes.
+
+**Fix:** DO NOT use `architecture-beta` for complex systems. Convert the diagram to a properly styled `C4Container` diagram immediately. C4's layout engine spaces elements perfectly.
+
+### 20. C4 — Lines Too Dark / Overlapping Elements
+
+**Symptom:** Black lines create visual clutter, labels overlap with elements
+
+**Cause:** Missing `UpdateRelStyle` and `UpdateLayoutConfig` directives
+
+**Fixes:**
+
+```
+%% Add to the END of every C4 diagram, after all Rel() definitions
+%% Apply to EACH Rel() with soft colors
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8")
+
+%% Add offsets when labels overlap elements
+UpdateRelStyle(from, to, $textColor="#475569", $lineColor="#94a3b8", $offsetY="-10")
+
+%% Spread out elements
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+### 21. General — Diagram Lines Too Dark/Harsh
+
+**Symptom:** Diagram looks cluttered even with few nodes
+
+**Cause:** Default Mermaid theme uses black (#000000) lines
+
+**Fix:** Add init directive with soft line color:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {
+  'lineColor': '#94a3b8'
+}}}%%
+```
+
+### 22. General — Init Directive Not Applying
+
+**Symptom:** Colors don't change despite adding `%%{init}` directive
+
+**Cause:** The directive must be on the very first line (no blank lines before it)
+
+**Fix:** Ensure `%%{init}` is the absolute first non-comment line:
+
+```
+%%{init: {'theme': 'base', 'themeVariables': {...}}}%%
+flowchart LR
+    A --> B
+```
+
+NOT:
+
+```
+flowchart LR
+%%{init: {'theme': 'base', 'themeVariables': {...}}}%%  %% THIS WILL NOT WORK
+    A --> B
+```
+
+## Validation Script Errors
+
+### 23. validate.mjs Reports False Positives
+
+If the validator rejects valid syntax, it might be using an older Mermaid parser version. Try:
+
+```bash
+# Update the validation script's dependency
+cd $SKILL_DIR && npm update mermaid
+
+# Or skip validation and render directly (rendering validates implicitly)
+node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output test.svg
+```
+
+### 24. Batch Script Hangs
+
+**Symptom:** batch.mjs processes some files then stops
+
+**Causes:**
+
+- Too many workers for available memory
+- One diagram has infinite loop syntax
+- Puppeteer timeout on complex diagrams
+
+**Fixes:**
+
+```bash
+# Reduce workers
+node $SKILL_DIR/scripts/batch.mjs --workers 1
+
+# Increase timeout (ms)
+node $SKILL_DIR/scripts/batch.mjs --timeout 60000
+
+# Process problematic files individually to isolate the issue
+```
+
+## Performance Tips
+
+1. **Simple diagrams first** — start with fewer nodes, add incrementally
+2. **Split large diagrams** — over 15 nodes hurts readability and rendering
+3. **Use SVG over PNG** — SVG renders faster and scales infinitely
+4. **ASCII for CI/CD** — no Puppeteer needed, fast and portable
+5. **Batch in parallel** — use `--workers 4` for multiple files
+6. **Cache renders** — only re-render when .mmd source changes
+
+## Rendering Quality Issues
+
+### 25. Fonts Render as Times New Roman / Serif
+
+**Symptom:** Text in the rendered PNG/SVG appears in an ugly serif font instead of the expected sans-serif font.
+
+**Cause:** The `%%{init}%%` directive uses `fontFamily: 'system-ui'` or `fontFamily: 'Segoe UI'` or other desktop-only fonts. These fonts are NOT available in headless Chromium (which `mmdc` uses internally), so the browser falls back to a serif font.
+
+**Fix:** Do NOT set `fontFamily` at all (Mermaid's default `trebuchet ms, verdana, arial, sans-serif` works perfectly), or use only universally available fonts:
+
+```
+%% BAD — these fonts don't exist in headless Chromium
+%%{init: {'theme': 'base', 'themeVariables': {
+  'fontFamily': 'system-ui, -apple-system, sans-serif'
+}}}%%
+
+%% GOOD — use Mermaid defaults (don't set fontFamily at all)
+%%{init: {'theme': 'base', 'themeVariables': {
+  'primaryColor': '#4f46e5', 'lineColor': '#94a3b8'
+}}}%%
+
+%% GOOD — if you must set a font, use web-safe ones
+%%{init: {'theme': 'base', 'themeVariables': {
+  'fontFamily': 'trebuchet ms, verdana, arial, sans-serif'
+}}}%%
+```
+
+### 26. Theme / Init Directive Ignored When Rendering
+
+**Symptom:** You set `%%{init: {'theme': 'dark', ...}}%%` in your `.mmd` file but the diagram renders with the default light theme.
+
+**Cause:** The render script passes a config file with `{"theme": "default"}` via `mmdc -c`, which was overriding the init directive in the diagram.
+
+**Fix:** This bug has been fixed in the render script — it now detects `%%{init` in the input file and does NOT pass a theme in the config file, allowing the init directive to take full precedence. If you still experience this issue, verify:
+
+1. The `%%{init}%%` directive is on the very first line of the `.mmd` file (no blank lines before it)
+2. You are NOT passing `--theme` to the render script when using init directives
+3. The render script version includes the `hasInitDirective` detection fix
+
+### 27. Render Script Fails Silently with `mmdc=no`
+
+**Symptom:** The render script reports `Engines: mmdc=no` even though `mmdc` is installed in `.deps/node_modules/.bin/`.
+
+**Cause:** The skill's directory path contains special characters (like parentheses in `(tooling)`) that break shell execution in `execSync()`. The shell interprets `(` as subshell syntax and fails.
+
+**Fix:** This bug has been fixed in the render script — all paths are now wrapped with `shellQuote()` which uses single quotes to protect against special characters. If you still experience this issue, verify that the `shellQuote()` function exists in `render.mjs` and is used for all path arguments in `execSync()` calls.

--- a/.windsurf/skills/mermaid-studio/scripts/batch.mjs
+++ b/.windsurf/skills/mermaid-studio/scripts/batch.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/batch.mjs
+ *
+ * Batch renders multiple Mermaid diagrams in parallel.
+ *
+ * Usage:
+ *   node batch.mjs --input-dir ./diagrams --output-dir ./rendered [options]
+ *
+ * Options:
+ *   --input-dir     Directory containing .mmd files
+ *   --output-dir    Directory for rendered outputs
+ *   --format        Output format: svg (default), png, pdf, ascii
+ *   --theme         Theme name (default: default)
+ *   --workers       Parallel workers (default: 4)
+ *   --recursive     Search subdirectories for .mmd files
+ *   --timeout       Per-file timeout in ms (default: 30000)
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, readdirSync } from "fs";
+import { basename, dirname, extname, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function parseArgs(args) {
+  const opts = {
+    inputDir: null,
+    outputDir: null,
+    format: "svg",
+    theme: "default",
+    workers: 4,
+    recursive: false,
+    timeout: 30000,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input-dir":
+        opts.inputDir = args[++i];
+        break;
+      case "--output-dir":
+        opts.outputDir = args[++i];
+        break;
+      case "--format":
+        opts.format = args[++i];
+        break;
+      case "--theme":
+        opts.theme = args[++i];
+        break;
+      case "--workers":
+        opts.workers = parseInt(args[++i], 10);
+        break;
+      case "--recursive":
+        opts.recursive = true;
+        break;
+      case "--timeout":
+        opts.timeout = parseInt(args[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        console.log(`
+Mermaid Studio — Batch Renderer
+
+Usage:
+  node batch.mjs --input-dir <dir> --output-dir <dir> [options]
+
+Options:
+  --input-dir     Directory containing .mmd/.mermaid files
+  --output-dir    Output directory for rendered files
+  --format        Output format: svg (default), png, pdf, ascii
+  --theme         Theme name (default: default)
+  --workers       Parallel render workers (default: 4)
+  --recursive     Include subdirectories
+  --timeout       Per-file timeout in ms (default: 30000)
+  --help, -h      Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function findMmdFiles(dir, recursive = false) {
+  const files = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isFile() && (entry.name.endsWith(".mmd") || entry.name.endsWith(".mermaid"))) {
+      files.push(fullPath);
+    } else if (entry.isDirectory() && recursive) {
+      files.push(...findMmdFiles(fullPath, true));
+    }
+  }
+
+  return files.sort();
+}
+
+function getOutputPath(inputFile, inputDir, outputDir, format) {
+  const rel = relative(inputDir, inputFile);
+  const ext = format === "ascii" ? ".txt" : `.${format}`;
+  const outputName = basename(rel, extname(rel)) + ext;
+  const outputSubdir = dirname(rel);
+  return resolve(outputDir, outputSubdir, outputName);
+}
+
+async function renderFile(inputFile, outputFile, format, theme, timeout) {
+  const renderScript =
+    format === "ascii"
+      ? resolve(__dirname, "render-ascii.mjs")
+      : resolve(__dirname, "render.mjs");
+
+  const args =
+    format === "ascii"
+      ? ["--input", inputFile, "--output", outputFile]
+      : ["--input", inputFile, "--output", outputFile, "--format", format, "--theme", theme];
+
+  return new Promise((resolvePromise) => {
+    try {
+      const cmd = `node "${renderScript}" ${args.map((a) => `"${a}"`).join(" ")}`;
+      execSync(cmd, {
+        stdio: "pipe",
+        timeout: timeout,
+        env: { ...process.env },
+      });
+      resolvePromise({ success: true, file: basename(inputFile) });
+    } catch (e) {
+      const stderr = e.stderr?.toString()?.slice(0, 100) || e.message;
+      resolvePromise({
+        success: false,
+        file: basename(inputFile),
+        error: stderr,
+      });
+    }
+  });
+}
+
+async function runBatch(files, opts) {
+  const results = [];
+  let completed = 0;
+  const total = files.length;
+
+  // Process in chunks of --workers size
+  for (let i = 0; i < files.length; i += opts.workers) {
+    const chunk = files.slice(i, i + opts.workers);
+    const promises = chunk.map((inputFile) => {
+      const outputFile = getOutputPath(
+        inputFile,
+        resolve(opts.inputDir),
+        resolve(opts.outputDir),
+        opts.format
+      );
+      mkdirSync(dirname(outputFile), { recursive: true });
+      return renderFile(inputFile, outputFile, opts.format, opts.theme, opts.timeout);
+    });
+
+    const chunkResults = await Promise.all(promises);
+    for (const result of chunkResults) {
+      completed++;
+      const icon = result.success ? "✓" : "✗";
+      console.log(`  ${icon} [${completed}/${total}] ${result.file}${result.error ? ` — ${result.error}` : ""}`);
+      results.push(result);
+    }
+  }
+
+  return results;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (!opts.inputDir || !opts.outputDir) {
+    console.error("Error: --input-dir and --output-dir are required");
+    console.error('Run with --help for usage info.');
+    process.exit(1);
+  }
+
+  if (!existsSync(opts.inputDir)) {
+    console.error(`Error: Input directory not found: ${opts.inputDir}`);
+    process.exit(1);
+  }
+
+  mkdirSync(opts.outputDir, { recursive: true });
+
+  const files = findMmdFiles(resolve(opts.inputDir), opts.recursive);
+
+  if (files.length === 0) {
+    console.log("No .mmd or .mermaid files found in input directory.");
+    process.exit(0);
+  }
+
+  console.log(`\n=== Mermaid Studio — Batch Render ===`);
+  console.log(`Input:   ${resolve(opts.inputDir)}`);
+  console.log(`Output:  ${resolve(opts.outputDir)}`);
+  console.log(`Format:  ${opts.format}`);
+  console.log(`Theme:   ${opts.theme}`);
+  console.log(`Workers: ${opts.workers}`);
+  console.log(`Files:   ${files.length}`);
+  console.log(`${"─".repeat(40)}`);
+
+  const startTime = Date.now();
+  const results = await runBatch(files, opts);
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  console.log(`${"─".repeat(40)}`);
+  console.log(`\nCompleted in ${elapsed}s`);
+  console.log(`  ✓ ${succeeded} succeeded`);
+  if (failed > 0) {
+    console.log(`  ✗ ${failed} failed`);
+  }
+  console.log(`  Total: ${results.length}/${files.length}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(2);
+});

--- a/.windsurf/skills/mermaid-studio/scripts/render-ascii.mjs
+++ b/.windsurf/skills/mermaid-studio/scripts/render-ascii.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/render-ascii.mjs
+ *
+ * Renders Mermaid diagrams as ASCII/Unicode art for terminal display.
+ * Uses beautiful-mermaid library for ASCII output.
+ *
+ * Usage:
+ *   node render-ascii.mjs --input diagram.mmd
+ *   node render-ascii.mjs --input diagram.mmd --output diagram.txt
+ *   echo "graph LR; A-->B" | node render-ascii.mjs --stdin
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+function parseArgs(args) {
+  const opts = {
+    input: null,
+    output: null, // null = stdout
+    stdin: false,
+    width: null,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input":
+      case "-i":
+        opts.input = args[++i];
+        break;
+      case "--output":
+      case "-o":
+        opts.output = args[++i];
+        break;
+      case "--stdin":
+        opts.stdin = true;
+        break;
+      case "--width":
+      case "-w":
+        opts.width = parseInt(args[++i], 10);
+        break;
+      case "--help":
+      case "-h":
+        console.log(`
+Mermaid Studio — ASCII Renderer
+
+Usage:
+  node render-ascii.mjs --input <file.mmd> [--output <file.txt>]
+  echo "graph LR; A-->B" | node render-ascii.mjs --stdin
+
+Options:
+  --input, -i     Input .mmd file path
+  --output, -o    Output file (default: print to stdout)
+  --stdin         Read diagram from stdin
+  --width, -w     Max width in characters
+  --help, -h      Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+function findBeautifulMermaid() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/beautiful-mermaid"),
+    resolve(process.cwd(), "node_modules/beautiful-mermaid"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+async function renderAscii(mmdContent, bmPath, opts) {
+  try {
+    const bm = await import(resolve(bmPath, "index.js")).catch(() =>
+      import(resolve(bmPath, "dist/index.js")).catch(() =>
+        import(resolve(bmPath, "src/index.js"))
+      )
+    );
+
+    // Try various function names the library might expose
+    const renderFn =
+      bm.renderMermaidAscii ||
+      bm.renderAscii ||
+      bm.default?.renderMermaidAscii ||
+      bm.default?.renderAscii;
+
+    if (renderFn) {
+      const asciiOpts = {};
+      if (opts.width) asciiOpts.maxWidth = opts.width;
+
+      const result = await renderFn(mmdContent, asciiOpts);
+      return typeof result === "string" ? result : result?.ascii || result?.text || String(result);
+    }
+
+    // If no dedicated ASCII function, try the general render with ascii format
+    const generalRender =
+      bm.renderMermaid ||
+      bm.render ||
+      bm.default?.renderMermaid ||
+      bm.default?.render;
+
+    if (generalRender) {
+      const renderOpts = { format: "ascii" };
+      if (opts.width) renderOpts.maxWidth = opts.width;
+
+      const result = await generalRender(mmdContent, renderOpts);
+      if (typeof result === "string") return result;
+      if (result?.ascii) return result.ascii;
+      if (result?.text) return result.text;
+      return String(result);
+    }
+
+    throw new Error("No suitable render function found in beautiful-mermaid");
+  } catch (e) {
+    throw new Error(`beautiful-mermaid ASCII rendering failed: ${e.message}`);
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Get input
+  let mmdContent;
+  if (opts.stdin) {
+    mmdContent = await readFromStdin();
+  } else if (opts.input) {
+    const inputFile = resolve(opts.input);
+    if (!existsSync(inputFile)) {
+      console.error(`Error: Input file not found: ${inputFile}`);
+      process.exit(1);
+    }
+    mmdContent = readFileSync(inputFile, "utf-8");
+  } else {
+    console.error("Error: --input or --stdin is required");
+    process.exit(1);
+  }
+
+  if (!mmdContent.trim()) {
+    console.error("Error: Empty input");
+    process.exit(1);
+  }
+
+  // Find engine
+  const bmPath = findBeautifulMermaid();
+  if (!bmPath) {
+    console.error("Error: beautiful-mermaid not found.");
+    console.error(`Run: bash ${resolve(__dirname, "setup.sh")}`);
+    process.exit(1);
+  }
+
+  try {
+    const ascii = await renderAscii(mmdContent, bmPath, opts);
+
+    if (opts.output) {
+      mkdirSync(dirname(resolve(opts.output)), { recursive: true });
+      writeFileSync(resolve(opts.output), ascii, "utf-8");
+      console.error(`✓ ASCII output saved to: ${resolve(opts.output)}`);
+    } else {
+      // Print to stdout
+      console.log(ascii);
+    }
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
+    console.error("");
+    console.error("Tip: ASCII rendering requires beautiful-mermaid.");
+    console.error("Supported diagram types: flowchart, sequence, state, class, ER.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(1);
+});

--- a/.windsurf/skills/mermaid-studio/scripts/render.mjs
+++ b/.windsurf/skills/mermaid-studio/scripts/render.mjs
@@ -1,0 +1,600 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/render.mjs
+ *
+ * Dual-engine Mermaid renderer with automatic fallback and icon pack support.
+ * Primary: @mermaid-js/mermaid-cli (mmdc) — supports all diagram types, PNG/SVG/PDF
+ * Fallback: beautiful-mermaid — better themes, SVG output
+ * Icon mode: Puppeteer-based custom renderer — registers icon packs for architecture-beta
+ *
+ * Usage:
+ *   node render.mjs --input diagram.mmd --output diagram.svg [--format svg|png|pdf] [--theme default] [--width 1200] [--config '{}']
+ *   node render.mjs --input diagram.mmd --output diagram.svg --icons logos,fa
+ *   echo "graph LR; A-->B" | node render.mjs --stdin --output out.svg
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, extname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+// --- Argument parsing ---
+
+function parseArgs(args) {
+  const opts = {
+    input: null,
+    output: null,
+    format: "svg",
+    theme: "default",
+    width: 1200,
+    height: null,
+    config: null,
+    stdin: false,
+    engine: "auto", // auto | mmdc | beautiful-mermaid | puppeteer
+    background: "white",
+    icons: [], // icon pack names to register (e.g., ['logos', 'fa'])
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--input":
+      case "-i":
+        opts.input = args[++i];
+        break;
+      case "--output":
+      case "-o":
+        opts.output = args[++i];
+        break;
+      case "--format":
+      case "-f":
+        opts.format = args[++i];
+        break;
+      case "--theme":
+      case "-t":
+        opts.theme = args[++i];
+        break;
+      case "--width":
+      case "-w":
+        opts.width = parseInt(args[++i], 10);
+        break;
+      case "--height":
+        opts.height = parseInt(args[++i], 10);
+        break;
+      case "--config":
+      case "-c":
+        opts.config = args[++i];
+        break;
+      case "--stdin":
+        opts.stdin = true;
+        break;
+      case "--engine":
+      case "-e":
+        opts.engine = args[++i];
+        break;
+      case "--background":
+      case "--bg":
+        opts.background = args[++i];
+        break;
+      case "--icons":
+        opts.icons = args[++i].split(",").map((s) => s.trim()).filter(Boolean);
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`
+Mermaid Studio — Render Script
+
+Usage:
+  node render.mjs --input <file.mmd> --output <file.svg> [options]
+  echo "graph LR; A-->B" | node render.mjs --stdin --output out.svg
+
+Options:
+  --input, -i     Input .mmd file path
+  --output, -o    Output file path (required)
+  --format, -f    Output format: svg (default), png, pdf
+  --theme, -t     Theme name (see SKILL.md for available themes)
+  --width, -w     Width in pixels for PNG (default: 1200)
+  --height        Height in pixels for PNG (auto-calculated if omitted)
+  --config, -c    JSON string with mermaid config overrides
+  --engine, -e    Force engine: auto (default), mmdc, beautiful-mermaid, puppeteer
+  --background    Background color (default: white)
+  --icons         Comma-separated Iconify pack names to register (e.g., logos,fa)
+                  Use 'logos' for AWS/tech icons, 'fa' for Font Awesome
+                  When specified, uses Puppeteer-based renderer for proper icon support
+  --stdin         Read diagram from stdin
+  --help, -h      Show this help
+`);
+}
+
+// --- Icon pack CDN URLs ---
+
+const ICON_PACK_URLS = {
+  logos: "https://unpkg.com/@iconify-json/logos/icons.json",
+  fa: "https://unpkg.com/@iconify-json/fa6-regular/icons.json",
+  "fa-solid": "https://unpkg.com/@iconify-json/fa6-solid/icons.json",
+  "fa-brands": "https://unpkg.com/@iconify-json/fa6-brands/icons.json",
+  mdi: "https://unpkg.com/@iconify-json/mdi/icons.json",
+  "simple-icons": "https://unpkg.com/@iconify-json/simple-icons/icons.json",
+};
+
+// --- Engine detection ---
+
+function shellQuote(p) {
+  // Wrap path in single quotes and escape any internal single quotes
+  return `'${p.replace(/'/g, "'\\''")}' `;
+}
+
+function isMmdcAvailable() {
+  try {
+    const mmdcPaths = [
+      resolve(DEPS_DIR, "node_modules/.bin/mmdc"),
+      "mmdc",
+    ];
+    for (const p of mmdcPaths) {
+      try {
+        execSync(`${shellQuote(p)} --version`, { stdio: "pipe", timeout: 10000 });
+        return p;
+      } catch {
+        continue;
+      }
+    }
+    // Try npx
+    execSync("npx mmdc --version", { stdio: "pipe", timeout: 15000 });
+    return "npx mmdc";
+  } catch {
+    return null;
+  }
+}
+
+function isBeautifulMermaidAvailable() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/beautiful-mermaid"),
+    resolve(process.cwd(), "node_modules/beautiful-mermaid"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function isPuppeteerAvailable() {
+  const paths = [
+    resolve(DEPS_DIR, "node_modules/puppeteer"),
+    resolve(DEPS_DIR, "node_modules/puppeteer-core"),
+  ];
+  for (const p of paths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+// --- beautiful-mermaid themes ---
+
+const BEAUTIFUL_MERMAID_THEMES = new Set([
+  "zinc-light",
+  "zinc-dark",
+  "tokyo-night",
+  "tokyo-night-storm",
+  "tokyo-night-light",
+  "catppuccin-mocha",
+  "catppuccin-latte",
+  "nord",
+  "nord-light",
+  "dracula",
+  "github-dark",
+  "github-light",
+  "solarized-dark",
+  "solarized-light",
+  "one-dark",
+]);
+
+const MMDC_THEMES = new Set(["default", "forest", "dark", "neutral", "base"]);
+
+// --- Rendering engines ---
+
+async function renderWithMmdc(mmdcPath, inputFile, outputFile, opts) {
+  const puppeteerConfig = resolve(DEPS_DIR, "puppeteer-config.json");
+  const configFile = resolve(DEPS_DIR, ".mermaid-render-config.json");
+
+  // Build mermaid config — respect %%{init}%% directives in the input file
+  const inputContent = readFileSync(inputFile, "utf-8");
+  const hasInitDirective = inputContent.includes("%%{init");
+  let mermaidConfig = {};
+  if (!hasInitDirective) {
+    mermaidConfig.theme = opts.theme;
+  }
+  if (opts.config) {
+    try {
+      const userConfig = JSON.parse(opts.config);
+      mermaidConfig = { ...mermaidConfig, ...userConfig };
+    } catch (e) {
+      console.warn(`Warning: Could not parse --config JSON: ${e.message}`);
+    }
+  }
+
+  writeFileSync(configFile, JSON.stringify(mermaidConfig, null, 2));
+
+  let cmd = `${shellQuote(mmdcPath)} -i ${shellQuote(inputFile)} -o ${shellQuote(outputFile)}`;
+  cmd += ` -c ${shellQuote(configFile)}`;
+  cmd += ` -b ${shellQuote(opts.background)}`;
+
+  if (opts.format === "png") {
+    cmd += ` -w ${opts.width}`;
+    if (opts.height) cmd += ` -H ${opts.height}`;
+    cmd += ` -s 3`; // 3x scale for crisp PNGs
+  }
+
+  if (existsSync(puppeteerConfig)) {
+    cmd += ` -p ${shellQuote(puppeteerConfig)}`;
+  }
+
+  try {
+    execSync(cmd, { stdio: "pipe", timeout: 60000 });
+    return true;
+  } catch (e) {
+    const stderr = e.stderr?.toString() || "";
+    console.error(`mmdc failed: ${stderr.slice(0, 200)}`);
+    return false;
+  }
+}
+
+async function renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts) {
+  // Dynamic import of beautiful-mermaid
+  try {
+    const bm = await import(resolve(bmPath, "index.js")).catch(() =>
+      import(resolve(bmPath, "dist/index.js")).catch(() =>
+        import(resolve(bmPath, "src/index.js"))
+      )
+    );
+
+    const mmdContent = readFileSync(inputFile, "utf-8");
+    const renderFn = bm.renderMermaid || bm.render || bm.default?.renderMermaid || bm.default?.render;
+
+    if (!renderFn) {
+      // If no direct function, try renderMermaidSvg
+      const renderSvg = bm.renderMermaidSvg || bm.default?.renderMermaidSvg;
+      if (renderSvg) {
+        const svg = await renderSvg(mmdContent, { theme: opts.theme });
+        writeFileSync(outputFile, svg, "utf-8");
+        return true;
+      }
+      console.error("Could not find render function in beautiful-mermaid");
+      return false;
+    }
+
+    const result = await renderFn(mmdContent, {
+      theme: opts.theme,
+      format: opts.format === "png" ? "png" : "svg",
+    });
+
+    if (typeof result === "string") {
+      writeFileSync(outputFile, result, "utf-8");
+    } else if (Buffer.isBuffer(result)) {
+      writeFileSync(outputFile, result);
+    } else if (result?.svg) {
+      writeFileSync(outputFile, result.svg, "utf-8");
+    } else if (result?.data) {
+      writeFileSync(outputFile, result.data);
+    }
+
+    return true;
+  } catch (e) {
+    console.error(`beautiful-mermaid failed: ${e.message}`);
+    return false;
+  }
+}
+
+async function renderWithPuppeteer(inputFile, outputFile, opts) {
+  const puppeteerPath = isPuppeteerAvailable();
+  if (!puppeteerPath) {
+    console.error("Puppeteer not available for icon-enabled rendering. Run setup.sh first.");
+    return false;
+  }
+
+  try {
+    const { createRequire } = await import("module");
+    const require = createRequire(import.meta.url);
+    const puppeteer = require(puppeteerPath);
+    const mmdContent = readFileSync(inputFile, "utf-8");
+
+    // Build icon pack registration code
+    const iconRegistrations = opts.icons
+      .filter((name) => ICON_PACK_URLS[name])
+      .map(
+        (name) =>
+          `{ name: '${name}', loader: () => fetch('${ICON_PACK_URLS[name]}').then(r => r.json()) }`
+      )
+      .join(",\n      ");
+
+    // Build mermaid config
+    let mermaidConfig = {};
+    if (opts.config) {
+      try {
+        mermaidConfig = JSON.parse(opts.config);
+      } catch (e) {
+        console.warn(`Warning: Could not parse --config JSON: ${e.message}`);
+      }
+    }
+
+    const htmlContent = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { margin: 0; padding: 20px; background: ${opts.background}; font-family: 'trebuchet ms', 'verdana', 'arial', sans-serif; }
+    #container { display: inline-block; }
+    svg { max-width: none !important; }
+    .error { color: red; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: '${mermaidConfig.theme || opts.theme || "default"}',
+      ${mermaidConfig.themeVariables ? `themeVariables: ${JSON.stringify(mermaidConfig.themeVariables)},` : ""}
+      securityLevel: 'loose',
+      logLevel: 'error',
+    });
+
+    ${opts.icons.length > 0
+        ? `mermaid.registerIconPacks([
+      ${iconRegistrations}
+    ]);`
+        : ""
+      }
+
+    try {
+      // Small delay to ensure icon packs are loaded
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const { svg } = await mermaid.render('mermaid-diagram', ${JSON.stringify(mmdContent)});
+      document.getElementById('container').innerHTML = svg;
+      window.__mermaidRendered = true;
+      window.__mermaidSvg = svg;
+    } catch (e) {
+      document.getElementById('container').innerHTML = '<pre class="error">' + e.message + '</pre>';
+      window.__mermaidRendered = true;
+      window.__mermaidError = e.message;
+    }
+  </script>
+</body>
+</html>`;
+
+    // Write temp HTML
+    const tempHtml = resolve(DEPS_DIR, ".mermaid-icon-render.html");
+    mkdirSync(dirname(tempHtml), { recursive: true });
+    writeFileSync(tempHtml, htmlContent, "utf-8");
+
+    // Launch Puppeteer
+    const browser = await puppeteer.launch({
+      headless: "new",
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: opts.width || 1200, height: 800, deviceScaleFactor: 3 });
+    await page.goto(`file://${tempHtml}`, { waitUntil: "networkidle0", timeout: 30000 });
+
+    // Wait for render
+    await page.waitForFunction("window.__mermaidRendered === true", { timeout: 15000 });
+
+    // Check for errors
+    const error = await page.evaluate(() => window.__mermaidError);
+    if (error) {
+      console.error(`Mermaid render error: ${error}`);
+      await browser.close();
+      return false;
+    }
+
+    if (opts.format === "png") {
+      // Screenshot approach for PNG
+      await page.screenshot({ path: outputFile, type: "png", fullPage: true, omitBackground: opts.background === "transparent" });
+    } else {
+      // Extract SVG
+      const svg = await page.evaluate(() => window.__mermaidSvg);
+      if (svg) {
+        writeFileSync(outputFile, svg, "utf-8");
+      }
+    }
+
+    await browser.close();
+
+    // Clean up temp file
+    try {
+      const { unlinkSync } = await import("fs");
+      unlinkSync(tempHtml);
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return true;
+  } catch (e) {
+    console.error(`Puppeteer renderer failed: ${e.message}`);
+    return false;
+  }
+}
+
+// --- Read input ---
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+// --- Auto-detect if diagram needs icon packs ---
+
+function diagramNeedsIcons(content) {
+  // Check if the diagram uses external icon references
+  const iconPatterns = [
+    /logos:\w/,
+    /fa:\w/,
+    /fa6-\w+:\w/,
+    /mdi:\w/,
+    /simple-icons:\w/,
+    /aws:\w/,
+  ];
+  return iconPatterns.some((p) => p.test(content));
+}
+
+// --- Main ---
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Validate args
+  if (!opts.output) {
+    console.error("Error: --output is required");
+    process.exit(1);
+  }
+
+  // Determine format from output extension if not explicitly set
+  if (!process.argv.includes("--format") && !process.argv.includes("-f")) {
+    const ext = extname(opts.output).toLowerCase();
+    if (ext === ".png") opts.format = "png";
+    else if (ext === ".pdf") opts.format = "pdf";
+    else opts.format = "svg";
+  }
+
+  // Get input content
+  let inputFile;
+  if (opts.stdin) {
+    const content = await readFromStdin();
+    inputFile = resolve(DEPS_DIR, ".mermaid-stdin-temp.mmd");
+    mkdirSync(dirname(inputFile), { recursive: true });
+    writeFileSync(inputFile, content, "utf-8");
+  } else if (opts.input) {
+    inputFile = resolve(opts.input);
+    if (!existsSync(inputFile)) {
+      console.error(`Error: Input file not found: ${inputFile}`);
+      process.exit(1);
+    }
+  } else {
+    console.error("Error: --input or --stdin is required");
+    process.exit(1);
+  }
+
+  // Ensure output directory exists
+  mkdirSync(dirname(resolve(opts.output)), { recursive: true });
+  const outputFile = resolve(opts.output);
+
+  // Auto-detect icon needs
+  const mmdContent = readFileSync(inputFile, "utf-8");
+  const needsIcons = opts.icons.length > 0 || diagramNeedsIcons(mmdContent);
+
+  if (needsIcons && opts.icons.length === 0) {
+    // Auto-detect which icon packs are needed
+    if (/logos:\w/.test(mmdContent)) opts.icons.push("logos");
+    if (/fa:\w/.test(mmdContent) || /fa6-\w+:\w/.test(mmdContent)) opts.icons.push("fa");
+    if (/mdi:\w/.test(mmdContent)) opts.icons.push("mdi");
+    console.log(`Auto-detected icon packs needed: ${opts.icons.join(", ")}`);
+  }
+
+  // Detect engines
+  const mmdcPath = isMmdcAvailable();
+  const bmPath = isBeautifulMermaidAvailable();
+  const hasPuppeteer = isPuppeteerAvailable();
+
+  console.log(`Input:  ${inputFile}`);
+  console.log(`Output: ${outputFile}`);
+  console.log(`Format: ${opts.format}`);
+  console.log(`Theme:  ${opts.theme}`);
+  console.log(`Icons:  ${opts.icons.length > 0 ? opts.icons.join(", ") : "none"}`);
+  console.log(`Engines: mmdc=${mmdcPath ? "yes" : "no"}, beautiful-mermaid=${bmPath ? "yes" : "no"}, puppeteer=${hasPuppeteer ? "yes" : "no"}`);
+
+  let success = false;
+
+  // Determine engine order based on theme, format, and icons
+  const isBeautifulTheme = BEAUTIFUL_MERMAID_THEMES.has(opts.theme);
+  const needsPng = opts.format === "png" || opts.format === "pdf";
+
+  if (needsIcons) {
+    // Icon mode: Use Puppeteer-based renderer
+    console.log("Using Puppeteer renderer (icon packs required)...");
+    success = await renderWithPuppeteer(inputFile, outputFile, opts);
+    if (!success && mmdcPath) {
+      console.log("Falling back to mmdc (icons may not render)...");
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+    }
+  } else if (opts.engine === "mmdc") {
+    // Forced mmdc
+    if (mmdcPath) {
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: mmdc not available. Run setup.sh first.");
+    }
+  } else if (opts.engine === "beautiful-mermaid") {
+    // Forced beautiful-mermaid
+    if (bmPath) {
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: beautiful-mermaid not available. Run setup.sh first.");
+    }
+  } else if (opts.engine === "puppeteer") {
+    // Forced Puppeteer
+    success = await renderWithPuppeteer(inputFile, outputFile, opts);
+  } else {
+    // Auto selection
+    if (isBeautifulTheme && bmPath && !needsPng) {
+      // beautiful-mermaid theme requested, try it first
+      console.log("Using beautiful-mermaid (theme match)...");
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+      if (!success && mmdcPath) {
+        console.log("Falling back to mmdc...");
+        const fallbackOpts = { ...opts, theme: "default" };
+        success = await renderWithMmdc(mmdcPath, inputFile, outputFile, fallbackOpts);
+      }
+    } else if (mmdcPath) {
+      // Default: mmdc first (best compatibility)
+      console.log("Using mmdc (primary)...");
+      success = await renderWithMmdc(mmdcPath, inputFile, outputFile, opts);
+      if (!success && bmPath && !needsPng) {
+        console.log("Falling back to beautiful-mermaid...");
+        success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+      }
+    } else if (bmPath && !needsPng) {
+      // Only beautiful-mermaid available
+      console.log("Using beautiful-mermaid (only engine available)...");
+      success = await renderWithBeautifulMermaid(bmPath, inputFile, outputFile, opts);
+    } else {
+      console.error("Error: No rendering engine available. Run setup.sh first.");
+      console.error(`  bash ${resolve(__dirname, "setup.sh")}`);
+      process.exit(1);
+    }
+  }
+
+  if (success && existsSync(outputFile)) {
+    const stats = readFileSync(outputFile);
+    console.log(`\n✓ Rendered successfully: ${outputFile} (${stats.length} bytes)`);
+  } else {
+    console.error("\n✗ Rendering failed.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(1);
+});

--- a/.windsurf/skills/mermaid-studio/scripts/setup.sh
+++ b/.windsurf/skills/mermaid-studio/scripts/setup.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# mermaid-studio/scripts/setup.sh
+# Auto-installs rendering dependencies. Run once per environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_DIR="${MERMAID_STUDIO_DIR:-$SKILL_DIR/.deps}"
+
+echo "=== Mermaid Studio — Dependency Setup ==="
+echo "Install directory: $INSTALL_DIR"
+
+# Ensure Node.js is available
+if ! command -v node &>/dev/null; then
+    echo "ERROR: Node.js is required but not found."
+    echo "Install Node.js 18+ from https://nodejs.org"
+    exit 1
+fi
+
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+    echo "WARNING: Node.js 18+ recommended. Found: $(node -v)"
+fi
+
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# Initialize package.json if missing
+if [ ! -f package.json ]; then
+    echo '{"name":"mermaid-studio-deps","version":"1.0.0","private":true,"type":"module"}' > package.json
+fi
+
+echo ""
+echo "--- Installing @mermaid-js/mermaid-cli (primary renderer) ---"
+npm install --save @mermaid-js/mermaid-cli 2>&1 | tail -3
+
+echo ""
+echo "--- Installing beautiful-mermaid (secondary renderer + ASCII) ---"
+npm install --save beautiful-mermaid 2>&1 | tail -3
+
+echo ""
+echo "--- Installing mermaid (for validation) ---"
+npm install --save mermaid 2>&1 | tail -3
+
+echo ""
+echo "--- Installing puppeteer (for icon-enabled rendering) ---"
+npm install --save puppeteer 2>&1 | tail -3
+
+# Create puppeteer config for headless rendering
+cat > "$INSTALL_DIR/puppeteer-config.json" << 'PCONF'
+{
+  "executablePath": "",
+  "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+  "headless": true
+}
+PCONF
+
+# Try to install Chromium for Puppeteer
+echo ""
+echo "--- Installing Chromium for Puppeteer ---"
+npx puppeteer browsers install chrome 2>&1 | tail -3 || {
+    echo "WARNING: Chromium install failed. mmdc may not work."
+    echo "  Fallback: beautiful-mermaid will be used for SVG rendering."
+    echo "  Or set PUPPETEER_EXECUTABLE_PATH to your Chrome/Chromium binary."
+}
+
+# Verify installations
+echo ""
+echo "=== Verification ==="
+
+if npx --prefix "$INSTALL_DIR" mmdc --version &>/dev/null 2>&1; then
+    echo "✓ mermaid-cli: $(npx --prefix "$INSTALL_DIR" mmdc --version 2>&1)"
+else
+    echo "✗ mermaid-cli: not working (beautiful-mermaid will be used as fallback)"
+fi
+
+if node -e "import('$INSTALL_DIR/node_modules/beautiful-mermaid/index.js').then(() => console.log('ok')).catch(() => console.log('fail'))" 2>/dev/null | grep -q ok; then
+    echo "✓ beautiful-mermaid: installed"
+else
+    # Try CommonJS require as fallback check
+    if node -e "try{require('$INSTALL_DIR/node_modules/beautiful-mermaid');console.log('ok')}catch(e){console.log('fail')}" 2>/dev/null | grep -q ok; then
+        echo "✓ beautiful-mermaid: installed"
+    else
+        echo "⚠ beautiful-mermaid: installed (module check inconclusive, may still work)"
+    fi
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Dependency directory: $INSTALL_DIR"
+echo ""
+echo "Usage:"
+echo "  node $SKILL_DIR/scripts/render.mjs --input diagram.mmd --output diagram.svg"
+echo "  node $SKILL_DIR/scripts/render-ascii.mjs --input diagram.mmd"
+echo "  node $SKILL_DIR/scripts/validate.mjs diagram.mmd"

--- a/.windsurf/skills/mermaid-studio/scripts/validate.mjs
+++ b/.windsurf/skills/mermaid-studio/scripts/validate.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+/**
+ * mermaid-studio/scripts/validate.mjs
+ *
+ * Validates Mermaid diagram syntax before rendering.
+ * Uses mermaid library's parser for accurate validation.
+ *
+ * Usage:
+ *   node validate.mjs <file.mmd>
+ *   node validate.mjs <file1.mmd> <file2.mmd>
+ *   echo "graph LR; A-->B" | node validate.mjs --stdin
+ *
+ * Exit codes:
+ *   0 = valid
+ *   1 = invalid syntax
+ *   2 = file not found or error
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { basename, dirname, resolve } from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, "..");
+const DEPS_DIR = process.env.MERMAID_STUDIO_DIR || resolve(SKILL_DIR, ".deps");
+
+// Known diagram type keywords for basic pre-validation
+const DIAGRAM_TYPES = [
+  "flowchart",
+  "graph",
+  "sequenceDiagram",
+  "classDiagram",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "erDiagram",
+  "gantt",
+  "pie",
+  "mindmap",
+  "timeline",
+  "gitGraph",
+  "C4Context",
+  "C4Container",
+  "C4Component",
+  "C4Dynamic",
+  "C4Deployment",
+  "sankey-beta",
+  "xychart-beta",
+  "quadrantChart",
+  "block-beta",
+  "architecture-beta",
+  "packet-beta",
+  "kanban",
+  "journey",
+  "requirementDiagram",
+  "zenuml",
+];
+
+async function readFromStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    const rl = createInterface({ input: process.stdin });
+    rl.on("line", (line) => (data += line + "\n"));
+    rl.on("close", () => resolve(data.trim()));
+  });
+}
+
+function stripFrontmatter(content) {
+  // Remove YAML frontmatter (---...---)
+  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  if (match) return match[1].trim();
+  return content.trim();
+}
+
+function stripDirectives(content) {
+  // Remove %%{init: ...}%% directives
+  return content.replace(/%%\{[\s\S]*?\}%%/g, "").trim();
+}
+
+function stripComments(content) {
+  // Remove %% single-line comments
+  return content
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("%%"))
+    .join("\n")
+    .trim();
+}
+
+function detectDiagramType(content) {
+  const cleaned = stripFrontmatter(stripDirectives(stripComments(content)));
+  const firstLine = cleaned.split("\n")[0].trim();
+
+  for (const type of DIAGRAM_TYPES) {
+    if (firstLine.startsWith(type)) {
+      return type;
+    }
+  }
+  return null;
+}
+
+function basicValidation(content, filename) {
+  const errors = [];
+  const warnings = [];
+
+  // Empty check
+  if (!content.trim()) {
+    errors.push("File is empty");
+    return { errors, warnings };
+  }
+
+  // Detect diagram type
+  const cleaned = stripFrontmatter(stripDirectives(content));
+  const diagramType = detectDiagramType(content);
+  if (!diagramType) {
+    const firstLine = stripComments(stripFrontmatter(stripDirectives(content)))
+      .split("\n")[0]
+      .trim();
+    errors.push(
+      `Unknown diagram type. First content line: "${firstLine.slice(0, 50)}". ` +
+      `Expected one of: flowchart, graph, sequenceDiagram, classDiagram, etc.`
+    );
+  }
+
+  // Bracket matching
+  const lines = cleaned.split("\n");
+  let braces = 0;
+  let brackets = 0;
+  let parens = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip comments
+    if (line.trim().startsWith("%%")) continue;
+
+    for (const char of line) {
+      if (char === "{") braces++;
+      if (char === "}") braces--;
+      if (char === "[") brackets++;
+      if (char === "]") brackets--;
+      if (char === "(") parens++;
+      if (char === ")") parens--;
+
+      if (braces < 0)
+        errors.push(`Unmatched '}' at line ${i + 1}`);
+      if (brackets < 0)
+        errors.push(`Unmatched ']' at line ${i + 1}`);
+      if (parens < 0)
+        errors.push(`Unmatched ')' at line ${i + 1}`);
+    }
+  }
+
+  if (braces > 0) errors.push(`Unclosed '{' — missing ${braces} closing brace(s)`);
+  if (brackets > 0) errors.push(`Unclosed '[' — missing ${brackets} closing bracket(s)`);
+  if (parens > 0) errors.push(`Unclosed '(' — missing ${parens} closing paren(s)`);
+
+  // Common reserved words used as bare node IDs
+  const reservedWords = [
+    "end",
+    "graph",
+    "subgraph",
+    "style",
+    "class",
+    "click",
+    "linkStyle",
+    "default",
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("%%")) continue;
+
+    for (const word of reservedWords) {
+      // Check if reserved word is used as a bare node ID (without brackets)
+      const pattern = new RegExp(
+        `(?:^|-->|---|-\\.->|==>|\\s)${word}(?:\\s|-->|---|-\\.->|==>|$)`,
+        "i"
+      );
+      if (pattern.test(trimmed) && !trimmed.includes(`${word}[`) && !trimmed.includes(`${word}(`)) {
+        warnings.push(
+          `Line ${i + 1}: "${word}" is a reserved keyword. Use "${word}Node" or "${word}State" instead.`
+        );
+      }
+    }
+  }
+
+  // Check for common syntax mistakes
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("%%")) continue;
+
+    // Unescaped special characters in labels
+    if (trimmed.includes('[') && trimmed.includes(']')) {
+      const labelMatch = trimmed.match(/\[([^\]]*)\]/g);
+      if (labelMatch) {
+        for (const label of labelMatch) {
+          if (label.includes('"') && !label.startsWith('["')) {
+            warnings.push(
+              `Line ${i + 1}: Unquoted label with double quotes. Wrap in ["..."]: ${label.slice(0, 30)}`
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Node count warning
+  const nodePattern = /\b\w+[\[({]/g;
+  const nodeMatches = cleaned.match(nodePattern) || [];
+  if (nodeMatches.length > 25) {
+    warnings.push(
+      `High node count (~${nodeMatches.length}). Consider splitting into multiple diagrams for readability.`
+    );
+  }
+
+  return { errors, warnings };
+}
+
+async function mermaidParserValidation(content) {
+  // Try to use the mermaid library parser for deep validation
+  try {
+    const mermaidPath = resolve(DEPS_DIR, "node_modules/mermaid");
+    if (!existsSync(mermaidPath)) {
+      return { available: false };
+    }
+
+    const mermaid = await import(resolve(mermaidPath, "dist/mermaid.js")).catch(
+      () => import(resolve(mermaidPath, "dist/mermaid.esm.mjs")).catch(
+        () => null
+      )
+    );
+
+    if (!mermaid) return { available: false };
+
+    const m = mermaid.default || mermaid;
+    if (m.parse) {
+      await m.parse(stripFrontmatter(stripDirectives(content)));
+      return { available: true, valid: true };
+    }
+
+    return { available: false };
+  } catch (e) {
+    return {
+      available: true,
+      valid: false,
+      error: e.message || String(e),
+    };
+  }
+}
+
+function printResult(filename, basicResult, parserResult) {
+  const hasErrors = basicResult.errors.length > 0 || (parserResult?.available && !parserResult?.valid);
+  const hasWarnings = basicResult.warnings.length > 0;
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`File: ${filename}`);
+  console.log(`${"=".repeat(60)}`);
+
+  if (basicResult.errors.length > 0) {
+    console.log("\n❌ ERRORS:");
+    for (const err of basicResult.errors) {
+      console.log(`  • ${err}`);
+    }
+  }
+
+  if (parserResult?.available && !parserResult?.valid) {
+    console.log("\n❌ PARSER ERROR:");
+    console.log(`  • ${parserResult.error}`);
+  }
+
+  if (hasWarnings) {
+    console.log("\n⚠️  WARNINGS:");
+    for (const warn of basicResult.warnings) {
+      console.log(`  • ${warn}`);
+    }
+  }
+
+  if (!hasErrors) {
+    const diagramType = detectDiagramType(
+      readFileSync ? "" : ""
+    );
+    console.log(`\n✅ Valid${parserResult?.available ? " (parser verified)" : " (basic checks only)"}`);
+    if (hasWarnings) {
+      console.log("   (warnings above are non-blocking suggestions)");
+    }
+  }
+
+  return !hasErrors;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Mermaid Studio — Syntax Validator
+
+Usage:
+  node validate.mjs <file.mmd> [<file2.mmd> ...]
+  echo "graph LR; A-->B" | node validate.mjs --stdin
+
+Exit codes:
+  0 = all files valid
+  1 = syntax errors found
+  2 = file not found or runtime error
+`);
+    process.exit(0);
+  }
+
+  let allValid = true;
+
+  if (args.includes("--stdin")) {
+    const content = await readFromStdin();
+    const basicResult = basicValidation(content, "stdin");
+    const parserResult = await mermaidParserValidation(content);
+    if (!printResult("stdin", basicResult, parserResult)) {
+      allValid = false;
+    }
+  } else {
+    for (const arg of args) {
+      if (arg.startsWith("--")) continue;
+
+      const filepath = resolve(arg);
+      if (!existsSync(filepath)) {
+        console.error(`Error: File not found: ${filepath}`);
+        allValid = false;
+        continue;
+      }
+
+      const content = readFileSync(filepath, "utf-8");
+      const basicResult = basicValidation(content, filepath);
+      const parserResult = await mermaidParserValidation(content);
+      if (!printResult(basename(filepath), basicResult, parserResult)) {
+        allValid = false;
+      }
+    }
+  }
+
+  process.exit(allValid ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(`Fatal error: ${e.message}`);
+  process.exit(2);
+});

--- a/.windsurf/skills/tlc-spec-driven/.skill-meta.json
+++ b/.windsurf/skills/tlc-spec-driven/.skill-meta.json
@@ -1,0 +1,4 @@
+{
+  "contentHash": "69867b0e19be1fb556d2e697f0f18f1de0363d1aa2de9d36754d5b107156357c",
+  "downloadedAt": 1776159111004
+}

--- a/.windsurf/skills/tlc-spec-driven/README.md
+++ b/.windsurf/skills/tlc-spec-driven/README.md
@@ -1,0 +1,449 @@
+<p align="center">
+  <img src="https://img.shields.io/badge/Skill-TLC%20Spec--Driven-blue?style=for-the-badge" alt="skill badge" />
+  <img src="https://img.shields.io/badge/Stack-Agnostic-green?style=for-the-badge" alt="stack agnostic" />
+  <img src="https://img.shields.io/badge/Version-2.0.0-purple?style=for-the-badge" alt="version" />
+</p>
+
+<h1 align="center">🎯 TLC Spec-Driven</h1>
+
+<p align="center">
+  <strong>Plan and implement projects with precision. Granular tasks. Clear dependencies. Right tools. Zero ceremony.</strong>
+</p>
+
+<p align="center">
+  <em>From the <a href="https://github.com/tech-leads-club">Tech Lead's Club</a> community</em>
+</p>
+
+<p align="center">
+  <strong>Author:</strong> <a href="https://github.com/felipfr">Felipe Rodrigues</a> · 
+  <a href="https://linkedin.com/in/felipfr">LinkedIn</a>
+</p>
+
+## ✨ What Is This Skill?
+
+**TLC Spec-Driven** transforms how AI agents approach software projects. Instead of a rigid, bureaucratic pipeline, it uses **4 adaptive phases** that auto-size based on complexity — applying full rigor for complex features and skipping ceremony for simple ones:
+
+```
+┌──────────┐   ┌──────────┐   ┌─────────┐   ┌─────────┐
+│ SPECIFY  │ → │  DESIGN  │ → │  TASKS  │ → │ EXECUTE │
+└──────────┘   └──────────┘   └─────────┘   └─────────┘
+   required      optional*      optional*     required
+
+* Agent auto-skips when scope doesn't need it
+```
+
+**The complexity is in the system, not in your workflow.** You talk naturally — the skill decides how deep to go:
+
+| Scope                               | What happens                                                      |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| **Small** (≤3 files)                | Quick mode — describe → implement → verify → commit               |
+| **Medium** (clear feature)          | Specify → Execute (design and tasks inline)                       |
+| **Large** (multi-component)         | Full pipeline with formal design and task breakdown               |
+| **Complex** (ambiguity, new domain) | Full pipeline + gray area discussion + research + interactive UAT |
+
+## 🚀 Quick Start
+
+### Installation
+
+```bash
+npx @tech-leads-club/agent-skills install -s tlc-spec-driven
+```
+
+### First Commands
+
+| What You Want           | Say This                                      |
+| ----------------------- | --------------------------------------------- |
+| Start a new project     | `"Initialize project"` or `"Setup project"`   |
+| Work with existing code | `"Map codebase"` or `"Analyze existing code"` |
+| Plan a feature          | `"Specify feature [name]"`                    |
+| Quick bug fix           | `"Quick fix: [description]"`                  |
+| Resume previous work    | `"Resume work"` or `"Continue"`               |
+
+> 💬 **Natural Conversation, Not Commands**
+>
+> These are trigger phrases, not strict commands. The skill works through **natural conversation** — talk to your agent like you would to a colleague. Say things like _"I want to build an authentication system"_ or _"Fix the login button, it returns 401"_. The agent understands context and intent, not just keywords.
+
+## 📁 Project Structure
+
+The skill creates a `.specs/` directory to organize all project documentation:
+
+```
+.specs/
+├── project/
+│   ├── PROJECT.md      # Vision, goals, tech stack, constraints
+│   ├── ROADMAP.md      # Milestones, features, status tracking
+│   └── STATE.md        # Persistent memory: decisions, blockers, learnings, todos, deferred ideas
+│
+├── codebase/           # Brownfield analysis (existing projects only)
+│   ├── STACK.md        # Technology stack and dependencies
+│   ├── ARCHITECTURE.md # Patterns, data flow, code organization
+│   ├── CONVENTIONS.md  # Naming, style, coding patterns
+│   ├── STRUCTURE.md    # Directory layout and modules
+│   ├── TESTING.md      # Test frameworks and patterns
+│   ├── INTEGRATIONS.md # External services and APIs
+│   └── CONCERNS.md     # Tech debt, risks, fragile areas
+│
+├── features/           # Feature specifications
+│   └── [feature-name]/
+│       ├── spec.md     # Requirements with traceable IDs (FEAT-01, AUTH-02...)
+│       ├── context.md  # User decisions for gray areas (only when needed)
+│       ├── design.md   # Architecture and components (only for large/complex)
+│       └── tasks.md    # Atomic tasks with dependencies (only for large/complex)
+│
+└── quick/              # Ad-hoc tasks (quick mode)
+    └── NNN-slug/
+        ├── TASK.md     # Description + verification
+        └── SUMMARY.md  # What was done + commit
+```
+
+## 🔄 The Four Adaptive Phases
+
+### Specify (always)
+
+**Goal:** Capture WHAT to build with testable, traceable requirements.
+
+The agent acts as a thinking partner — not an interviewer. It asks clarifying questions, challenges vagueness, and captures requirements with traceable IDs:
+
+```markdown
+### P1: User Login ⭐ MVP
+
+**User Story:** As a user, I want to log in so that I can access my account.
+
+| Requirement ID | Acceptance Criteria                                                            |
+| -------------- | ------------------------------------------------------------------------------ |
+| AUTH-01        | WHEN user enters valid credentials THEN system SHALL authenticate and redirect |
+| AUTH-02        | WHEN user enters invalid credentials THEN system SHALL display error message   |
+| AUTH-03        | WHEN user is already logged in THEN system SHALL redirect to dashboard         |
+```
+
+**Discuss gray areas (auto-triggered):** When the spec has ambiguous, user-facing decisions (layout preferences, interaction patterns, error handling style), the agent automatically asks the user about them — creating a `context.md` that locks those decisions before design. This is NOT a separate phase — it only happens within Specify when ambiguity is detected.
+
+### Design (when needed)
+
+**Goal:** Define HOW to build it. Architecture, components, what to reuse.
+
+**Skipped when:** The change is straightforward — no architectural decisions, no new patterns. For simple features, design happens inline during Execute.
+
+**Includes research:** Before designing with unfamiliar tech, the agent follows the **Knowledge Verification Chain** (codebase → project docs → Context7 MCP → web search → flag uncertain). It **never assumes or fabricates** — if it can't find documentation, it says so.
+
+**Output:** `design.md` with architecture diagrams, component definitions, and integration points.
+
+### Tasks (when needed)
+
+**Goal:** Break into GRANULAR, ATOMIC tasks with clear dependencies.
+
+**Skipped when:** There are ≤3 obvious steps. In that case, tasks are listed inline at the start of Execute.
+
+**Safety valve:** If listing inline steps reveals >5 steps or complex dependencies, the agent STOPS and creates a formal `tasks.md` — acknowledging that the Tasks phase was wrongly skipped.
+
+| ❌ Vague Task | ✅ Atomic Tasks                   |
+| ------------- | --------------------------------- |
+| "Create form" | T1: Create email input component  |
+|               | T2: Add email validation function |
+|               | T3: Create submit button          |
+|               | T4: Add form state management     |
+
+Each task includes: What (deliverable), Where (file path), Depends on (prerequisites), Reuses (existing code), Requirement (traceable ID), Done when (verifiable criteria), Commit (message format).
+
+### Execute (always)
+
+**Goal:** Implement one task at a time. Verify. Commit. Repeat.
+
+Every task follows the same cycle:
+
+```
+Plan → Implement → Verify → Commit → Next
+```
+
+**Key principles:**
+
+- **Surgical changes** — Only touch required files
+- **No scope creep** — If it's not in the task, don't touch it. Capture ideas in STATE.md as Deferred Ideas
+- **Verify before commit** — Check all "Done when" criteria
+- **Atomic git commits** — One task = one commit, following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+
+```
+feat(auth): add email validation to login form
+
+refactor(api): extract token refresh logic into service
+
+fix(cart): prevent negative quantity on item decrement
+```
+
+**Feature-level validation** happens after all tasks complete — including acceptance criteria checks, code quality review, and optionally interactive UAT for complex user-facing features.
+
+## ⚡ Quick Mode
+
+For small tasks (bug fixes, config changes, tweaks ≤3 files) that don't need the full pipeline:
+
+```
+You: Quick fix: login button returns 401 because token refresh skips expired check
+
+Agent: Quick Task: Fix token refresh expired check
+       Files: src/services/auth.ts
+       Approach: Add expiry validation before refresh attempt
+       Verify: Login with expired token returns new session, not 401
+
+       [Implements...]
+
+       ✅ Done. Committed: fix(auth): add expiry check to token refresh
+```
+
+**Guardrails:** Max 3 files, max 1 hour, no design decisions, no new dependencies. If any of these are exceeded, the agent recommends the full pipeline.
+
+## 📋 Complete Command Reference
+
+These trigger patterns help the agent recognize your intent, but you don't need to use them verbatim. Speak naturally — the agent understands variations and context.
+
+### Project-Level
+
+| Trigger Pattern                              | Description                                           |
+| -------------------------------------------- | ----------------------------------------------------- |
+| `Initialize project`, `Setup project`        | Create PROJECT.md with vision, goals, and constraints |
+| `Create roadmap`, `Plan features`            | Create ROADMAP.md with milestones and features        |
+| `Map codebase`, `Analyze existing code`      | Create 7 brownfield docs for existing projects        |
+| `Document concerns`, `Find tech debt`        | Identify and document codebase risks                  |
+| `Record decision`, `Log blocker`, `Add todo` | Add entries to STATE.md                               |
+| `Pause work`, `End session`                  | Create handoff for session continuity                 |
+| `Resume work`, `Continue`                    | Load previous state and continue                      |
+
+### Feature-Level (auto-sized)
+
+| Trigger Pattern                           | Description                             |
+| ----------------------------------------- | --------------------------------------- |
+| `Specify feature`, `Define requirements`  | Create spec.md with requirement IDs     |
+| `Discuss feature`, `How should this work` | Capture user decisions for gray areas   |
+| `Design feature`, `Architecture`          | Create design.md with architecture      |
+| `Break into tasks`, `Create tasks`        | Create tasks.md with atomic breakdown   |
+| `Implement task`, `Build`, `Execute`      | Execute specific task with verification |
+| `Validate`, `Verify work`, `UAT`          | Feature-level validation and testing    |
+| `Quick fix`, `Quick task`, `Bug fix`      | Express lane for small changes          |
+
+## 🔁 Workflow Examples
+
+### Starting a New Project
+
+```
+You: Initialize project
+
+Agent: I'll help you set up your project. Let me ask a few questions:
+       1. What are you building?
+       2. Who is it for and what problem does it solve?
+       ...
+
+You: [Answer questions]
+
+Agent: ✅ Created .specs/project/PROJECT.md
+       Next: Would you like to create a roadmap? Say "Create roadmap"
+```
+
+### Working with an Existing Codebase
+
+```
+You: Map codebase
+
+Agent: I'll analyze your existing codebase and document:
+       - Technology stack, Architecture patterns, Coding conventions
+       - Project structure, Testing infrastructure, External integrations
+       - Concerns (tech debt, risks, fragile areas)
+
+       [Analyzes codebase...]
+
+       ✅ Created 7 brownfield docs in .specs/codebase/
+       Next: Initialize project to define goals and roadmap
+```
+
+### Implementing a Feature (auto-sized)
+
+```
+You: Specify feature user-authentication
+
+Agent: [Asks clarifying questions, creates spec.md with requirement IDs]
+       I notice some gray areas in the UX — how should failed login attempts behave?
+       [Discusses gray areas, creates context.md]
+
+You: Design the feature
+
+Agent: [Researches JWT best practices via Context7, creates design.md]
+
+You: Break into tasks
+
+Agent: [Creates tasks.md with 8 atomic tasks + parallel execution plan]
+
+You: Implement T1
+
+Agent: Implementing T1: Create auth service interface
+       Files: src/services/auth.interface.ts
+       Approach: Define interface based on design
+       Verify: Interface compiles, exports correctly
+
+       [Implements...]
+
+       ✅ Committed: feat(auth): create auth service interface
+       Next available: T2, T3 [P] (parallel)
+```
+
+### Quick Bug Fix
+
+```
+You: Quick fix: dark mode toggle doesn't persist after page refresh
+
+Agent: Quick Task: Persist dark mode preference
+       Files: src/hooks/useTheme.ts, src/utils/storage.ts
+       Approach: Save preference to localStorage on toggle
+       Verify: Toggle dark mode, refresh page, preference persists
+
+       [Implements...]
+
+       ✅ Committed: fix(theme): persist dark mode preference to localStorage
+```
+
+### Session Continuity
+
+```
+You: Pause work
+
+Agent: ✅ Created .specs/HANDOFF.md
+       - Feature: user-authentication
+       - Completed: T1, T2 (committed)
+       - In progress: T3 (70%)
+       - Next session: Continue T3, then T4
+
+--- Later, new session ---
+
+You: Resume work
+
+Agent: Resuming user-authentication at T3
+       - Completed: T1 (auth interface), T2 (token storage)
+       - In progress: T3 - auth service at src/services/auth.service.ts:45
+       - Next: Complete T3, then T4 (parallel with T5)
+
+       Continue with T3?
+```
+
+## 🧠 Context Management
+
+The skill is designed to work within context limits:
+
+| Load Strategy          | Documents                                   | Tokens |
+| ---------------------- | ------------------------------------------- | ------ |
+| **Base load** (always) | PROJECT.md, ROADMAP.md, STATE.md            | ~15k   |
+| **On-demand**          | Current spec, context, design, or tasks     | +5-10k |
+| **Never simultaneous** | Multiple feature specs or architecture docs | —      |
+
+**Target:** <40k tokens loaded (20% of context)
+**Reserve:** 160k+ tokens for work, reasoning, outputs
+
+When context exceeds 40k tokens, the skill displays a status indicator and suggests optimizations.
+
+## 🔗 Skill Integrations
+
+TLC Spec-Driven works even better when combined with complementary skills:
+
+| Skill              | Integration                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
+| **mermaid-studio** | Diagrams — architecture overviews, data flows, sequence diagrams                  |
+| **codenavi**       | Code exploration — brownfield mapping, pattern identification, dependency tracing |
+
+The skill automatically detects if these are installed and delegates specialized tasks to them. If not installed, it falls back gracefully and recommends them once per session.
+
+## 📚 Reference Files
+
+The skill includes detailed reference documentation loaded on-demand:
+
+| File                    | Purpose                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `project-init.md`       | Project initialization process and template                            |
+| `roadmap.md`            | Roadmap creation and milestone tracking                                |
+| `brownfield-mapping.md` | Comprehensive codebase analysis (7 docs)                               |
+| `concerns.md`           | Tech debt, risks, and fragile area documentation                       |
+| `specify.md`            | Requirements gathering with traceable IDs                              |
+| `discuss.md`            | Gray area discussion and context capture                               |
+| `design.md`             | Architecture, research, and component design                           |
+| `tasks.md`              | Granular task breakdown methodology                                    |
+| `implement.md`          | Execute: implementation + verification + atomic commits                |
+| `validate.md`           | Feature validation and interactive UAT                                 |
+| `quick-mode.md`         | Express lane for ad-hoc tasks                                          |
+| `session-handoff.md`    | Pause/resume work process                                              |
+| `state-management.md`   | Persistent memory: decisions, blockers, lessons, todos, deferred ideas |
+| `coding-principles.md`  | Behavioral guidelines for implementation                               |
+| `context-limits.md`     | Token budget and monitoring                                            |
+| `code-analysis.md`      | Available tools and fallbacks                                          |
+
+## ⚡ Tips for Best Results
+
+### Do's ✅
+
+- **Start with project initialization** — Even for existing codebases
+- **Be specific about scope** — Clear boundaries prevent creep
+- **Trust the auto-sizing** — The agent applies the right depth
+- **Use natural language** — No need to memorize commands
+- **Say "pause work" before ending** — Enables seamless resumption
+- **Challenge the agent** — If something looks wrong, say so
+
+### Don'ts ❌
+
+- **Don't force all phases** — Let the agent skip what's unnecessary
+- **Don't work on multiple features at once** — One feature per cycle
+- **Don't ignore verification** — Even quick tasks need a verify step
+- **Don't accept vague answers** — If the agent says something fuzzy, ask for specifics
+
+## 💡 Model Recommendation
+
+> **Best results with modern, reasoning-capable models:**
+>
+> - **Claude Opus 4.6 / Sonnet 4.5** — Excellent for all phases
+> - **Gemini 3 Pro / GPT 5.2** — Strong reasoning and large context window
+> - **Gemini 3 Flash / Claude Haiku 4.5** — Great general-purpose performance
+>
+> For cost optimization, the skill will suggest when lighter models are sufficient for simple tasks like validation or session handoff.
+
+## 🤖 Compatibility
+
+This skill works with **any AI coding agent** that supports skills or custom instructions.
+
+**Tested and verified on:**
+
+| Agent                | Status    |
+| -------------------- | --------- |
+| Antigravity (Gemini) | ✅ Tested |
+| Claude Code          | ✅ Tested |
+| GitHub Copilot       | ✅ Tested |
+| Cursor               | ✅ Tested |
+| Opencode             | ✅ Tested |
+
+> **Note:** If your agent supports loading custom instructions or skills, this skill should work. The agents above are simply where it has been actively tested.
+
+## ❓ FAQ
+
+**Q: Can I skip phases?**
+A: Yes! The skill auto-sizes. Design and Tasks are skipped for simple features. Quick mode skips the entire pipeline for small changes. You only get ceremony when scope demands it.
+
+**Q: What if my project already has code?**
+A: Use `"Map codebase"` first. This creates 7 documents analyzing your existing architecture, conventions, stack, and concerns before you start adding features.
+
+**Q: How does requirement traceability work?**
+A: Each requirement gets a unique ID (e.g., `AUTH-01`) in spec.md. Tasks reference these IDs, and validation checks which requirements are verified. You get a clear trail from spec → design → task → commit.
+
+**Q: What are atomic git commits?**
+A: Each task produces exactly one commit following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). This means clean git history, easy bisect for debugging, and simple rollbacks when needed.
+
+**Q: Can I use this for small tasks or quick fixes?**
+A: Yes! Say `"Quick fix: [description]"` for bug fixes, config changes, or small tweaks. You get quality guardrails (verify + commit) without the planning overhead.
+
+**Q: What happens if I close my session mid-task?**
+A: Say `"Pause work"` before ending your session. This creates a handoff document. Next session, say `"Resume work"` to continue exactly where you left off.
+
+**Q: Does this work with any tech stack?**
+A: Yes! The skill is completely stack-agnostic. It works with any language, framework, or architecture.
+
+**Q: What if the agent invents an API or pattern that doesn't exist?**
+A: The skill enforces a strict **Knowledge Verification Chain**: codebase → project docs → Context7 MCP → web search → flag as uncertain. It NEVER fabricates information. If the agent can't find documentation, it will say "I don't know" instead of guessing.
+
+## 📄 License
+
+CC-BY-4.0 © [Tech Lead's Club](https://github.com/tech-leads-club)
+
+<p align="center">
+  <sub>Built with ❤️ by the Tech Lead's Club community</sub>
+</p>

--- a/.windsurf/skills/tlc-spec-driven/SKILL.md
+++ b/.windsurf/skills/tlc-spec-driven/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: tlc-spec-driven
+description: Project and feature planning with 4 adaptive phases - Specify, Design, Tasks, Execute. Auto-sizes depth by complexity. Creates atomic tasks with verification criteria, atomic git commits, requirement traceability, and persistent memory across sessions. Stack-agnostic. Use when (1) Starting new projects (initialize vision, goals, roadmap), (2) Working with existing codebases (map stack, architecture, conventions), (3) Planning features (requirements, design, task breakdown), (4) Implementing with verification and atomic commits, (5) Quick ad-hoc tasks (bug fixes, config changes), (6) Tracking decisions/blockers/deferred ideas across sessions, (7) Pausing/resuming work. Triggers on "initialize project", "map codebase", "specify feature", "discuss feature", "design", "tasks", "implement", "validate", "verify work", "UAT", "quick fix", "quick task", "pause work", "resume work". Do NOT use for architecture decomposition analysis (use architecture skills) or technical design docs (use create-technical-design-doc).
+license: CC-BY-4.0
+metadata:
+  author: Felipe Rodrigues - github.com/felipfr
+  version: 2.0.0
+---
+
+# Tech Lead's Club - Spec-Driven Development
+
+Plan and implement projects with precision. Granular tasks. Clear dependencies. Right tools. Zero ceremony.
+
+```
+┌──────────┐   ┌──────────┐   ┌─────────┐   ┌─────────┐
+│ SPECIFY  │ → │  DESIGN  │ → │  TASKS  │ → │ EXECUTE │
+└──────────┘   └──────────┘   └─────────┘   └─────────┘
+   required      optional*      optional*     required
+
+* Agent auto-skips when scope doesn't need it
+```
+
+## Auto-Sizing: The Core Principle
+
+**The complexity determines the depth, not a fixed pipeline.** Before starting any feature, assess its scope and apply only what's needed:
+
+| Scope       | What                     | Specify                                                 | Design                                          | Tasks                         | Execute                                               |
+| ----------- | ------------------------ | ------------------------------------------------------- | ----------------------------------------------- | ----------------------------- | ----------------------------------------------------- |
+| **Small**   | ≤3 files, one sentence   | **Quick mode** — skip pipeline entirely                 | -                                               | -                             | -                                                     |
+| **Medium**  | Clear feature, <10 tasks | Spec (brief)                                            | Skip — design inline                            | Skip — tasks implicit         | Implement + verify                                    |
+| **Large**   | Multi-component feature  | Full spec + requirement IDs                             | Architecture + components                       | Full breakdown + dependencies | Implement + verify per task                           |
+| **Complex** | Ambiguity, new domain    | Full spec + [discuss gray areas](references/discuss.md) | [Research](references/design.md) + architecture | Breakdown + parallel plan     | Implement + [interactive UAT](references/validate.md) |
+
+**Rules:**
+
+- **Specify and Execute are always required** — you always need to know WHAT and DO it
+- **Design is skipped** when the change is straightforward (no architectural decisions, no new patterns)
+- **Tasks is skipped** when there are ≤3 obvious steps (they become implicit in Execute)
+- **Discuss is triggered within Specify** only when the agent detects ambiguous gray areas that need user input
+- **Interactive UAT is triggered within Execute** only for user-facing features with complex behavior
+- **Quick mode** is the express lane — for bug fixes, config changes, and small tweaks
+
+**Safety valve:** Even when Tasks is skipped, Execute ALWAYS starts by listing atomic steps inline (see [implement.md](references/implement.md)). If that listing reveals >5 steps or complex dependencies, STOP and create a formal `tasks.md` — the Tasks phase was wrongly skipped.
+
+## Project Structure
+
+```
+.specs/
+├── project/
+│   ├── PROJECT.md      # Vision & goals
+│   ├── ROADMAP.md      # Features & milestones
+│   └── STATE.md        # Memory: decisions, blockers, lessons, todos, deferred ideas
+├── codebase/           # Brownfield analysis (existing projects)
+│   ├── STACK.md
+│   ├── ARCHITECTURE.md
+│   ├── CONVENTIONS.md
+│   ├── STRUCTURE.md
+│   ├── TESTING.md
+│   ├── INTEGRATIONS.md
+│   └── CONCERNS.md
+├── features/           # Feature specifications
+│   └── [feature]/
+│       ├── spec.md     # Requirements with traceable IDs
+│       ├── context.md  # User decisions for gray areas (only when discuss is triggered)
+│       ├── design.md   # Architecture & components (only for Large/Complex)
+│       └── tasks.md    # Atomic tasks with verification (only for Large/Complex)
+└── quick/              # Ad-hoc tasks (quick mode)
+    └── NNN-slug/
+        ├── TASK.md
+        └── SUMMARY.md
+```
+
+## Workflow
+
+**New project:**
+
+1. Initialize project → PROJECT.md + ROADMAP.md
+2. For each feature → Specify → (Design) → (Tasks) → Execute (depth auto-sized)
+
+**Existing codebase:**
+
+1. Map codebase → 7 brownfield docs
+2. Initialize project → PROJECT.md + ROADMAP.md
+3. For each feature → same adaptive workflow
+
+**Quick mode:** Describe → Implement → Verify → Commit (for ≤3 files, one-sentence scope)
+
+## Context Loading Strategy
+
+**Base load (~15k tokens):**
+
+- PROJECT.md (if exists)
+- ROADMAP.md (when planning/working on features)
+- STATE.md (persistent memory)
+
+**On-demand load:**
+
+- Codebase docs (when working in existing project)
+- CONCERNS.md (when planning features that touch flagged areas, estimating risk, or modifying fragile components)
+- TESTING.md (when creating tasks or executing — drives test type assignment and gate checks)
+- spec.md (when working on specific feature)
+- context.md (when designing or implementing from user decisions)
+- design.md (when implementing from design)
+- tasks.md (when executing tasks)
+
+**Never load simultaneously:**
+
+- Multiple feature specs
+- Multiple architecture docs
+- Archived documents
+
+**Target:** <40k tokens total context
+**Reserve:** 160k+ tokens for work, reasoning, outputs
+**Monitoring:** Display status when >40k (see [context-limits.md](references/context-limits.md))
+
+## Sub-Agent Delegation
+
+Use sub-agents (the Task tool or equivalent) to keep the main context window lean and enable
+parallel execution. The orchestrating agent plans and coordinates; sub-agents do the heavy lifting.
+
+**When to delegate to a sub-agent:**
+
+| Activity | Delegate? | Why |
+|---|---|---|
+| Research (design phase, brownfield mapping) | Yes | Research output is large; only the summary matters to the main context |
+| Implementing a task | Yes | File reads, edits, test output consume context; only the result matters |
+| Parallel `[P]` tasks | Yes (one per task) | The only way to actually run tasks in parallel |
+| Sequential tasks with no `[P]` | Yes | Keeps implementation artifacts out of the main context |
+| Planning, task creation, validation reports | No | These require the full accumulated context to be coherent |
+| Quick mode tasks | No | Too small to justify the overhead |
+
+**Context each sub-agent receives:**
+
+The orchestrating agent MUST provide each sub-agent with:
+- The specific task definition from tasks.md (What, Where, Depends on, Reuses, Done when, Tests, Gate)
+- Relevant coding principles and conventions (coding-principles.md, CONVENTIONS.md)
+- TESTING.md, if it exists (for gate check commands and test patterns)
+- Any spec/design context the task references
+
+The sub-agent does NOT receive: other tasks' definitions, accumulated chat history, validation reports
+from other tasks, or STATE.md (unless the task explicitly references a decision/blocker).
+
+**What sub-agents return:**
+
+Each sub-agent reports back:
+- Status: Complete | Blocked | Partial
+- Files changed: [list]
+- Gate check result: [pass/fail + test counts]
+- SPEC_DEVIATION markers (if any)
+- Issues encountered (if any)
+
+The orchestrating agent uses this to update tasks.md status, traceability, and decide next steps.
+
+## Commands
+
+**Project-level:**
+| Trigger Pattern | Reference |
+|----------------|-----------|
+| Initialize project, setup project | [project-init.md](references/project-init.md) |
+| Create roadmap, plan features | [roadmap.md](references/roadmap.md) |
+| Map codebase, analyze existing code | [brownfield-mapping.md](references/brownfield-mapping.md) |
+| Document concerns, find tech debt, what's risky | [concerns.md](references/concerns.md) |
+| Record decision, log blocker, add todo | [state-management.md](references/state-management.md) |
+| Pause work, end session | [session-handoff.md](references/session-handoff.md) |
+| Resume work, continue | [session-handoff.md](references/session-handoff.md) |
+
+**Feature-level (auto-sized):**
+| Trigger Pattern | Reference |
+|----------------|-----------|
+| Specify feature, define requirements | [specify.md](references/specify.md) |
+| Discuss feature, capture context, how should this work | [discuss.md](references/discuss.md) |
+| Design feature, architecture | [design.md](references/design.md) |
+| Break into tasks, create tasks | [tasks.md](references/tasks.md) |
+| Implement task, build, execute | [implement.md](references/implement.md) |
+| Validate, verify, test, UAT, walk me through it | [validate.md](references/validate.md) |
+| Quick fix, quick task, small change, bug fix | [quick-mode.md](references/quick-mode.md) |
+
+## Skill Integrations
+
+This skill coexists with other skills. Before specific tasks, check if complementary skills are installed and prefer them when available.
+
+### Diagrams → mermaid-studio
+
+Whenever the workflow requires creating or updating a diagram (architecture overviews, data flows, component diagrams, sequence diagrams, etc.), **always** check if the `mermaid-studio` skill is installed in the user's environment before proceeding. If it is installed, delegate all diagram creation and rendering to it. If it is not installed, proceed with inline mermaid code blocks as usual and recommend the user install `mermaid-studio` for richer diagram capabilities (rendering to SVG/PNG, validation, theming, etc.). Display this recommendation at most once per session.
+
+### Code Exploration → codenavi
+
+Whenever the workflow requires exploring or discovering things in an existing repository (brownfield mapping, code reuse analysis, pattern identification, dependency tracing, etc.), **always** check if the `codenavi` skill is installed in the user's environment before proceeding. If it is installed, delegate code exploration and navigation tasks to it. If it is not installed, fall back to the built-in code analysis tools (see [code-analysis.md](references/code-analysis.md)) and recommend the user install `codenavi` for more effective codebase exploration. Display this recommendation at most once per session.
+
+## Knowledge Verification Chain
+
+When researching, designing, or making any technical decision, follow this chain in strict order. Never skip steps.
+
+```
+Step 1: Codebase → check existing code, conventions, and patterns already in use
+Step 2: Project docs → README, docs/, inline comments, .specs/codebase/
+Step 3: Context7 MCP → resolve library ID, then query for current API/patterns
+Step 4: Web search → official docs, reputable sources, community patterns
+Step 5: Flag as uncertain → "I'm not certain about X — here's my reasoning, but verify"
+```
+
+**Rules:**
+
+- Never skip to Step 5 if Steps 1-4 are available
+- Step 5 is ALWAYS flagged as uncertain — never presented as fact
+- **NEVER assume or fabricate.** If you cannot find an answer, say "I don't know" or "I couldn't find documentation for this". Inventing APIs, patterns, or behaviors causes cascading failures across design → tasks → implementation. Uncertainty is always preferable to fabrication.
+
+## Output Behavior
+
+**Model guidance:** After completing lightweight tasks (validation, state updates, session handoff), naturally mention once that such tasks work well with faster/cheaper models. Track in STATE.md under `Preferences` to avoid repeating. For heavy tasks (brownfield mapping, complex design), briefly note the reasoning requirements before starting.
+
+Be conversational, not robotic. Don't interrupt workflow—add as a natural closing note. Skip if user seems experienced or has already acknowledged the tip.
+
+## Code Analysis
+
+Use available tools with graceful degradation. See [code-analysis.md](references/code-analysis.md).

--- a/.windsurf/skills/tlc-spec-driven/references/brownfield-mapping.md
+++ b/.windsurf/skills/tlc-spec-driven/references/brownfield-mapping.md
@@ -1,0 +1,455 @@
+# Brownfield Mapping
+
+**Trigger:** "Map codebase", "Analyze existing code", "Document current architecture"
+
+**Purpose:** Understand existing project structure before adding features.
+
+## Process
+
+Before starting, check if the `codenavi` skill is available for code exploration (see Skill Integrations in SKILL.md). If available, prefer it for all discovery and navigation tasks below.
+
+**High-level approach:**
+
+1. Explore directory structure systematically
+2. Identify technology stack from dependency manifests
+3. Extract patterns from representative code samples
+4. Document observed conventions and architectures
+5. Catalog external integrations
+6. Identify concerns: tech debt, known bugs, security risks, performance bottlenecks, fragile areas
+
+**Analysis depth:**
+
+- Sample 5-10 representative files per category
+- Focus on consistency and patterns, not exhaustive coverage
+- Extract actual examples, not assumptions
+
+## Output: 7 Files in .specs/codebase/
+
+---
+
+### 1. STACK.md
+
+**Purpose:** Document technology stack and dependencies.
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Extract from:**
+
+- Dependency manifest files
+- Build configuration
+- Runtime configuration
+
+**Document:**
+
+```markdown
+# Tech Stack
+
+**Analyzed:** [date]
+
+## Core
+
+- Framework: [detected name + version]
+- Language: [detected name + version]
+- Runtime: [detected name + version]
+- Package manager: [detected manager]
+
+## Frontend (if applicable)
+
+- UI Framework: [name + version]
+- Styling: [approach + tools]
+- State Management: [library/pattern]
+- Form Handling: [library if present]
+
+## Backend (if applicable)
+
+- API Style: [REST/GraphQL/gRPC + framework]
+- Database: [ORM/query builder + database system]
+- Authentication: [library/approach]
+
+## Testing
+
+- Unit: [framework]
+- Integration: [framework]
+- E2E: [framework if present]
+
+## External Services
+
+- [Category]: [Service name]
+- [Category]: [Service name]
+
+## Development Tools
+
+- [Tool category]: [Tool name]
+```
+
+**Instructions:**
+
+- Extract from actual dependency files
+- Include versions for major dependencies
+- Categorize by purpose
+- Note testing frameworks explicitly
+
+---
+
+### 2. ARCHITECTURE.md
+
+**Purpose:** Document architectural patterns and data flow.
+
+**Size limit:** 4,000 tokens (~2,400 words)
+
+**Extract from:**
+
+- Directory organization
+- Code structure analysis
+- Repeated patterns across files
+
+**Document:**
+
+```markdown
+# Architecture
+
+**Pattern:** [Identified pattern - monolith/microservices/modular/etc]
+
+## High-Level Structure
+
+[Create diagram/description based on actual organization]
+
+## Identified Patterns
+
+### [Pattern Name]
+
+**Location:** [where this pattern lives]
+**Purpose:** [what this achieves]
+**Implementation:** [how it's structured]
+**Example:** [reference to actual file/function]
+
+### [Pattern Name]
+
+[Same structure]
+
+## Data Flow
+
+### [Key Flow - e.g., Authentication/Payment/etc]
+
+[Map actual flow from code analysis]
+
+### [Key Flow]
+
+[Map actual flow]
+
+## Code Organization
+
+**Approach:** [feature-based/layer-based/domain-driven/etc]
+
+**Structure:**
+[Document actual directory organization]
+
+**Module boundaries:**
+[How code is divided into modules/packages]
+```
+
+**Instructions:**
+
+- Identify patterns from actual code, not assumptions
+- Document observed architectural decisions
+- Create flow diagrams for critical paths
+- Reference concrete examples from codebase
+
+---
+
+### 3. CONVENTIONS.md
+
+**Purpose:** Document code style and naming conventions.
+
+**Size limit:** 3,000 tokens (~1,800 words)
+
+**Extract from:**
+
+- Analyzing 5-10 representative files
+- Identifying consistent patterns
+- Observing actual conventions in use
+
+**Document:**
+
+```markdown
+# Code Conventions
+
+## Naming Conventions
+
+**Files:**
+[Observed pattern - document actual approach]
+Examples: [actual filenames from codebase]
+
+**Functions/Methods:**
+[Observed pattern]
+Examples: [actual function names]
+
+**Variables:**
+[Observed pattern]
+Examples: [actual variable names]
+
+**Constants:**
+[Observed pattern]
+Examples: [actual constant names]
+
+## Code Organization
+
+**Import/Dependency Declaration:**
+[Observed ordering pattern]
+[Example from actual file]
+
+**File Structure:**
+[Observed organization within files]
+[Example from actual file]
+
+## Type Safety/Documentation
+
+**Approach:** [Type system/documentation approach used]
+[Example from actual code]
+
+## Error Handling
+
+**Pattern:** [Observed error handling approach]
+[Example from actual code]
+
+## Comments/Documentation
+
+**Style:** [When/how comments are used]
+[Example from actual code]
+```
+
+**Instructions:**
+
+- Extract patterns from actual code samples
+- Document observed conventions, not ideal conventions
+- Include concrete examples from codebase
+- Note exceptions or variations where found
+
+---
+
+### 4. STRUCTURE.md
+
+**Purpose:** Document directory layout and file organization.
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Document:**
+
+```markdown
+# Project Structure
+
+**Root:** [project root path]
+
+## Directory Tree
+
+[Visual tree representation - max 3 levels deep]
+
+## Module Organization
+
+### [Module/Area Name]
+
+**Purpose:** [what this area handles]
+**Location:** [where files live]
+**Key files:** [important files in this area]
+
+### [Module/Area Name]
+
+[Same structure]
+
+## Where Things Live
+
+**[Capability/Feature]:**
+
+- UI/Interface: [location]
+- Business Logic: [location]
+- Data Access: [location]
+- Configuration: [location]
+
+**[Capability/Feature]:**
+[Same structure]
+
+## Special Directories
+
+**[Directory name]:**
+**Purpose:** [what belongs here]
+**Examples:** [key files in this directory]
+```
+
+**Instructions:**
+
+- Create tree view of actual directory structure
+- Limit depth to maintain readability
+- Document purpose of key directories
+- Map capabilities to physical locations
+
+---
+
+### 5. TESTING.md
+
+**Purpose:** Document testing infrastructure and patterns.
+
+**Size limit:** 4,000 tokens (~2,400 words)
+
+**Document:**
+
+```markdown
+# Testing Infrastructure
+
+## Test Frameworks
+
+**Unit/Integration:** [framework name + version]
+**E2E:** [framework name + version]
+**Coverage:** [tool if used]
+
+## Test Organization
+
+**Location:** [where tests live]
+**Naming:** [test file naming pattern]
+**Structure:** [how tests are organized]
+
+## Testing Patterns
+
+### Unit Tests
+
+**Approach:** [observed pattern]
+**Location:** [where unit tests live]
+[Description of actual pattern used]
+
+### Integration Tests
+
+**Approach:** [observed pattern]
+**Location:** [where integration tests live]
+[Description of actual pattern used]
+
+### E2E Tests
+
+**Approach:** [observed pattern if present]
+**Location:** [where E2E tests live]
+[Description of actual pattern used]
+
+## Test Execution
+
+**Commands:** [how to run tests]
+**Configuration:** [test configuration approach]
+
+## Coverage Targets
+
+**Current:** [if measurable]
+**Goals:** [if documented]
+**Enforcement:** [if automated]
+
+## Test Coverage Matrix
+
+Analyze the codebase to determine which code layers require which test types.
+For each layer, document the required test type, file location pattern, and run command.
+
+| Code Layer | Required Test Type          | Location Pattern       | Run Command |
+| ---------- | --------------------------- | ---------------------- | ----------- |
+| [layer]    | [unit/integration/e2e/none] | [glob or path pattern] | [command]   |
+
+## Parallelism Assessment
+
+| Test Type | Parallel-Safe? | Isolation Model | Evidence                      |
+| --------- | -------------- | --------------- | ----------------------------- |
+| [type]    | [Yes/No]       | [description]   | [file/pattern that proves it] |
+
+## Gate Check Commands
+
+| Gate Level | When to Use                            | Command                     |
+| ---------- | -------------------------------------- | --------------------------- |
+| Quick      | After tasks with unit tests only       | [unit test command]         |
+| Full       | After tasks with e2e/integration tests | [unit + e2e commands]       |
+| Build      | After phase completion                 | [build + lint + unit + e2e] |
+```
+
+**Instructions:**
+
+- Identify test frameworks from dependencies and code
+- Document actual testing patterns observed
+- Note test organization approach
+- Include execution instructions
+- **Test Coverage Matrix:** Sample 5-10 existing test files to identify which layers are tested and how. Look at test file locations relative to source to determine patterns. Extract run commands from `package.json`, `project.json`, `Makefile`, CI config. Mark layers with no existing tests as "none" with a note in CONCERNS.md.
+- **Parallelism Assessment:** NOT parallel-safe signals: shared DB connection (same URL from config), table-level cleanup in `beforeEach`/`afterAll` (`.del()`, `DELETE FROM`, `TRUNCATE`), shared mock state reset on globals. Parallel-safe signals: per-test DB creation (Testcontainers, dynamic schema, SQLite in-memory), data namespacing (all data keyed by unique test ID), no shared mutable state between test files, all deps mocked (`jest.fn()`, `vi.fn()`).
+- **Gate Check Commands:** Extract from actual project commands — do not invent commands.
+
+---
+
+### 6. INTEGRATIONS.md
+
+**Purpose:** Document external service integrations.
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+**Document:**
+
+```markdown
+# External Integrations
+
+## [Service Category]
+
+**Service:** [service name]
+**Purpose:** [what this integration provides]
+**Implementation:** [where integration lives in code]
+**Configuration:** [how service is configured]
+**Authentication:** [auth approach if applicable]
+
+## [Service Category]
+
+[Same structure]
+
+## API Integrations
+
+### [API Name]
+
+**Purpose:** [what this API provides]
+**Location:** [where API client/code lives]
+**Authentication:** [auth method]
+**Key endpoints:** [major endpoints used]
+
+## Webhooks
+
+### [Webhook Source]
+
+**Purpose:** [what events are handled]
+**Location:** [webhook handler location]
+**Events:** [event types processed]
+
+## Background Jobs
+
+**Queue system:** [system if used]
+**Location:** [where job definitions live]
+**Jobs:** [key background jobs]
+```
+
+**Instructions:**
+
+- Identify integrations from code and configuration
+- Document authentication approaches
+- Note webhook handlers if present
+- Include background job infrastructure
+
+---
+
+### 7. CONCERNS.md
+
+**Purpose:** Surface actionable warnings about the codebase — tech debt, known bugs, security gaps, performance bottlenecks, fragile areas, scaling limits, risky dependencies, missing features, and test coverage gaps.
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+See [concerns.md](concerns.md) for the full template, guidelines, and examples.
+
+**Instructions:**
+
+- Document only concerns backed by evidence (file paths, measurements, reproduction steps)
+- Include fix approaches, not just problems
+- Omit sections with no findings
+- Prioritize by risk/impact
+- Use professional, solution-oriented tone
+
+---
+
+## Total Context Budget
+
+**Combined:** ~19,000 tokens (10% of context window)
+**Acceptable for:** Brownfield projects requiring codebase understanding
+**Loading strategy:** Load relevant docs on-demand based on task

--- a/.windsurf/skills/tlc-spec-driven/references/code-analysis.md
+++ b/.windsurf/skills/tlc-spec-driven/references/code-analysis.md
@@ -1,0 +1,98 @@
+# Code Analysis Tools
+
+Use graceful degradation for code search and structural analysis.
+
+## Tool Priority
+
+1. **ast-grep** (`sg`) - Structural pattern-based search
+2. **ripgrep** (`rg`) - Fast context-aware text search
+3. **grep** - Standard text search (always available)
+
+## Detection
+
+Check tool availability before use:
+
+```bash
+# Check for ast-grep
+if command -v sg >/dev/null 2>&1; then
+  # Use ast-grep for structural search
+elif command -v rg >/dev/null 2>&1; then
+  # Fall back to ripgrep
+else
+  # Use standard grep as final fallback
+fi
+```
+
+## Usage Examples
+
+**Finding function definitions:**
+
+```bash
+# ast-grep (best - structural)
+sg -p 'function $NAME($$$) { $$$ }'
+
+# ripgrep (fallback - fast text)
+rg '^function\s+\w+\(' --type-add 'source:*.[extension]' -t source
+
+# grep (last resort - basic)
+grep -r '^function ' --include="*.[extension]"
+```
+
+**Finding imports/requires:**
+
+```bash
+# ast-grep
+sg -p 'import { $$$ } from "$MODULE"'
+
+# ripgrep
+rg '^import .* from' --type-add 'source:*.[extension]' -t source
+
+# grep
+grep -r '^import ' --include="*.[extension]"
+```
+
+**Finding class/component definitions:**
+
+```bash
+# ast-grep
+sg -p 'class $NAME { $$$ }'
+
+# ripgrep
+rg '^(class|export class)\s+\w+' --type-add 'source:*.[extension]' -t source
+
+# grep
+grep -r '^class ' --include="*.[extension]"
+```
+
+## Search Scope
+
+**Best practices:**
+
+- Limit to source file extensions relevant to project
+- Exclude directories: `node_modules`, `vendor`, `dist`, `build`, `.git`
+- Focus on source directories: `src`, `lib`, `app`
+- Use file type filters when available
+
+**Performance tips:**
+
+- Use specific patterns over broad searches
+- Limit directory depth with `--max-depth` (ripgrep/grep)
+- Cache results for repeated queries
+
+## Fallback Notice
+
+If ast-grep unavailable, display once per session:
+
+```
+⚠️ ast-grep not detected. Install for more precise structural code analysis.
+   https://ast-grep.github.io/guide/quick-start.html
+```
+
+## When to Use
+
+- Finding usage patterns across codebase
+- Identifying code structure and organization
+- Locating function/class/component definitions
+- Analyzing import/dependency patterns
+- Refactoring impact analysis
+- Code navigation in unfamiliar codebases

--- a/.windsurf/skills/tlc-spec-driven/references/coding-principles.md
+++ b/.windsurf/skills/tlc-spec-driven/references/coding-principles.md
@@ -1,0 +1,56 @@
+# Coding Principles
+
+Behavioral bias, not checklist. Read before every implementation.
+
+---
+
+## Before Coding
+
+- State assumptions explicitly. If uncertain, ask.
+- Multiple interpretations exist? Present all—don't pick silently.
+- Simpler approach exists? Say so. Push back when warranted.
+- Something unclear? Stop. Name what's confusing. Ask.
+- User's approach seems wrong? Disagree honestly. Don't be sycophantic.
+
+---
+
+## During Implementation
+
+### Simplicity
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" not requested
+- No error handling for impossible scenarios
+- 200 lines that could be 50? Rewrite it.
+
+### Surgical Changes
+
+- Don't "improve" adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Match existing style, even if you'd do differently
+- Unrelated dead code noticed? Mention it—don't delete it
+- Remove ONLY imports/variables/functions YOUR changes orphaned
+- Don't remove pre-existing dead code unless asked
+
+### Test Integrity
+
+- NEVER weaken an existing test assertion to make it pass
+- NEVER delete a test to reduce failure count
+- NEVER use the test framework's skip/disable/pending mechanism to bypass a failing test
+- NEVER modify tests written in the RED phase during GREEN phase
+- If a test is genuinely wrong, STOP and confirm with the user before changing it
+- Tests are the spec — implementation conforms to tests, not the other way around
+
+### Goal-Driven
+
+- Transform vague tasks into verifiable goals
+- Multi-step work? State brief plan with verify checkpoints
+- Every changed line must trace directly to user's request
+
+---
+
+## After Each Change
+
+Ask: "Would senior engineer call this overcomplicated?"
+If yes → simplify before proceeding.

--- a/.windsurf/skills/tlc-spec-driven/references/concerns.md
+++ b/.windsurf/skills/tlc-spec-driven/references/concerns.md
@@ -1,0 +1,193 @@
+# Phase: Codebase Concerns
+
+**Trigger:** Part of brownfield mapping, or explicitly "document concerns", "find tech debt", "what's risky in this codebase"
+
+**Purpose:** Surface actionable warnings about the codebase. Focused on "what to watch out for when making changes." This is living documentation, not a complaint list.
+
+## When to Generate
+
+CONCERNS.md is generated as part of the brownfield mapping flow (alongside STACK.md, ARCHITECTURE.md, etc.). It can also be created or updated independently when:
+
+- Exploring a new area of the codebase reveals risks
+- A bug investigation uncovers systemic issues
+- A feature implementation hits unexpected fragility
+- A dependency audit reveals risks
+
+## Process
+
+### 1. Gather Evidence
+
+During codebase exploration, look for concrete signals — not opinions. Evidence sources:
+
+- Code patterns that indicate shortcuts (TODO/FIXME/HACK comments, duplicated logic, missing error handling)
+- Test coverage gaps (untested critical paths, missing edge cases)
+- Dependency manifests (outdated packages, deprecated libraries, security advisories)
+- Performance indicators (N+1 queries, missing indexes, synchronous blocking calls)
+- Security patterns (client-side-only auth checks, unvalidated inputs, exposed secrets)
+
+### 2. Classify and Document
+
+Each concern must have: **what** the problem is, **where** it lives (file paths), **why** it matters (impact), and **how** to fix it (approach).
+
+### 3. Prioritize by Risk
+
+Focus on concerns that could cause real damage — data loss, security breaches, user-facing failures, scaling walls. Minor style issues and normal TODOs do not belong here.
+
+---
+
+## Template: `.specs/codebase/CONCERNS.md`
+
+**Size limit:** 5,000 tokens (~3,000 words)
+
+```markdown
+# Codebase Concerns
+
+**Analysis Date:** [YYYY-MM-DD]
+
+## Tech Debt
+
+**[Area/Component]:**
+
+- Issue: [What's the shortcut/workaround]
+- Files: [Specific file paths with backticks]
+- Why: [Why it was done this way]
+- Impact: [What breaks or degrades because of it]
+- Fix approach: [How to properly address it]
+
+## Known Bugs
+
+**[Bug description]:**
+
+- Symptoms: [What happens]
+- Trigger: [How to reproduce]
+- Files: [Where the bug lives]
+- Workaround: [Temporary mitigation if any]
+- Root cause: [If known]
+- Blocked by: [If waiting on something]
+
+## Security Considerations
+
+**[Area requiring security care]:**
+
+- Risk: [What could go wrong]
+- Files: [Where the risk lives]
+- Current mitigation: [What's in place now]
+- Recommendations: [What should be added]
+
+## Performance Bottlenecks
+
+**[Slow operation/endpoint]:**
+
+- Problem: [What's slow]
+- Files: [Where the bottleneck lives]
+- Measurement: [Actual numbers: "500ms p95", "2s load time"]
+- Cause: [Why it's slow]
+- Improvement path: [How to speed it up]
+
+## Fragile Areas
+
+**[Component/Module]:**
+
+- Files: [Where the fragility lives]
+- Why fragile: [What makes it break easily]
+- Common failures: [What typically goes wrong]
+- Safe modification: [How to change it without breaking]
+- Test coverage: [Is it tested? Gaps?]
+
+## Scaling Limits
+
+**[Resource/System]:**
+
+- Current capacity: [Numbers: "100 req/sec", "10k users"]
+- Limit: [Where it breaks]
+- Symptoms at limit: [What happens]
+- Scaling path: [How to increase capacity]
+
+## Dependencies at Risk
+
+**[Package/Service]:**
+
+- Risk: [e.g., "deprecated", "unmaintained", "breaking changes coming"]
+- Impact: [What breaks if it fails]
+- Migration plan: [Alternative or upgrade path]
+
+## Missing Critical Features
+
+**[Feature gap]:**
+
+- Problem: [What's missing]
+- Current workaround: [How users cope]
+- Blocks: [What can't be done without it]
+- Implementation complexity: [Rough effort estimate]
+
+## Test Coverage Gaps
+
+**[Untested area]:**
+
+- What's not tested: [Specific functionality]
+- Risk: [What could break unnoticed]
+- Priority: [High/Medium/Low]
+- Difficulty to test: [Why it's not tested yet]
+
+---
+
+_Concerns audit: [date]_
+_Update as issues are fixed or new ones discovered_
+```
+
+**Include only sections that have findings.** Empty sections should be omitted entirely.
+
+---
+
+## What Belongs vs. What Doesn't
+
+**Include:**
+
+- Tech debt with clear impact and fix approach
+- Known bugs with reproduction steps
+- Security gaps and mitigation recommendations
+- Performance bottlenecks with measurements
+- Fragile code that breaks easily
+- Scaling limits with numbers
+- Dependencies that need attention
+- Missing features that block workflows
+- Test coverage gaps
+
+**Exclude:**
+
+- Opinions without evidence ("code is messy")
+- Complaints without solutions ("auth sucks")
+- Future feature ideas (that's for product planning)
+- Normal TODOs (those live in code comments)
+- Architectural decisions that are working fine
+- Minor code style issues
+
+---
+
+## Writing Guidelines
+
+- **Always include file paths** — Concerns without locations are not actionable. Use backticks: `src/file.ts`
+- Be specific with measurements ("500ms p95" not "slow")
+- Include reproduction steps for bugs
+- Suggest fix approaches, not just problems
+- Focus on actionable items
+- Prioritize by risk/impact
+
+**Tone:** Professional, not emotional. Solution-oriented. Risk-focused. Factual.
+
+- ✅ "N+1 query pattern in `app/api/courses/route.ts` — 1.2s p95 with 50+ courses"
+- ❌ "Terrible queries, everything is slow"
+- ✅ "Fix: add index on `user_id` in `subscriptions` table"
+- ❌ "Needs fixing"
+
+---
+
+## How CONCERNS.md Gets Used
+
+- **Feature planning:** Check CONCERNS.md before designing features that touch flagged areas
+- **Risk estimation:** Use fragile areas and scaling limits to estimate change risk
+- **Onboarding new sessions:** Load CONCERNS.md to give context about what to watch out for
+- **Refactoring prioritization:** Use tech debt and test coverage gaps to plan improvement sprints
+- **Implementation phase:** Consult before modifying any flagged component
+
+This is living documentation. Update as issues are fixed or new ones discovered during any workflow phase.

--- a/.windsurf/skills/tlc-spec-driven/references/context-limits.md
+++ b/.windsurf/skills/tlc-spec-driven/references/context-limits.md
@@ -1,0 +1,40 @@
+# Context Limits
+
+## File Size Limits
+
+| File            | Max Tokens | ~Words | Warning At  |
+| --------------- | ---------- | ------ | ----------- |
+| PROJECT.md      | 2,000      | 1,200  | 1,600 (80%) |
+| ROADMAP.md      | 3,000      | 1,800  | 2,400       |
+| STATE.md        | 10,000     | 6,000  | 7,000 (70%) |
+| spec.md         | 5,000      | 3,000  | 4,000       |
+| design.md       | 8,000      | 4,800  | 6,400       |
+| tasks.md        | 10,000     | 6,000  | 8,000       |
+| STACK.md        | 2,000      | 1,200  | 1,600       |
+| ARCHITECTURE.md | 4,000      | 2,400  | 3,200       |
+| CONVENTIONS.md  | 3,000      | 1,800  | 2,400       |
+| STRUCTURE.md    | 2,000      | 1,200  | 1,600       |
+| TESTING.md      | 4,000      | 2,400  | 3,200       |
+| INTEGRATIONS.md | 5,000      | 3,000  | 4,000       |
+
+## Context Zones
+
+🟢 **Healthy** (<40k total): Silent
+🟡 **Moderate** (40-60k): Discrete footer note
+🔴 **Critical** (>60k): Active warning, suggest optimization
+
+## Monitoring
+
+Display context status in footer when >40k:
+
+```
+📊 Context: 52k tokens (moderate)
+  - STATE.md: 8k (yellow zone)
+  - tasks.md: 11k (ok)
+  - Total: 52k / 200k (26%)
+```
+
+## Principles
+
+**Target:** <40k tokens loaded (20% of window)
+**Reserve:** 160k+ tokens for work, reasoning, outputs

--- a/.windsurf/skills/tlc-spec-driven/references/design.md
+++ b/.windsurf/skills/tlc-spec-driven/references/design.md
@@ -1,0 +1,166 @@
+# Design
+
+**Goal**: Define HOW to build it. Architecture, components, what to reuse.
+
+**Skip this phase when:** The change is straightforward — no architectural decisions, no new patterns, no component interactions to plan. For simple features, design happens inline during Execute.
+
+## Process
+
+### 1. Load Context
+
+Read `.specs/features/[feature]/spec.md` before designing. If `.specs/features/[feature]/context.md` exists, load it too — it contains implementation decisions that constrain the design (layout choices, behavior preferences, interaction patterns). Decisions marked as "Agent's Discretion" are yours to decide.
+
+### 1.5. Research (Optional but Recommended)
+
+If the feature involves unfamiliar technology, patterns, or integrations, research before designing. Document findings briefly in the design doc or as inline notes. This prevents incorrect assumptions from propagating into tasks.
+
+Follow the **Knowledge Verification Chain** (see SKILL.md) in strict order:
+
+```
+Codebase → Project docs → Context7 MCP → Web search → Flag as uncertain
+```
+
+**CRITICAL: NEVER assume or fabricate information.** If you cannot find an answer through the chain, explicitly say "I don't know" or "I couldn't find documentation for this". Inventing an API, a pattern, or a behavior that doesn't exist is far worse than admitting uncertainty. Wrong assumptions propagate through design → tasks → implementation and cause cascading failures.
+
+Good triggers for research: new libraries, unfamiliar APIs, performance-sensitive features, security-sensitive features, patterns you haven't used in this codebase before.
+
+### 2. Define Architecture
+
+Overview of how components interact. Use mermaid diagrams when helpful. Before creating any diagrams, check if the `mermaid-studio` skill is available (see Skill Integrations in SKILL.md).
+
+### 3. Identify Code Reuse
+
+**CRITICAL**: What existing code can we leverage? This saves tokens and reduces errors.
+
+If `.specs/codebase/CONCERNS.md` exists, check it before designing. Any component flagged as fragile, carrying tech debt, or having test coverage gaps requires extra care in the design — document how the design mitigates those concerns.
+
+### 4. Define Components and Interfaces
+
+Each component: Purpose, Location, Interfaces, Dependencies, What it reuses.
+
+### 5. Define Data Models
+
+If the feature involves data, define models before implementation.
+
+---
+
+## Template: `.specs/[feature]/design.md`
+
+````markdown
+# [Feature] Design
+
+**Spec**: `.specs/[feature]/spec.md`
+**Status**: Draft | Approved
+
+---
+
+## Architecture Overview
+
+[Brief description of the architecture approach]
+
+```mermaid
+graph TD
+    A[User Action] --> B[Component A]
+    B --> C[Service Layer]
+    C --> D[Data Store]
+    B --> E[Component B]
+```
+````
+
+---
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+| Component            | Location            | How to Use                |
+| -------------------- | ------------------- | ------------------------- |
+| [Existing Component] | `src/path/to/file`  | [Extend/Import/Reference] |
+| [Existing Utility]   | `src/utils/file`    | [How it helps]            |
+| [Existing Pattern]   | `src/patterns/file` | [Apply same pattern]      |
+
+### Integration Points
+
+| System         | Integration Method                      |
+| -------------- | --------------------------------------- |
+| [Existing API] | [How new feature connects]              |
+| [Database]     | [How data connects to existing schemas] |
+
+---
+
+## Components
+
+### [Component Name]
+
+- **Purpose**: [What this component does - one sentence]
+- **Location**: `src/path/to/component/`
+- **Interfaces**:
+  - `methodName(param: Type): ReturnType` - [description]
+  - `methodName(param: Type): ReturnType` - [description]
+- **Dependencies**: [What it needs to function]
+- **Reuses**: [Existing code this builds upon]
+
+### [Component Name]
+
+- **Purpose**: [What this component does]
+- **Location**: `src/path/to/component/`
+- **Interfaces**:
+  - `methodName(param: Type): ReturnType`
+- **Dependencies**: [Dependencies]
+- **Reuses**: [Existing code]
+
+---
+
+## Data Models (if applicable)
+
+### [Model Name]
+
+```typescript
+interface ModelName {
+  id: string
+  field1: string
+  field2: number
+  createdAt: Date
+}
+```
+
+**Relationships**: [How this relates to other models]
+
+### [Model Name]
+
+```typescript
+interface AnotherModel {
+  id: string
+  // ...
+}
+```
+
+---
+
+## Error Handling Strategy
+
+| Error Scenario | Handling      | User Impact      |
+| -------------- | ------------- | ---------------- |
+| [Scenario 1]   | [How handled] | [What user sees] |
+| [Scenario 2]   | [How handled] | [What user sees] |
+
+---
+
+## Tech Decisions (only non-obvious ones)
+
+| Decision          | Choice          | Rationale     |
+| ----------------- | --------------- | ------------- |
+| [What we decided] | [What we chose] | [Why - brief] |
+
+---
+
+## Tips
+
+- **Load context first** — If context.md exists, decisions there are locked
+- **Research when uncertain** — 5 minutes of research prevents hours of rework
+- **Reuse is king** — Every component should reference existing patterns
+- **Interfaces first** — Define contracts before implementation
+- **Keep it visual** — Diagrams save 1000 words (check mermaid-studio skill in Skill Integrations)
+- **Small components** — If component does 3+ things, split it
+- **Check CONCERNS.md** — If it exists, flag fragile areas the design must address
+- **Confirm before Tasks** — User approves design before breaking into tasks

--- a/.windsurf/skills/tlc-spec-driven/references/discuss.md
+++ b/.windsurf/skills/tlc-spec-driven/references/discuss.md
@@ -1,0 +1,129 @@
+# Specify: Discuss Gray Areas
+
+**Goal:** Capture HOW the user envisions the feature when the spec has ambiguous areas. This is NOT a separate phase — it's triggered within Specify when the agent detects gray areas that need user input.
+
+**Trigger:** Automatically when gray areas are detected during spec creation, or explicitly via "discuss feature", "how should this work?", "capture context"
+
+**When to trigger (auto-detect):** The spec contains user-facing behavior that could go multiple ways AND the user hasn't expressed a preference. If the spec is clear and unambiguous, skip this entirely.
+
+**When NOT to trigger:** Infrastructure work, CRUD operations, well-defined API contracts, anything where the "how" is obvious from the "what".
+
+## Why This Phase Exists
+
+Specifications capture WHAT to build. Design captures the architecture. But neither captures the user's vision for ambiguous areas — layout preferences, interaction patterns, error handling style, content tone. Without this, the agent guesses. With this, the agent builds what the user actually imagined.
+
+The output — `context.md` — feeds directly into Design and Tasks:
+
+- **Design reads it** to know what decisions are locked vs. flexible
+- **Tasks reads it** to include specific behaviors in task definitions
+
+## Process
+
+### 1. Analyze the Feature
+
+Read `.specs/features/[feature]/spec.md` and identify the domain:
+
+| Domain                         | Gray areas to explore                                         |
+| ------------------------------ | ------------------------------------------------------------- |
+| Something users **SEE**        | Layout, density, interactions, empty states, visual hierarchy |
+| Something users **CALL** (API) | Response format, errors, auth, versioning, rate limiting      |
+| Something users **RUN** (CLI)  | Output format, flags, modes, error handling, verbosity        |
+| Something users **READ**       | Structure, tone, depth, flow, navigation                      |
+| Something being **ORGANIZED**  | Grouping criteria, naming, duplicates, exceptions             |
+
+Generate 3-4 **feature-specific** gray areas. Not generic categories, but concrete decisions for THIS feature.
+
+### 2. Present Gray Areas
+
+Present the feature boundary (from spec.md) and the gray areas to the user. Let them choose which to discuss. Do NOT include a "skip all" option — the user invoked this phase to discuss.
+
+### 3. Deep-Dive Each Area
+
+For each selected area:
+
+1. Ask 3-4 concrete questions with specific options (not vague categories)
+2. After the questions, check: "More about [area], or move on?"
+3. If more → ask 3-4 more, check again
+4. After all areas → "Ready to create context?"
+
+**Question design:**
+
+- Options should be concrete ("Card layout" not "Option A")
+- Each answer should inform the next question
+- Include "You decide" as an option when reasonable — captures agent discretion
+
+### 4. Scope Guardrail (CRITICAL)
+
+The feature boundary from spec.md is **fixed**. Discussion clarifies HOW to implement, never WHETHER to add new capabilities.
+
+**Allowed:** "How should posts be displayed?" (clarifying ambiguity)
+**Not allowed:** "Should we also add comments?" (new capability)
+
+When user suggests scope creep: "That sounds like a separate feature. I'll note it in Deferred Ideas. Back to [current area]."
+
+### 5. Write context.md
+
+---
+
+## Template: `.specs/features/[feature]/context.md`
+
+```markdown
+# [Feature] Context
+
+**Gathered:** [date]
+**Spec:** `.specs/features/[feature]/spec.md`
+**Status:** Ready for design
+
+---
+
+## Feature Boundary
+
+[Clear statement of what this feature delivers — the scope anchor from spec.md]
+
+---
+
+## Implementation Decisions
+
+### [Area 1 that was discussed]
+
+- [Specific decision made]
+- [Another decision if applicable]
+
+### [Area 2 that was discussed]
+
+- [Specific decision made]
+
+### [Area 3 that was discussed]
+
+- [Specific decision made]
+
+### Agent's Discretion
+
+[Areas where user explicitly said "you decide" — agent has flexibility here during design/implementation]
+
+---
+
+## Specific References
+
+[Any "I want it like X" moments, product references, specific behaviors, interaction patterns mentioned during discussion]
+
+[If none: "No specific requirements — open to standard approaches"]
+
+---
+
+## Deferred Ideas
+
+[Ideas that came up during discussion but belong in other features/phases. Captured here so they're not lost, but explicitly out of scope]
+
+[If none: "None — discussion stayed within feature scope"]
+```
+
+---
+
+## Tips
+
+- **Decisions, not vision** — "Card-based layout with subtle shadows" is a decision. "Should feel modern" is not.
+- **Scope is sacred** — Deferred Ideas captures scope creep without losing ideas
+- **User = visionary, Agent = builder** — Ask about how they imagine it, not about technical implementation
+- **Don't ask about:** Technical architecture, performance, implementation details — that's Design's job
+- **Confirm before Design** — User approves context.md before moving to design phase

--- a/.windsurf/skills/tlc-spec-driven/references/implement.md
+++ b/.windsurf/skills/tlc-spec-driven/references/implement.md
@@ -1,0 +1,284 @@
+# Execute
+
+**Goal**: Implement ONE task at a time. Surgical changes. Verify. Commit. Repeat.
+
+This is where code gets written. Every task follows the same cycle: plan → implement → verify → commit. Verification is built into every task, not a separate phase.
+
+---
+
+## MANDATORY: Before Starting Any Implementation
+
+**Read [coding-principles.md](coding-principles.md) and state:**
+
+1. **Assumptions** - What am I assuming? Any uncertainty?
+2. **Files to touch** - List ONLY files this task requires
+3. **Success criteria** - How will I verify this works?
+
+⚠️ **Do not proceed without stating these explicitly.**
+
+---
+
+## Process
+
+**Sub-agent context:** When this task is executed by a sub-agent, the sub-agent receives
+the task definition, coding principles, TESTING.md, and relevant spec/design context.
+All steps below apply identically whether running in the main context or a sub-agent.
+The only difference: sub-agents report results back to the orchestrator rather than
+continuing to the next task.
+
+### 0. List Atomic Steps (MANDATORY when Tasks phase was skipped)
+
+If there is no `tasks.md` for this feature, you MUST list atomic steps before writing any code. This is non-negotiable — it prevents the agent from losing focus and doing too many things at once.
+
+```
+## Execution Plan
+
+1. [Step] → files: [list] → verify: [how] → commit: [message]
+2. [Step] → files: [list] → verify: [how] → commit: [message]
+3. [Step] → files: [list] → verify: [how] → commit: [message]
+```
+
+**Each step must be:**
+
+- ONE deliverable (one component, one function, one endpoint, one file change)
+- Independently verifiable (can prove it works before moving on)
+- Independently committable (gets its own atomic git commit)
+
+If listing steps reveals >5 steps or complex dependencies, STOP and create a formal `tasks.md` instead. The Tasks phase was wrongly skipped.
+
+### 1. Pick Task
+
+From tasks.md (if exists) or from the execution plan above. User specifies ("implement T3") or suggest next available.
+
+### 2. Verify Dependencies
+
+If tasks.md exists, check dependencies. If using inline plan, follow the order listed.
+
+❌ If blocked: "T3 depends on T2 which isn't done. Should I do T2 first?"
+
+### 3. State Implementation Plan
+
+Before writing code:
+
+```
+Files: [list]
+Approach: [brief description]
+Success: [how to verify]
+```
+
+### 4. Write Tests First (RED)
+
+If the task includes tests (per the Tests field in tasks.md or TESTING.md coverage matrix):
+
+1. Write the test file(s) BEFORE writing any implementation
+2. Tests must encode the expected behavior from the task's "Done when" criteria
+3. Run the test command — confirm tests FAIL (RED state)
+4. If tests pass before implementation exists, the tests are too weak — rewrite them
+
+**Constraints:**
+
+- Tests define correct behavior independently of implementation
+- Each acceptance criterion from "Done when" maps to at least one test assertion
+- Edge cases from spec.md that apply to this task get test cases too
+
+If the task does NOT include tests (e.g., entity-only, config-only), skip to Step 4b.
+
+### 4b. Implement (GREEN)
+
+Write the minimum implementation needed to satisfy the task's success criteria: pass all relevant tests (when present) and meet the defined verification/gate checks when there are no direct tests.
+
+**HARD CONSTRAINTS:**
+
+- Do NOT modify tests written in Step 4. The tests are the spec — implementation conforms to them.
+- Do NOT weaken assertions (making them less specific to pass more easily)
+- Do NOT delete or skip test cases
+- Do NOT use the test framework's skip/disable/pending mechanism to bypass failing tests
+- Minimum code to pass — save structural improvements for a refactor task
+
+If a test is genuinely wrong (tests the wrong behavior per spec), STOP and ask the user
+before modifying it. Never silently change a test.
+
+Follow [coding-principles.md](coding-principles.md):
+
+- Simplest code that works
+- Touch ONLY listed files
+- No scope creep
+
+### 5. Gate Check (VERIFY)
+
+Run the gate check command from the task definition. This is MANDATORY — not "if applicable."
+
+1. Look up the command for the task's Gate level (quick/full/build) in TESTING.md's Gate Check Commands section, then run it
+2. Non-zero exit code = STOP. Fix the failure. Re-run. Do not proceed until green.
+3. Confirm the test count matches expectations (no tests were silently deleted or skipped)
+
+**Tiered gates (from TESTING.md Gate Check Commands):**
+
+| Task includes                    | Gate level | What runs                |
+| -------------------------------- | ---------- | ------------------------ |
+| Unit tests only                  | Quick      | Unit test command        |
+| E2E or integration tests         | Full       | Unit + E2E commands      |
+| Last task in a phase             | Build      | Build + lint + all tests |
+| No tests (config, entities, etc) | Build      | Build + lint only        |
+
+The gate check is deterministic. The test runner decides if the code is correct,
+not the agent's self-assessment.
+
+### 6. Post-Gate Review
+
+After the gate check passes:
+
+1. Verify test count: Are there at least as many test cases as before? (prevents silent deletion)
+2. Verify no SPEC_DEVIATION: If implementation diverged from spec/design, add a marker:
+
+```
+// SPEC_DEVIATION: [what diverged]
+// Reason: [why the deviation was necessary]
+```
+
+3. Quick complexity check: "Would senior engineer flag this as overcomplicated?"
+   - Yes → Simplify, re-run gate
+   - No → Proceed to commit
+
+### 7. Atomic Git Commit
+
+Each task gets its own commit immediately after verification. Never batch multiple tasks into one commit.
+
+**Format ([Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)):**
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+| Type       | When to use                                             |
+| ---------- | ------------------------------------------------------- |
+| `feat`     | New feature or capability                               |
+| `fix`      | Bug fix                                                 |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `docs`     | Documentation only                                      |
+| `test`     | Adding or correcting tests                              |
+| `style`    | Formatting, missing semicolons, etc. (no code change)   |
+| `perf`     | Performance improvement                                 |
+| `build`    | Build system or external dependencies                   |
+| `ci`       | CI configuration files and scripts                      |
+| `chore`    | Maintenance tasks that don't modify src or test files   |
+
+**Scope:** Feature name or module area, lowercase, e.g., `auth`, `cart`, `api`
+
+**Description rules:**
+
+- Imperative mood ("add", not "added" or "adds")
+- Lowercase first letter
+- No period at the end
+- Complete the sentence: "If applied, this commit will _[your description]_"
+
+**Breaking changes:** Append `!` after type/scope AND add `BREAKING CHANGE:` footer:
+
+```
+feat(api)!: change authentication endpoint response format
+
+BREAKING CHANGE: login endpoint now returns JWT in body instead of cookie
+```
+
+**Examples:**
+
+```
+feat(auth): add email validation to login form
+```
+
+```
+fix(cart): prevent negative quantity on item decrement
+```
+
+```
+refactor(api): extract token refresh logic into service
+
+Move token refresh from inline handler to dedicated AuthTokenService
+for reuse across multiple endpoints.
+```
+
+**Rules:**
+
+- One task = one commit
+- Description references what was DONE, not what was planned
+- Include only files listed in the task — never sneak in "while I'm here" changes
+- If tests are part of the task, include them in the same commit
+
+### 8. Scope Guardrail
+
+During implementation, you will notice things that could be improved, refactored, or added. **Do not act on them.** Instead:
+
+- If it's a bug: note it in STATE.md as a blocker or use quick mode
+- If it's an improvement: note it in STATE.md under "Deferred Ideas" or "Lessons Learned"
+- If it's related to the current task: only include it if it's in the "Done when" criteria
+
+**The heuristic:** "Is this in my task definition?" If no, don't touch it.
+
+### 9. Update Task Status
+
+Mark task complete in tasks.md. Update requirement traceability in spec.md if requirement IDs are used.
+
+---
+
+## Execution Template
+
+```markdown
+## Implementing T[X]: [Task Title]
+
+**Reading**: task definition from tasks.md
+**Dependencies**: [All done? ✅ | Blocked by: TY]
+**Tests**: [unit/e2e/integration/none]
+**Gate**: [quick/full/build]
+
+### Pre-Implementation (MANDATORY)
+
+- **Assumptions**: [state explicitly]
+- **Files to touch**: [list ONLY these]
+- **Success criteria**: [how to verify]
+
+### RED: Write Tests
+
+- Test file(s): [paths]
+- Test count: [N test cases]
+- Confirmed failing: [Yes — all N tests fail as expected]
+
+### GREEN: Implement
+
+[Write minimum code to pass tests]
+
+- Tests modified: None
+- Tests skipped/deleted: None
+
+### VERIFY: Gate Check
+
+- Command: [gate check command]
+- Result: [X passed, 0 failed]
+- Test count: [N — matches RED phase count]
+
+### Post-Gate
+
+- [x] No SPEC_DEVIATION (or markers added)
+- [x] No unnecessary changes made
+- [x] Matches existing patterns
+
+**Status**: ✅ Complete | ❌ Blocked | ⚠️ Partial
+```
+
+---
+
+## Tips
+
+- **One task at a time** — Focus prevents errors
+- **Tools matter** — Wrong MCP = wrong approach
+- **Reuses save tokens** — Copy patterns, don't reinvent
+- **Check before commit** — Verify all criteria, then commit
+- **Stay surgical** — Touch only what's necessary
+- **Commit per task** — Clean git history enables bisect and rollback
+- **Never "while I'm here"** — Scope creep during implementation is the #1 quality killer
+- **Learn from mistakes** — If something goes wrong, add a Lesson Learned to STATE.md

--- a/.windsurf/skills/tlc-spec-driven/references/project-init.md
+++ b/.windsurf/skills/tlc-spec-driven/references/project-init.md
@@ -1,0 +1,71 @@
+# Project Initialization
+
+**Trigger:** "Initialize project", "Setup project", "Start new project"
+
+## Process
+
+Extract project vision via iterative Q&A (max 3-5 questions per message):
+
+**Essential questions:**
+
+1. What are you building?
+2. Who is it for and what problem does it solve?
+3. What tech stack are you using? (if known)
+4. What's in scope for v1? What's explicitly excluded?
+5. Critical constraints? (timeline, technical, resources)
+
+**Stop when:** Clear understanding of vision, goals, and boundaries.
+
+## Output: .specs/project/PROJECT.md
+
+**Structure:**
+
+```markdown
+# [Project Name]
+
+**Vision:** [1-2 sentence description]
+**For:** [target users]
+**Solves:** [core problem being addressed]
+
+## Goals
+
+- [Primary goal with measurable success metric]
+- [Secondary goal with measurable success metric]
+
+## Tech Stack
+
+**Core:**
+
+- Framework: [name + version]
+- Language: [name + version]
+- Database: [name]
+
+**Key dependencies:** [3-5 critical libraries/frameworks]
+
+## Scope
+
+**v1 includes:**
+
+- [Core capability 1]
+- [Core capability 2]
+- [Core capability 3]
+
+**Explicitly out of scope:**
+
+- [What is NOT being built]
+- [What is NOT being built]
+
+## Constraints
+
+- Timeline: [if applicable]
+- Technical: [if applicable]
+- Resources: [if applicable]
+```
+
+**Size limit:** 2,000 tokens (~1,200 words)
+
+**Validation:**
+
+- Vision clear in 1-2 sentences?
+- Goals have measurable outcomes?
+- Scope boundaries explicit?

--- a/.windsurf/skills/tlc-spec-driven/references/quick-mode.md
+++ b/.windsurf/skills/tlc-spec-driven/references/quick-mode.md
@@ -1,0 +1,132 @@
+# Quick Mode
+
+**Goal:** Execute small, ad-hoc tasks with the same quality principles but without full pipeline ceremony.
+
+**Trigger:** "Quick fix", "Quick task", "Small change", "Bug fix", "Just do X"
+
+## When to Use
+
+| Use quick mode             | Use full pipeline                   |
+| -------------------------- | ----------------------------------- |
+| Bug fixes with known cause | New features with multiple stories  |
+| Config changes             | Architectural changes               |
+| Small UI tweaks            | Features requiring design decisions |
+| Adding a field/column      | Multi-component features            |
+| One-off scripts            | Anything with unclear scope         |
+| Dependency updates         | Features requiring user stories     |
+
+**Rule of thumb:** If you can describe it in one sentence AND it touches ≤3 files, it's a quick task.
+
+## Process
+
+### 1. Describe the Task
+
+User provides a clear, one-sentence description. If vague, ask for specifics:
+
+- ❌ "Fix the login" → Ask: "What's broken? What should happen instead?"
+- ✅ "Fix: login button returns 401 because token refresh skips expired check"
+
+### 2. Pre-Implementation Check
+
+Before writing code, state:
+
+```
+Quick Task: [description]
+Files: [list ONLY files to touch]
+Approach: [one sentence]
+Verify: [how to prove it works]
+```
+
+Get user approval before proceeding. If the pre-implementation check reveals the task is bigger than expected (>3 files, unclear dependencies, design decisions needed), recommend the full pipeline instead.
+
+### 3. Implement
+
+Follow [coding-principles.md](coding-principles.md):
+
+- Simplest code that works
+- Touch ONLY listed files
+- No scope creep — fix the thing, nothing else
+
+### 4. Verify
+
+Run verification from step 2. Mark done only after verification passes.
+
+### 5. Commit
+
+Atomic commit following [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>(<scope>): <description>
+```
+
+Use imperative mood, lowercase, no period. See [implement.md](implement.md) for full types table.
+
+Examples:
+
+- `fix(auth): prevent 401 on token refresh`
+- `feat(settings): add dark mode toggle`
+- `chore(deps): update eslint to v9`
+
+### 6. Track
+
+Update `.specs/project/STATE.md` with quick task record (see state-management.md Quick Tasks section).
+
+---
+
+## Structure
+
+Quick tasks live separately from planned features:
+
+```
+.specs/
+└── quick/
+    └── NNN-slug/
+        ├── TASK.md       # Description + verification
+        └── SUMMARY.md    # What was done + commit
+```
+
+**TASK.md template:**
+
+```markdown
+# Quick Task NNN: [Title]
+
+**Date:** [date]
+**Status:** Done | In Progress | Blocked
+
+## Description
+
+[One sentence: what and why]
+
+## Files Changed
+
+- `src/path/to/file.ts` — [what changed]
+- `src/path/to/other.ts` — [what changed]
+
+## Verification
+
+- [ ] [How to verify it works]
+- [ ] [Expected behavior after fix]
+
+## Commit
+
+`[hash]` — [commit message]
+```
+
+---
+
+## Guardrails
+
+- **Max 3 files** — If more, use full pipeline
+- **Max 1 hour** — If longer, scope is wrong
+- **No design decisions** — If you're choosing between approaches, use full pipeline
+- **No new dependencies** — Adding packages needs full pipeline review
+- **Track everything** — Even quick tasks get commits and STATE.md entries
+
+---
+
+## Tips
+
+- **Quick ≠ sloppy** — Same coding principles apply, just less ceremony
+- **When in doubt, go full** — Better to over-plan than to ship broken code
+- **Quick tasks compound** — If you're doing 5+ quick tasks for the same area, it's a feature that needs planning
+- **Verify before marking done** — The whole point is quality, even for small tasks

--- a/.windsurf/skills/tlc-spec-driven/references/roadmap.md
+++ b/.windsurf/skills/tlc-spec-driven/references/roadmap.md
@@ -1,0 +1,80 @@
+# Roadmap Creation
+
+**Trigger:** "Create roadmap", "Plan features", "Map project phases"
+
+## Process
+
+Based on PROJECT.md, decompose vision into:
+
+- Milestones (shippable increments)
+- Features (user-facing capabilities)
+- Status tracking (planned/in-progress/complete)
+
+## Output: .specs/project/ROADMAP.md
+
+**Structure:**
+
+```markdown
+# Roadmap
+
+**Current Milestone:** [milestone name]
+**Status:** Planning | In Progress | Complete
+
+---
+
+## [Milestone 1 Name]
+
+**Goal:** [What makes this milestone shippable]
+**Target:** [Date or completion criteria]
+
+### Features
+
+**[Feature Name]** - STATUS
+
+- [Capability 1]
+- [Capability 2]
+- [Capability 3]
+
+**[Feature Name]** - STATUS
+
+- [Capability 1]
+- [Capability 2]
+
+---
+
+## [Milestone 2 Name]
+
+**Goal:** [What this milestone adds]
+
+### Features
+
+**[Feature Name]** - PLANNED
+**[Feature Name]** - PLANNED
+
+---
+
+## Future Considerations
+
+- [Potential future capability]
+- [Potential future capability]
+```
+
+**Status values:**
+
+- PLANNED: Not started
+- IN PROGRESS: Currently implementing
+- COMPLETE: Shipped and verified
+
+**Size limit:** 3,000 tokens (~1,800 words)
+
+**Update strategy:**
+
+- Mark features PLANNED → IN PROGRESS when starting
+- Mark IN PROGRESS → COMPLETE when verified
+- Add new milestones as project evolves
+
+**Validation:**
+
+- Each milestone has clear shippable outcome?
+- Features are user-facing capabilities?
+- Status reflects current reality?

--- a/.windsurf/skills/tlc-spec-driven/references/session-handoff.md
+++ b/.windsurf/skills/tlc-spec-driven/references/session-handoff.md
@@ -1,0 +1,71 @@
+# Session Handoff
+
+## Pause Work
+
+**Trigger:** "Pause work", "End session", "Create handoff"
+
+**Purpose:** Checkpoint current state for resumption.
+
+**Output:** `.specs/HANDOFF.md` (overwrites previous)
+
+**Size target:** ~500 tokens
+
+**Structure:**
+
+```markdown
+# Handoff
+
+**Date:** [ISO timestamp]
+**Feature:** [feature name]
+**Task:** [task identifier] - [brief status]
+
+## Completed ✓
+
+- [Completed work item]
+- [Completed work item]
+
+## In Progress
+
+- [Current work] ([percentage or status])
+- Specific location: [file:line if applicable]
+
+## Pending
+
+- [Next immediate step]
+- [Following step]
+
+## Blockers
+
+- [Blocker description] - [impact]
+
+## Context
+
+- Branch: [git branch if applicable]
+- Uncommitted: [files with changes]
+- Related decisions: [STATE.md references if applicable]
+```
+
+**Instructions:**
+
+- Focus on actionable information for resumption
+- Include specific file/line references where relevant
+- Note uncommitted changes explicitly
+- Reference related STATE.md entries if applicable
+
+## Resume Work
+
+**Trigger:** "Resume work", "Continue", "Load handoff"
+
+**Process:**
+
+1. Load HANDOFF.md
+2. Load STATE.md for context
+3. Summarize current position
+4. Propose next action
+
+**Response pattern:**
+
+- "Resuming [feature] at [task]"
+- "Completed: [summary]"
+- "Next: [immediate action]"
+- "Continue with [specific step]?"

--- a/.windsurf/skills/tlc-spec-driven/references/specify.md
+++ b/.windsurf/skills/tlc-spec-driven/references/specify.md
@@ -1,0 +1,155 @@
+# Specify
+
+**Goal**: Capture WHAT to build with testable, traceable requirements.
+
+If the feature has ambiguous gray areas (multiple valid approaches for user-facing behavior), the agent will automatically trigger the [discuss gray areas](discuss.md) process within this phase. For clear, well-defined features, it goes straight to the next phase.
+
+## Process
+
+### 1. Clarify Requirements
+
+You are a thinking partner, not an interviewer. Start open — let the user dump their mental model. Follow the energy: whatever they emphasize, dig into that.
+
+Ask conversationally (not as a checklist):
+
+- "What problem are you solving?"
+- "Who is the user and what's their pain?"
+- "What does success look like?"
+
+If needed:
+
+- "What are the constraints (time, tech, resources)?"
+- "What is explicitly out of scope?"
+
+**Challenge vagueness.** Never accept fuzzy answers. "Good" means what? "Users" means who? "Simple" means how? Make the abstract concrete: "Walk me through using this." "What does that actually look like?"
+
+**Know when to stop.** When you understand what they're building, why, who it's for, and what done looks like — offer to proceed.
+
+### 2. Capture User Stories with Priorities
+
+**P1 = MVP** (must ship), **P2** (should have), **P3** (nice to have)
+
+Each story MUST be **independently testable** - you can implement and demo just that story.
+
+### 3. Write Acceptance Criteria
+
+Use **WHEN/THEN/SHALL** format - it's precise and testable:
+
+- WHEN [event/action] THEN [system] SHALL [response/behavior]
+
+---
+
+## Template: `.specs/[feature]/spec.md`
+
+```markdown
+# [Feature Name] Specification
+
+## Problem Statement
+
+[Describe the problem in 2-3 sentences. What pain point are we solving? Why now?]
+
+## Goals
+
+- [ ] [Primary goal with measurable outcome]
+- [ ] [Secondary goal with measurable outcome]
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature     | Reason         |
+| ----------- | -------------- |
+| [Feature X] | [Why excluded] |
+| [Feature Y] | [Why excluded] |
+
+---
+
+## User Stories
+
+### P1: [Story Title] ⭐ MVP
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P1**: [Why this is critical for MVP]
+
+**Acceptance Criteria**:
+
+1. WHEN [user action/event] THEN system SHALL [expected behavior]
+2. WHEN [user action/event] THEN system SHALL [expected behavior]
+3. WHEN [edge case] THEN system SHALL [graceful handling]
+
+**Independent Test**: [How to verify this story works alone - e.g., "Can demo by doing X and seeing Y"]
+
+---
+
+### P2: [Story Title]
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P2**: [Why this isn't MVP but important]
+
+**Acceptance Criteria**:
+
+1. WHEN [event] THEN system SHALL [behavior]
+2. WHEN [event] THEN system SHALL [behavior]
+
+**Independent Test**: [How to verify]
+
+---
+
+### P3: [Story Title]
+
+**User Story**: As a [role], I want [capability] so that [benefit].
+
+**Why P3**: [Why this is nice-to-have]
+
+**Acceptance Criteria**:
+
+1. WHEN [event] THEN system SHALL [behavior]
+
+---
+
+## Edge Cases
+
+- WHEN [boundary condition] THEN system SHALL [behavior]
+- WHEN [error scenario] THEN system SHALL [graceful handling]
+- WHEN [unexpected input] THEN system SHALL [validation response]
+
+---
+
+## Requirement Traceability
+
+Each requirement gets a unique ID for tracking across design, tasks, and validation.
+
+| Requirement ID | Story       | Phase  | Status  |
+| -------------- | ----------- | ------ | ------- |
+| [FEAT]-01      | P1: [Story] | Design | Pending |
+| [FEAT]-02      | P1: [Story] | Design | Pending |
+| [FEAT]-03      | P2: [Story] | -      | Pending |
+
+**ID format:** `[CATEGORY]-[NUMBER]` (e.g., `AUTH-01`, `CART-03`, `NOTIF-02`)
+
+**Status values:** Pending → In Design → In Tasks → Implementing → Verified
+
+**Coverage:** X total, Y mapped to tasks, Z unmapped ⚠️
+
+---
+
+## Success Criteria
+
+How we know the feature is successful:
+
+- [ ] [Measurable outcome - e.g., "User can complete X in < 2 minutes"]
+- [ ] [Measurable outcome - e.g., "Zero errors in Y scenario"]
+```
+
+---
+
+## Tips
+
+- **P1 = Vertical Slice** — A complete, demo-able feature, not just backend or frontend
+- **WHEN/THEN is code** — If you can't write it as a test, rewrite it
+- **Requirement IDs are mandatory** — Every story maps to trackable IDs
+- **Edge cases matter** — What breaks? What's empty? What's huge?
+- **Out of Scope prevents creep** — If it's not here, it doesn't get built
+- **Confirm before Discuss** — User must approve spec before moving to discuss phase

--- a/.windsurf/skills/tlc-spec-driven/references/state-management.md
+++ b/.windsurf/skills/tlc-spec-driven/references/state-management.md
@@ -1,0 +1,130 @@
+# State Management
+
+**Purpose:** Persistent memory across sessions - decisions, blockers, learnings.
+
+## Structure
+
+**Output:** `.specs/project/STATE.md`
+
+```markdown
+# State
+
+**Last Updated:** [ISO timestamp]
+**Current Work:** [Feature name] - [Task identifier]
+
+---
+
+## Recent Decisions (Last 60 days)
+
+### AD-[NNN]: [Decision title] ([date])
+
+**Decision:** [What was decided]
+**Reason:** [Why this choice]
+**Trade-off:** [What was sacrificed]
+**Impact:** [How this affects implementation]
+
+### AD-[NNN]: [Decision title] ([date])
+
+[Same structure]
+
+---
+
+## Active Blockers
+
+### B-[NNN]: [Blocker description]
+
+**Discovered:** [Date]
+**Impact:** [Severity and scope]
+**Workaround:** [Temporary solution if available]
+**Resolution:** [Path to permanent fix]
+
+---
+
+## Lessons Learned
+
+### L-[NNN]: [Learning description]
+
+**Context:** [Situation that occurred]
+**Problem:** [What went wrong]
+**Solution:** [How it was resolved]
+**Prevents:** [What this knowledge prevents in future]
+
+---
+
+## Quick Tasks Completed
+
+| #   | Description              | Date   | Commit | Status  |
+| --- | ------------------------ | ------ | ------ | ------- |
+| 001 | [Quick task description] | [date] | [hash] | ✅ Done |
+
+---
+
+## Deferred Ideas
+
+Ideas captured during work that belong in future features or phases. Prevents scope creep while preserving good ideas.
+
+- [ ] [Idea description] — Captured during: [feature/phase]
+- [ ] [Idea description] — Captured during: [feature/phase]
+
+---
+
+## Todos
+
+Capture in-progress thoughts and action items that don't fit in active tasks.
+
+- [ ] [TODO: action item]
+- [ ] [TODO: action item]
+```
+
+## When to Update
+
+| Event                            | Action                                 |
+| -------------------------------- | -------------------------------------- |
+| Significant architectural choice | Add AD-[NNN]                           |
+| Implementation blocked           | Add B-[NNN]                            |
+| Important discovery/learning     | Add L-[NNN]                            |
+| Quick task completed             | Add row to Quick Tasks table           |
+| Scope creep captured             | Add to Deferred Ideas                  |
+| In-progress thought              | Add to Todos                           |
+| Session end                      | Update "Last Updated" + "Current Work" |
+
+## Size Management (Hybrid Strategy)
+
+**Zones:**
+
+- 🟢 <7k tokens: No action
+- 🟡 7-10k tokens: Footer note "STATE.md at [X]k. Cleanup recommended."
+- 🔴 >10k tokens: Active prompt "STATE.md critical ([X]k). Cleanup now?"
+
+**Cleanup process:**
+
+- Move decisions >60 days to STATE-ARCHIVE.md
+- Keep only active blockers
+- Preserve recent learnings (<60 days)
+
+**Validation:**
+
+- Decisions have clear rationale?
+- Blockers include resolution path?
+- Learnings are actionable?
+
+---
+
+## Preferences
+
+Track user-facing behavioral state in STATE.md:
+
+```markdown
+## Preferences
+
+**Model Guidance Shown:** [ISO date or "never"]
+```
+
+**Update when:**
+
+| Event                       | Action                   |
+| --------------------------- | ------------------------ |
+| First model tip given       | Set date                 |
+| User acknowledges/dismisses | Keep date (don't repeat) |
+
+This prevents repetitive suggestions while maintaining natural, helpful behavior.

--- a/.windsurf/skills/tlc-spec-driven/references/tasks.md
+++ b/.windsurf/skills/tlc-spec-driven/references/tasks.md
@@ -1,0 +1,419 @@
+# Tasks
+
+**Goal**: Break into GRANULAR, ATOMIC tasks. Clear dependencies. Right tools. Parallel execution plan.
+
+**Skip this phase when:** There are ≤3 obvious steps. In that case, tasks are implicit — go straight to Execute and list them inline in your implementation plan.
+
+## Why Granular Tasks?
+
+| Vague Task (BAD) | Granular Tasks (GOOD)             |
+| ---------------- | --------------------------------- |
+| "Create form"    | T1: Create email input component  |
+|                  | T2: Add email validation function |
+|                  | T3: Create submit button          |
+|                  | T4: Add form state management     |
+|                  | T5: Connect form to API           |
+| "Implement auth" | T1: Create login form             |
+|                  | T2: Create register form          |
+|                  | T3: Add token storage utility     |
+|                  | T4: Create auth API service       |
+|                  | T5: Add route protection          |
+
+**Benefits of granular:**
+
+- **Agents don't err** - Single focus, no ambiguity
+- **Easy to test** - Each task = one verifiable outcome
+- **Parallelizable** - Independent tasks run simultaneously
+- **Errors isolated** - One failure doesn't block everything
+
+**Rule**: One task = ONE of these:
+
+- One component
+- One function
+- One API endpoint
+- One file change
+
+---
+
+## Process
+
+### 1. Review Design
+
+Read `.specs/[feature]/design.md` before creating tasks.
+
+### 1.5. Load Test Coverage Matrix
+
+Read `.specs/codebase/TESTING.md` (if it exists) before creating tasks. The Test Coverage Matrix
+and Parallelism Assessment drive two critical decisions:
+
+**Co-located tests:** Every task that creates or modifies a code layer with a required test type
+MUST include writing/updating those tests in the same task. Tests are NOT separate tasks.
+
+| Task creates...                           | Done When must include...                   |
+| ----------------------------------------- | ------------------------------------------- |
+| Code layer with "unit" requirement        | Unit test written + quick gate passes       |
+| Code layer with "e2e" requirement         | E2E test written + full gate passes         |
+| Code layer with "integration" requirement | Integration test written + full gate passes |
+| Code layer with "none" requirement        | Gate check at appropriate level             |
+
+**Parallelism flags:** Cross-reference the Parallelism Assessment when marking tasks `[P]`:
+
+- If a task's required test type is marked "Parallel-Safe: No" → strip `[P]` flag
+- If a task's required test type is marked "Parallel-Safe: Yes" → `[P]` is allowed
+- If a task has no tests → `[P]` depends only on code dependencies
+
+If TESTING.md does not exist (greenfield project), ask the user what test types and commands
+the project will use before creating tasks.
+
+### 2. Break Into Atomic Tasks
+
+**Task = ONE deliverable**. Examples:
+
+- ✅ "Create UserService interface" (one file, one concept)
+- ❌ "Implement user management" (too vague, multiple files)
+
+### 3. Define Dependencies
+
+What MUST be done before this task can start?
+
+### 4. Create Execution Plan
+
+Group tasks into phases. Identify what can run in parallel.
+
+### 5. Validate Before Presenting (MANDATORY)
+
+Before showing tasks to the user, run ALL three pre-approval checks. These are NOT optional — they are gates. If any check fails, restructure the tasks and re-run until all pass.
+
+**Check 1: Task Granularity** — verify each task is atomic (see Granularity Check section).
+
+**Check 2: Diagram-Definition Cross-Check** — verify the execution diagram matches every task's `Depends on` field (see Diagram-Definition Cross-Check section). Build the cross-check table and include it in the output.
+
+**Check 3: Test Co-location Validation** — verify every task's `Tests` field matches the TESTING.md coverage matrix (see Test Co-location Validation section). Build the validation table and include it in the output.
+
+**Output both tables with the tasks** so the user can see the validation results. Any ❌ means you MUST restructure before presenting — do not show failing tasks to the user and ask them to approve.
+
+### 6. ASK About MCPs and Skills
+
+**CRITICAL**: Before execution, ask the user:
+
+> "For each task, which tools should I use?"
+>
+> **Available MCPs**: [list from project or user]
+> **Available Skills**: [list from project or user]
+
+---
+
+## Template: `.specs/[feature]/tasks.md`
+
+```markdown
+# [Feature] Tasks
+
+**Design**: `.specs/[feature]/design.md`
+**Status**: Draft | Approved | In Progress | Done
+
+---
+
+## Execution Plan
+
+### Phase 1: Foundation (Sequential)
+
+Tasks that must be done first, in order.
+```
+
+T1 → T2 → T3
+
+```
+
+### Phase 2: Core Implementation (Parallel OK)
+After foundation, these can run in parallel.
+
+```
+
+     ┌→ T4 ─┐
+
+T3 ──┼→ T5 ─┼──→ T8
+└→ T6 ─┘
+T7 ──────→
+
+```
+
+### Phase 3: Integration (Sequential)
+Bringing it all together.
+
+```
+
+T8 → T9
+
+---
+
+## Task Breakdown
+
+### T1: [Create X Interface]
+
+**What**: [One sentence: exact deliverable]
+**Where**: `src/path/to/file.ts`
+**Depends on**: None
+**Reuses**: `src/existing/BaseInterface.ts`
+**Requirement**: [FEAT]-01
+
+**Tools**:
+
+- MCP: `filesystem` (or NONE)
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Interface defined with all methods from design
+- [ ] Types exported correctly
+- [ ] No TypeScript errors
+
+**Tests**: [unit/e2e/integration/none — from coverage matrix]
+**Gate**: [quick/full/build — from gate check commands]
+
+---
+
+### T2: [Implement Y Service] [P]
+
+**What**: [Exact deliverable]
+**Where**: `src/services/YService.ts`
+**Depends on**: T1
+**Reuses**: `src/services/BaseService.ts` patterns
+
+**Tools**:
+
+- MCP: `filesystem`, `context7`
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Implements interface from T1
+- [ ] Handles error cases from design
+- [ ] Gate check passes: `[quick gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: unit
+**Gate**: quick
+
+---
+
+### T3: [Create Z Component] [P]
+
+**What**: [Exact deliverable]
+**Where**: `src/components/ZComponent.tsx`
+**Depends on**: T1
+**Reuses**: `src/components/BaseComponent.tsx`
+
+**Tools**:
+
+- MCP: `filesystem`
+- Skill: NONE
+
+**Done when**:
+
+- [ ] Component renders correctly
+- [ ] Handles props from interface
+- [ ] Follows existing component patterns
+- [ ] Gate check passes: `[quick gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: unit
+**Gate**: quick
+
+---
+
+### T4: [Add A Feature to Y]
+
+**What**: [Exact deliverable]
+**Where**: `src/services/YService.ts` (modify)
+**Depends on**: T2, T3
+**Reuses**: Existing service patterns
+
+**Tools**:
+
+- MCP: `filesystem`, `github`
+- Skill: `api-design`
+
+**Done when**:
+
+- [ ] Feature works per acceptance criteria
+- [ ] Gate check passes: `[full gate command from TESTING.md]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Tests**: integration
+**Gate**: full
+
+**Commit**: `feat([scope]): [description]`
+
+---
+
+## Parallel Execution Map
+
+Visual representation of what can run simultaneously:
+
+```
+
+Phase 1 (Sequential):
+  T1 ──→ T2 ──→ T3
+
+Phase 2 (Parallel):
+  T3 complete, then:
+    ├── T4 [P]
+    ├── T5 [P]  } Can run simultaneously
+    └── T6 [P]
+
+Phase 3 (Sequential):
+  T4, T5, T6 complete, then:
+    T7 ──→ T8
+
+```
+
+**Parallelism constraint:** A task marked `[P]` must have ALL of these:
+
+- No unfinished dependencies
+- Required test type is parallel-safe (per TESTING.md Parallelism Assessment)
+- No shared mutable state with other `[P]` tasks in the same phase
+
+If a task's tests are NOT parallel-safe, it MUST run sequentially even if its
+implementation code has no dependencies. The test execution is the bottleneck.
+
+**How parallel execution works:**
+
+Tasks marked `[P]` are executed via sub-agents — one sub-agent per task, launched concurrently.
+Each sub-agent receives only its task definition and relevant project context (see Sub-Agent
+Delegation in SKILL.md). The orchestrating agent waits for all sub-agents in a phase to complete
+before advancing to the next phase.
+
+Sequential tasks (no `[P]`) are also delegated to sub-agents, but one at a time. This keeps
+implementation artifacts (file reads, test output, gate check logs) out of the main context.
+
+**The orchestrating agent's role during Execute:**
+1. Pick the next task(s) to execute
+2. Provide each sub-agent with its task definition + context
+3. Monitor sub-agent completion
+4. Update tasks.md with results
+5. Decide whether to proceed, fix, or escalate
+
+---
+
+## Task Granularity Check
+
+Before approving tasks, verify they are granular enough:
+
+| Task                            | Scope         | Status       |
+| ------------------------------- | ------------- | ------------ |
+| T1: Create email input          | 1 component   | ✅ Granular  |
+| T2: Add validation function     | 1 function    | ✅ Granular  |
+| T3: Create form with all fields | 5+ components | ❌ Split it! |
+| T4: Connect to API              | 1 function    | ✅ Granular  |
+
+**Granularity check**:
+
+- ✅ 1 component / 1 function / 1 endpoint = Good
+- ⚠️ 2-3 related things in same file = OK if cohesive
+- ❌ Multiple components or files = MUST split
+
+---
+
+## Diagram-Definition Cross-Check
+
+Before approving tasks, verify the execution diagram is consistent with the task definitions. These are independent artifacts that can drift — the diagram is drawn for visual clarity while task bodies are written for precision. Both must agree.
+
+For each task, check:
+
+| Task | Depends On (task body) | Diagram Shows | Status |
+| ---- | ---------------------- | ------------- | ------ |
+| T[N] | [deps from body] | [deps from diagram arrows] | ✅ Match or ❌ Mismatch |
+
+**Rules:**
+
+- Every `Depends on` in a task body must have a corresponding arrow in the diagram.
+- Every arrow in the diagram must correspond to a `Depends on` in the target task's body.
+- Tasks shown as parallel (`[P]`) in the diagram must not depend on each other.
+- If a task depends on another task in the same parallel phase, they are NOT parallel — fix the diagram or remove the `[P]` flag.
+
+---
+
+## Test Co-location Validation
+
+Before approving tasks, verify EVERY task's `Tests` field is consistent with the TESTING.md Test Coverage Matrix. This is a hard gate — tasks that fail this check MUST be fixed.
+
+For each task, check: does the task create or modify a code layer that has a required test type in the coverage matrix? If yes, the task's `Tests` field MUST match.
+
+| Task | Code Layer Created/Modified | Matrix Requires | Task Says | Status |
+| ---- | --------------------------- | --------------- | --------- | ------ |
+| T[N]: [name] | [layer from coverage matrix] | [test type] | [task's Tests field] | ✅ OK or ❌ VIOLATION |
+
+**Rules:**
+
+- "Tested in another task" is NOT a valid justification for `Tests: none`. That is test deferral — the exact anti-pattern this validation prevents.
+- `Tests: none` is only valid when the coverage matrix says "none" for that code layer.
+- If a task creates MULTIPLE code layers (e.g., service + controller), use the HIGHEST test type required by any of them.
+- Any ❌ VIOLATION → restructure the task to include its required tests before proceeding.
+
+**Resolving compilation dependencies:**
+
+When a task creates code that can't be tested until a later task completes (e.g., a controller that needs module wiring before its e2e tests can run), do NOT defer the tests to a separate task. Instead, restructure:
+
+1. **Merge forward:** Move the untestable task's tests into the earliest task where they become runnable (e.g., the wiring task includes wiring + e2e tests for the controller it enables).
+2. **Merge backward:** Absorb the blocking dependency into the current task so it becomes self-testable (e.g., controller task includes its own module registration).
+
+Pick whichever option keeps tasks atomic and cohesive. The goal: no task produces unverified code. If code can't be tested in the task that creates it, the task boundaries are wrong.
+
+---
+
+## Tips
+
+- **[P] = Parallel OK** — Mark tasks that can run simultaneously
+- **Reuses = Token saver** — Always reference existing code
+- **Tools per task** — MCPs and Skills prevent wrong approaches
+- **Dependencies are gates** — Clear what blocks what
+- **Done when = Testable** — If you can't verify it, rewrite it
+- **Requirement ID = Traceable** — Every task traces back to a spec requirement
+- **One commit per task** — Plan the commit message format in advance
+
+---
+
+## Task Verification Standards
+
+Every task MUST include:
+
+**Done when checklist:**
+
+- Specific, testable outcomes
+- Pass/fail criteria
+- The specific test command from the Gate Check Commands table
+- Expected pass count (prevents silent test deletion)
+
+**Verify section:**
+
+- Commands to prove functionality
+- Expected outputs
+- Success indicators
+
+**Structure:**
+
+```markdown
+### T1: [Task name]
+
+**What:** [Deliverable]
+**Where:** [File path]
+**Tests**: [unit/e2e/integration/none]
+**Gate**: [quick/full/build]
+
+**Done when:**
+
+- [ ] [Specific outcome]
+- [ ] [Specific outcome]
+- [ ] Gate check passes: `[command from Gate Check Commands]`
+- [ ] Test count: [N] tests pass (no silent deletions)
+
+**Verify:**
+[Command to prove it works]
+[Expected output/behavior]
+```
+
+**Quality check:**
+
+- Can task be verified without human judgment?
+- Is success criteria binary (pass/fail)?
+- Can verification be automated?

--- a/.windsurf/skills/tlc-spec-driven/references/validate.md
+++ b/.windsurf/skills/tlc-spec-driven/references/validate.md
@@ -1,0 +1,256 @@
+# Execute: Validate & Verify
+
+**Goal**: Verify implementation meets spec AND coding principles. This is NOT a separate phase — verification is part of every task's completion within Execute.
+
+**Two levels of verification:**
+
+1. **Per-task verification (always):** After implementing each task, verify its "Done when" criteria before committing. This is mandatory and automatic.
+
+2. **Feature-level validation (on completion or on demand):** After all tasks for a feature (or priority group) are done, run a comprehensive validation. Includes acceptance criteria check, code quality review, and optionally interactive UAT.
+
+**Interactive UAT is triggered when:** The feature has complex user-facing behavior where human judgment matters (UI flows, interaction patterns, visual design). For backend-only or infrastructure work, automated checks are sufficient.
+
+**Trigger for explicit validation:** "Validate", "verify work", "UAT", "test with me", "walk me through it"
+
+---
+
+## Process
+
+### 1. Check Completed Tasks
+
+Go through tasks.md:
+
+- [ ] All tasks marked done?
+- [ ] Any blocked or partial?
+
+### 2. Verify Acceptance Criteria
+
+For each user story in spec.md:
+
+```markdown
+### P1: [Story Title]
+
+**Acceptance Criteria**:
+
+1. WHEN [X] THEN [Y] → [PASS/FAIL]
+2. WHEN [X] THEN [Y] → [PASS/FAIL]
+```
+
+### 3. Check Edge Cases
+
+From spec.md edge cases:
+
+- [ ] [Edge case 1] handled correctly
+- [ ] [Edge case 2] handled correctly
+
+### 4. Run Build-Level Gate Check (MANDATORY)
+
+Run the Build-level gate check from TESTING.md. This is NOT optional.
+
+If TESTING.md does not exist (greenfield project), use the gate command agreed upon with the user during the Tasks phase.
+
+1. Run: `[build gate command from TESTING.md, or the command agreed during planning]`
+2. Non-zero exit code = STOP. Do not proceed to Code Quality Check.
+3. Record results:
+   - Total test count: [N]
+   - Passed: [N]
+   - Failed: [list]
+   - Skipped: [list — each skip must be justified]
+
+**Test Integrity Check:**
+
+- Compare current test count against the count before this feature was implemented
+- If test count DECREASED: investigate why. Tests should only be deleted with explicit justification.
+- If assertions were weakened (less specific than before): flag as potential regression
+
+### 5. Code Quality Check (MANDATORY)
+
+For each changed file, verify against [coding-principles.md](coding-principles.md):
+
+| Check                                | Pass? |
+| ------------------------------------ | ----- |
+| No features beyond what was asked    |       |
+| No abstractions for single-use code  |       |
+| No unnecessary "flexibility" added   |       |
+| Only touched files required for task |       |
+| Didn't "improve" unrelated code      |       |
+| Matches existing patterns/style      |       |
+| Would senior engineer approve?       |       |
+
+❌ Any "No"? → Fix before marking complete.
+
+### 6. Interactive UAT (if user-facing feature)
+
+For each testable deliverable, present one test at a time:
+
+```
+Test [N]: [Test Name]
+
+Expected: [What should happen — specific and observable]
+
+→ Does this work? Describe what you see.
+```
+
+Wait for user response:
+
+| User says                      | Interpret as            |
+| ------------------------------ | ----------------------- |
+| "yes", "pass", "works", "next" | ✅ Pass                 |
+| "skip", "can't test", "n/a"    | ⏭️ Skip                 |
+| Anything else                  | ❌ Issue — log verbatim |
+
+**Severity inference (never ask the user for severity):**
+
+| User description contains               | Inferred severity |
+| --------------------------------------- | ----------------- |
+| crash, error, exception, fails, broken  | Blocker           |
+| doesn't work, wrong, missing, can't     | Major             |
+| slow, weird, off, minor, small          | Minor             |
+| color, font, spacing, alignment, visual | Cosmetic          |
+| (unclear)                               | Major (default)   |
+
+### 7. Generate Fix Plans (if issues found)
+
+For each issue found during UAT:
+
+1. **Diagnose** — Analyze the codebase to find root cause
+2. **Create fix task** — Write a task definition with:
+   - What: The specific fix
+   - Where: File paths
+   - Verify: How to prove the fix works
+   - Done when: Acceptance criteria for the fix
+3. **Present fix plan** — Show all fix tasks to user for approval
+
+Fix tasks follow the same format as regular tasks and can be executed with the implement phase.
+
+**Guardrail:** Maximum 3 diagnostic iterations per issue. If root cause isn't found after 3 attempts, flag for human investigation.
+
+### 8. Report
+
+---
+
+## Validation Report Template
+
+```markdown
+# [Feature] Validation
+
+**Date**: [YYYY-MM-DD]
+**Spec**: `.specs/features/[feature]/spec.md`
+
+---
+
+## Task Completion
+
+| Task | Status     | Notes   |
+| ---- | ---------- | ------- |
+| T1   | ✅ Done    | -       |
+| T2   | ✅ Done    | -       |
+| T3   | ⚠️ Partial | [Issue] |
+
+---
+
+## User Story Validation
+
+### P1: [Story Title] ⭐ MVP
+
+| Criterion     | Result  |
+| ------------- | ------- |
+| WHEN X THEN Y | ✅ PASS |
+| WHEN A THEN B | ✅ PASS |
+
+**Status**: ✅ P1 Complete
+
+### P2: [Story Title]
+
+| Criterion     | Result             |
+| ------------- | ------------------ |
+| WHEN X THEN Y | ❌ FAIL - [reason] |
+
+**Status**: ⚠️ P2 Issues
+
+---
+
+## Interactive UAT Results (if performed)
+
+| #   | Test        | Result   | Details                                         |
+| --- | ----------- | -------- | ----------------------------------------------- |
+| 1   | [Test name] | ✅ Pass  | -                                               |
+| 2   | [Test name] | ❌ Issue | [Verbatim user response] — Severity: [inferred] |
+| 3   | [Test name] | ⏭️ Skip  | [Reason]                                        |
+
+---
+
+## Code Quality
+
+| Principle        | Status |
+| ---------------- | ------ |
+| Minimum code     | ✅     |
+| Surgical changes | ✅     |
+| No scope creep   | ✅     |
+| Matches patterns | ✅     |
+
+---
+
+## Edge Cases
+
+- [x] Edge case 1: Handled correctly
+- [ ] Edge case 2: NOT handled - needs fix
+
+---
+
+## Tests
+
+- **Gate command**: [full command]
+- **Result**: [X] passed, [Y] failed, [Z] skipped
+- **Test count before feature**: [N]
+- **Test count after feature**: [M]
+- **Delta**: [+(M - N) new tests]
+- **Skipped tests**: [list with justification for each]
+- **Failures**: [list with details]
+
+---
+
+## Fix Plans (if issues found)
+
+### Fix 1: [Issue description]
+
+- **Root cause**: [What's actually wrong]
+- **Fix task**: [Task definition]
+- **Priority**: [Blocker/Major/Minor/Cosmetic]
+
+---
+
+## Requirement Traceability Update
+
+Update spec.md requirement statuses:
+
+| Requirement | Previous Status | New Status   |
+| ----------- | --------------- | ------------ |
+| [FEAT]-01   | Implementing    | ✅ Verified  |
+| [FEAT]-02   | Implementing    | ❌ Needs Fix |
+
+---
+
+## Summary
+
+**Overall**: ✅ Ready | ⚠️ Issues | ❌ Not Ready
+
+**What works**: [List]
+
+**Issues found**: [Issue 1: How to fix]
+
+**Next steps**: [Action]
+```
+
+---
+
+## Tips
+
+- **P1 first** — MVP must work before P2/P3
+- **WHEN/THEN = Test** — Each criterion is a test case
+- **Be specific** — "Doesn't work" isn't helpful
+- **Recommend fixes** — Don't just report problems, create fix tasks
+- **Quality check is mandatory** — Not optional
+- **Infer severity** — Never ask the user "how bad is this?"
+- **Max 3 diagnostic iterations** — Prevents infinite investigation loops
+- **Update traceability** — Every verified requirement updates spec.md status

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -6,6 +6,13 @@ This document describes the development workflow for the project, including nami
 
 For details on how to set up the project, see [Project Setup](./project-setup.md).
 
+## 🧩 GitHub Templates
+
+Use the repository templates when opening issues and pull requests:
+
+- Pull Request template: [../.github/pull_request_template.md](../.github/pull_request_template.md)
+- Issue templates: [../.github/ISSUE_TEMPLATE/](../.github/ISSUE_TEMPLATE/)
+
 ## 🎨 Code Formatting
 
 - There is an `.editorconfig` file to set what is expected as code formatting standards


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TMPLT-<ISSUE_ID>] - Same title as issue**_

closes #48 

## Description

- Added AI skill bundles for code exploration, Mermaid diagrams, and spec-driven workflow across agent environments.
- Introduced spec-driven project structure and initial docs for planning and brownfield mapping: PROJECT.md, ROADMAP.md and /codebase folder.
- Added a reusable feature spec template: spec.md
- Improved issue template quality by adding sections for user stories, technical refinement, and acceptance criteria general.yml.
- Updated development workflow docs with links to repository templates: dev-workflow.md.

**OBS**: Most added lines come from imported skill/reference documentation duplicated for multiple agent folders (.claude, .cursor, .windsurf).


## Evidences

No evidence

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
