### PR TITLE
[EVAST-00046][SUB-50][T1] Expand health check types

### DIFF
--- a/src/types/health.d.ts
+++ b/src/types/health.d.ts
@@ -1,17 +1,33 @@
-// Backend types (API/domain contract) ----------------------------------------------
+import type { ReactNode } from "react";
+
+// Base aliases ---------------------------------------------------------------------
+export type HealthCheckStatus = "ok" | "fail" | "not-in-use" | "loading";
+export type CoinGeckoEndpointKey = "evaPrice" | "btcPrice";
+
+// Backend contract ------------------------------------------------------------------
 export interface HealthData {
   status: "ok";
   checkedAt: string;
 }
 
-// Frontend types (UI and hook state) ------------------------------------------------
-export type HealthCheckStatus = "ok" | "fail" | "not-in-use" | "loading";
+// Domain state ----------------------------------------------------------------------
+export type EndpointHealthCheckState =
+  | { status: "loading" }
+  | { status: "ok" }
+  | {
+      status: "fail";
+      errorMessage: string;
+      rawError?: string;
+    };
 
 export interface HealthCheckItem {
   label: string;
   status: HealthCheckStatus;
+  errorMessage?: string;
+  children?: readonly HealthCheckItem[];
 }
 
+// UI contracts ----------------------------------------------------------------------
 export interface StatusUiConfig {
   toneClassName: string;
   icon: string;
@@ -22,10 +38,18 @@ export interface StatusUiConfig {
 export interface HealthCheckListItemProps {
   label: string;
   statusUi: StatusUiConfig;
+  errorMessage?: string;
+  depth?: number;
+  children?: ReactNode;
 }
 
+// Hook return contract ---------------------------------------------------------------
 export interface UseHealthCheckResult {
   data: HealthData;
   isLoading: boolean;
   isError: boolean;
+  coinGeckoStatusByEndpoint: Record<
+    CoinGeckoEndpointKey,
+    EndpointHealthCheckState
+  >;
 }


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TMPLT-<ISSUE_ID>] - Same title as issue**_

closes #50 

## Description

Adds `EndpointHealthCheckStatus` discriminated union for **per-endpoint** CoinGecko state (`loading/ok/fail` with **error** details), a `CoinGeckoEndpointKey` alias, and extends `HealthCheckItem`, `HealthCheckListItemProps`, and `UseHealthCheckResult` to **support nested items, depth**, error messages, and per-endpoint status tracking.

## Evidences

Attach some prints, gifs or videos of the new change

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
